### PR TITLE
Move setup pages under /setup prefix and add configurable top-bar items

### DIFF
--- a/docs/upgrade-0.6.md
+++ b/docs/upgrade-0.6.md
@@ -203,7 +203,7 @@ A new component for documentation-style code blocks with syntax highlighting and
 
 After upgrading:
 
-1. Visit `/system-settings` — confirm the page loads under the new route.
+1. Visit `/setup/system-settings` — confirm the page loads under the new route.
 2. Open any detail view that uses a relation field (e.g. customer or product) and confirm the picker opens, the title displays, and selection still works.
 3. In a multi-tenant install, switch tenants and check that each tenant has its own language list under Setup → Languages.
 4. Run the noerd test suite:

--- a/resources/views/components/layout/top-bar.blade.php
+++ b/resources/views/components/layout/top-bar.blade.php
@@ -2,8 +2,26 @@
 
 use Illuminate\Support\Facades\Auth;
 use Livewire\Component;
+use Symfony\Component\Yaml\Yaml;
 
 new class () extends Component {
+    /**
+     * Icon links contributed by optional modules, declared in app-configs/top-bar.yml.
+     * Each item: route (required), heroicon, label.
+     *
+     * @var array<int, array<string, string>>
+     */
+    public array $topBarItems = [];
+
+    public function mount(): void
+    {
+        $path = base_path('app-configs/top-bar.yml');
+
+        $this->topBarItems = file_exists($path)
+            ? (Yaml::parse(file_get_contents($path) ?: '')['items'] ?? [])
+            : [];
+    }
+
     public function logout(): void
     {
         Auth::guard('web')->logout();
@@ -55,15 +73,17 @@ new class () extends Component {
                 <livewire:noerd::layout.quick-menu/>
 
                 <div class="ml-auto my-auto flex items-center gap-x-4 shrink-0">
-                    @if(Route::has('layouts'))
-                        @can('manageLayouts')
-                            <a class="shrink-0" wire:navigate href="{{route('layouts')}}">
-                                <x-noerd::button variant="icon" icon="view-columns" type="button">
-                                    <span class="sr-only">{{ __('Layouts') }}</span>
+                    {{-- Route::has() is load-bearing: uninstalling a module leaves its entry
+                         behind in top-bar.yml, and route() would then take down every page. --}}
+                    @foreach($topBarItems as $item)
+                        @if(Route::has($item['route'] ?? ''))
+                            <a class="shrink-0" wire:navigate href="{{ route($item['route']) }}">
+                                <x-noerd::button variant="icon" :icon="$item['heroicon'] ?? 'squares-2x2'" type="button">
+                                    <span class="sr-only">{{ __($item['label'] ?? $item['route']) }}</span>
                                 </x-noerd::button>
                             </a>
-                        @endcan
-                    @endif
+                        @endif
+                    @endforeach
 
                     @if(auth()->user()->isAdmin())
                         <a class="shrink-0" wire:navigate href="{{route('setup')}}">

--- a/routes/noerd-routes.php
+++ b/routes/noerd-routes.php
@@ -3,8 +3,12 @@
 use Illuminate\Support\Facades\Route;
 use Noerd\Controllers\DashboardController;
 
-Route::group(['middleware' => ['auth', 'verified', 'setup', 'web']], function (): void {
-    Route::livewire('setup', 'noerd::setup.noerd-users-list')->name('setup');
+// Every setup page lives under /setup. Route NAMES are the public contract
+// (navigation.yml `route:` keys, tenant_apps.route, route() calls) and stay
+// unprefixed — only the URLs carry the prefix, so the redundant `setup-` in
+// paths like `setup-collections` is dropped in favour of the group prefix.
+Route::group(['prefix' => 'setup', 'middleware' => ['auth', 'verified', 'setup', 'web']], function (): void {
+    Route::livewire('/', 'noerd::setup.noerd-users-list')->name('setup');
     Route::livewire('tenant-apps', 'noerd::setup.tenant-apps-list')->name('tenant-apps');
     Route::livewire('users', 'noerd::setup.noerd-users-list')->name('users');
     Route::livewire('noerd-user/{modelId}', 'noerd::noerd-user-detail')->name('noerd-user.detail');
@@ -13,16 +17,16 @@ Route::group(['middleware' => ['auth', 'verified', 'setup', 'web']], function ()
     Route::livewire('tenant', 'noerd::setup.tenant-detail')->name('tenant');
     Route::livewire('create-tenant', 'noerd::setup.create-tenant')->name('create-tenant');
     Route::livewire('models', 'noerd::models-list')->name('models');
-    Route::livewire('setup-collections', 'noerd::setup-collections-list')->name('setup-collections');
-    Route::livewire('setup-collection/{modelId}', 'noerd::setup-collection-detail')->name('setup-collection.detail');
-    Route::livewire('setup-collection-definitions', 'noerd::setup-collection-definitions-list')
+    Route::livewire('collections', 'noerd::setup-collections-list')->name('setup-collections');
+    Route::livewire('collection/{modelId}', 'noerd::setup-collection-detail')->name('setup-collection.detail');
+    Route::livewire('collection-definitions', 'noerd::setup-collection-definitions-list')
         ->middleware('setup.collections.ui')
         ->name('setup-collection-definitions');
-    Route::livewire('setup-collection-definition/{modelId}', 'noerd::setup-collection-definition-detail')
+    Route::livewire('collection-definition/{modelId}', 'noerd::setup-collection-definition-detail')
         ->middleware('setup.collections.ui')
         ->name('setup-collection-definition.detail');
-    Route::livewire('setup-languages', 'noerd::setup-languages-list')->name('setup-languages');
-    Route::livewire('setup-language/{modelId}', 'noerd::setup-language-detail')->name('setup-language.detail');
+    Route::livewire('languages', 'noerd::setup-languages-list')->name('setup-languages');
+    Route::livewire('language/{modelId}', 'noerd::setup-language-detail')->name('setup-language.detail');
     Route::livewire('system-settings', 'noerd::setup.system-settings-detail')->name('system-settings');
 });
 

--- a/src/Contracts/LayoutOverrideResolver.php
+++ b/src/Contracts/LayoutOverrideResolver.php
@@ -6,10 +6,10 @@ namespace Noerd\Contracts;
  * Applies user/tenant layout overrides to a freshly parsed YAML config.
  *
  * Consulted by StaticConfigHelper right after Yaml::parse() for every list and
- * detail config. The core binding is a no-op (NullLayoutOverrideResolver); the
- * noerd-pro module rebinds it to inject DB-backed tenant-default and per-user
- * overrides. Keeping this as a container-resolved contract means noerd core never
- * references the Pro module.
+ * detail config. The core binding is a no-op (NullLayoutOverrideResolver); an
+ * optional module may rebind this contract to inject overrides of its own.
+ * Resolving it through the container means the core never needs to know about
+ * any such module.
  */
 interface LayoutOverrideResolver
 {

--- a/src/Helpers/StaticConfigHelper.php
+++ b/src/Helpers/StaticConfigHelper.php
@@ -63,8 +63,8 @@ class StaticConfigHelper
     }
 
     /**
-     * Apply registered layout overrides (tenant default + per-user) to a parsed
-     * config. No-op by default; the noerd-pro module rebinds the resolver.
+     * Apply registered layout overrides to a parsed config.
+     * No-op by default; a module may rebind the resolver.
      *
      * @param  array<string, mixed>  $config
      * @return array<string, mixed>
@@ -77,9 +77,8 @@ class StaticConfigHelper
 
     /**
      * Resolve the on-disk path of a list/detail YAML for an EXPLICIT app, bypassing
-     * the session-driven current-app context. Used by tooling (e.g. the noerd-pro
-     * layout editor) that must read the raw, un-overridden config of an arbitrary
-     * app while a different app is selected.
+     * the session-driven current-app context. Used by tooling that must read the raw,
+     * un-overridden config of an arbitrary app while a different app is selected.
      */
     public static function resolveConfigPath(string $app, string $viewType, string $component): ?string
     {

--- a/src/Navigation/SetupCollectionsNavigationProvider.php
+++ b/src/Navigation/SetupCollectionsNavigationProvider.php
@@ -18,6 +18,10 @@ class SetupCollectionsNavigationProvider implements DynamicNavigationProviderCon
     }
 
     /**
+     * The route takes its key from the query string rather than a route param, so
+     * route() is given the key as an extra param and appends it as a query string.
+     * Going through route() keeps this off the hardcoded-path list.
+     *
      * @return array<int, array{title: string, link: string, heroicon: string}>
      */
     public function items(): array
@@ -25,7 +29,7 @@ class SetupCollectionsNavigationProvider implements DynamicNavigationProviderCon
         return $this->repository->all()
             ->map(fn(SetupCollectionDefinitionData $d) => [
                 'title' => $d->titleList,
-                'link' => "/setup-collections?key={$d->filename}",
+                'link' => route('setup-collections', ['key' => $d->filename], absolute: false),
                 'heroicon' => 'archive-box',
             ])
             ->values()

--- a/src/Services/NullLayoutOverrideResolver.php
+++ b/src/Services/NullLayoutOverrideResolver.php
@@ -5,9 +5,9 @@ namespace Noerd\Services;
 use Noerd\Contracts\LayoutOverrideResolver;
 
 /**
- * Default no-op resolver: returns the config untouched. This keeps noerd core
- * fully inert when the noerd-pro module is not installed — every list and detail
- * renders straight from its YAML.
+ * Default no-op resolver: returns the config untouched. This keeps the core fully
+ * inert unless a module rebinds the resolver — every list and detail renders
+ * straight from its YAML.
  */
 final class NullLayoutOverrideResolver implements LayoutOverrideResolver
 {

--- a/src/Traits/HasModuleInstallation.php
+++ b/src/Traits/HasModuleInstallation.php
@@ -740,6 +740,91 @@ trait HasModuleInstallation
     }
 
     /**
+     * Ensure an icon link exists in the global top-bar config (app-configs/top-bar.yml),
+     * rendered right of the quick-menu. Matches on `route`, so calling this repeatedly
+     * never duplicates the item. Like the quick-menu config, the file is created on
+     * demand rather than published by noerd:install.
+     *
+     * @param  array{route: string, heroicon?: string, label?: string}  $item
+     */
+    protected function ensureTopBarItem(array $item): void
+    {
+        $configPath = base_path('app-configs/top-bar.yml');
+
+        $config = file_exists($configPath)
+            ? (Yaml::parse(file_get_contents($configPath) ?: '') ?? [])
+            : [];
+        $items = $config['items'] ?? [];
+
+        foreach ($items as $existing) {
+            if (($existing['route'] ?? null) === $item['route']) {
+                $this->line('<comment>Top-bar already contains the item.</comment>');
+
+                return;
+            }
+        }
+
+        $dir = dirname($configPath);
+        if (! is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+
+        $config['items'] = [...$items, $item];
+        file_put_contents($configPath, Yaml::dump($config, 10, 2));
+        $this->line('<info>Top-bar config updated:</info> app-configs/top-bar.yml');
+    }
+
+    /**
+     * Ensure a navigation entry exists in a block of the project's setup navigation
+     * (app-configs/setup/navigation.yml). Matches on the entry's `route`, so calling
+     * this repeatedly never duplicates the entry. Creates the named block if absent.
+     *
+     * Only the project copy is written — never the module's install template
+     * (app-modules/noerd/app-configs/setup/navigation.yml). The sidebar resolves
+     * `route:` keys through an unguarded route() call, so shipping an entry in the
+     * template would break every installation that lacks the route's module.
+     *
+     * @param  array{title: string, route: string, heroicon?: string}  $entry
+     */
+    protected function ensureSetupNavigation(string $blockTitle, array $entry): void
+    {
+        $configPath = base_path('app-configs/setup/navigation.yml');
+
+        if (! file_exists($configPath)) {
+            $this->warn('app-configs/setup/navigation.yml not found; navigation entry was not added.');
+
+            return;
+        }
+
+        $navigation = Yaml::parse(file_get_contents($configPath) ?: '') ?? [];
+
+        $blockIndex = null;
+        foreach ($navigation[0]['block_menus'] ?? [] as $i => $block) {
+            if (($block['title'] ?? null) === $blockTitle) {
+                $blockIndex = $i;
+                break;
+            }
+        }
+
+        if ($blockIndex === null) {
+            $navigation[0]['block_menus'][] = ['title' => $blockTitle, 'navigations' => []];
+            $blockIndex = array_key_last($navigation[0]['block_menus']);
+        }
+
+        foreach ($navigation[0]['block_menus'][$blockIndex]['navigations'] ?? [] as $existing) {
+            if (($existing['route'] ?? null) === $entry['route']) {
+                $this->line("<comment>Setup navigation already contains:</comment> {$entry['title']}");
+
+                return;
+            }
+        }
+
+        $navigation[0]['block_menus'][$blockIndex]['navigations'][] = $entry;
+        file_put_contents($configPath, Yaml::dump($navigation, 10, 2));
+        $this->line("<info>Setup navigation updated:</info> {$blockTitle} → {$entry['title']}");
+    }
+
+    /**
      * Ask the user if they want to run migrations.
      */
     protected function askForMigration(): void

--- a/tests/Feature/DetailRouteTest.php
+++ b/tests/Feature/DetailRouteTest.php
@@ -32,7 +32,7 @@ beforeEach(function (): void {
 });
 
 it('loads noerd-user-detail via direct route', function (): void {
-    $this->get('/noerd-user/' . $this->user->id)
+    $this->get('/setup/noerd-user/' . $this->user->id)
         ->assertSuccessful()
         ->assertSeeLivewire('noerd::noerd-user-detail');
 });
@@ -42,7 +42,7 @@ it('loads user-role-detail via direct route', function (): void {
         'tenant_id' => $this->tenant->id,
     ]);
 
-    $this->get('/user-role/' . $userRole->id)
+    $this->get('/setup/user-role/' . $userRole->id)
         ->assertSuccessful()
         ->assertSeeLivewire('noerd::user-role-detail');
 });
@@ -53,7 +53,7 @@ it('loads setup-collection-detail via direct route', function (): void {
         'collection_key' => 'test-collection',
     ]);
 
-    $this->get('/setup-collection/' . $setupCollection->id)
+    $this->get('/setup/collection/' . $setupCollection->id)
         ->assertSuccessful()
         ->assertSeeLivewire('noerd::setup-collection-detail');
 });
@@ -61,7 +61,7 @@ it('loads setup-collection-detail via direct route', function (): void {
 it('loads setup-language-detail via direct route', function (): void {
     $setupLanguage = SetupLanguage::where('code', 'en')->first();
 
-    $this->get('/setup-language/' . $setupLanguage->id)
+    $this->get('/setup/language/' . $setupLanguage->id)
         ->assertSuccessful()
         ->assertSeeLivewire('noerd::setup-language-detail');
 });

--- a/tests/Feature/SetupCollectionDefinitionRouteGuardTest.php
+++ b/tests/Feature/SetupCollectionDefinitionRouteGuardTest.php
@@ -12,7 +12,7 @@ it('returns 404 for /setup-collection-definitions in yaml mode', function (): vo
     ['user' => $user] = $this->createUserWithSetupAccess();
     $this->actingAs($user);
 
-    $response = $this->get('/setup-collection-definitions');
+    $response = $this->get('/setup/collection-definitions');
     $response->assertNotFound();
 });
 
@@ -23,6 +23,6 @@ it('returns 200 for /setup-collection-definitions in database mode', function ()
     ['user' => $user] = $this->createUserWithSetupAccess();
     $this->actingAs($user);
 
-    $response = $this->get('/setup-collection-definitions');
+    $response = $this->get('/setup/collection-definitions');
     $response->assertOk();
 });

--- a/tests/Feature/SetupCollectionDefinitionTest.php
+++ b/tests/Feature/SetupCollectionDefinitionTest.php
@@ -42,7 +42,7 @@ it('renders the list component and shows existing definitions', function (): voi
     ['user' => $user] = $this->createUserWithSetupAccess();
     $this->actingAs($user);
 
-    $response = $this->get('/setup-collection-definitions');
+    $response = $this->get('/setup/collection-definitions');
     $response->assertOk();
 
     Livewire::test('noerd::setup-collection-definitions-list')

--- a/tests/Feature/SetupCollectionsTest.php
+++ b/tests/Feature/SetupCollectionsTest.php
@@ -221,7 +221,7 @@ describe('SetupCollectionEntry Model', function (): void {
 
 describe('Setup Collections Route', function (): void {
     it('can access setup-collections route', function (): void {
-        $response = $this->get('/setup-collections?key=example');
+        $response = $this->get('/setup/collections?key=example');
 
         $response->assertStatus(200);
     });

--- a/tests/Feature/TenantAppsListTest.php
+++ b/tests/Feature/TenantAppsListTest.php
@@ -34,7 +34,7 @@ beforeEach(function (): void {
 it('renders the tenant-apps page for super admins', function (): void {
     $this->actingAs($this->admin);
 
-    $this->get('/tenant-apps')
+    $this->get('/setup/tenant-apps')
         ->assertSuccessful()
         ->assertSeeLivewire('noerd::setup.tenant-apps-list');
 });
@@ -44,7 +44,7 @@ it('renders the tenant-apps page in single-tenant mode', function (): void {
 
     $this->actingAs($this->admin);
 
-    $this->get('/tenant-apps')
+    $this->get('/setup/tenant-apps')
         ->assertSuccessful()
         ->assertSeeLivewire('noerd::setup.tenant-apps-list');
 });
@@ -82,7 +82,7 @@ it('denies access to non-admin users', function (): void {
 
     $this->actingAs($nonAdmin);
 
-    $this->get('/tenant-apps')
+    $this->get('/setup/tenant-apps')
         ->assertUnauthorized();
 });
 

--- a/tests/Feature/TopBarItemsTest.php
+++ b/tests/Feature/TopBarItemsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Route;
+use Livewire\Livewire;
+use Noerd\Helpers\TenantHelper;
+use Noerd\Models\NoerdUser;
+use Noerd\Models\Tenant;
+use Symfony\Component\Yaml\Yaml;
+
+uses(Tests\TestCase::class, RefreshDatabase::class);
+
+/**
+ * The top bar reads the real project config, so each test snapshots the file and
+ * restores it afterwards.
+ */
+beforeEach(function (): void {
+    $this->topBarPath = base_path('app-configs/top-bar.yml');
+    $this->topBarBackup = file_exists($this->topBarPath) ? file_get_contents($this->topBarPath) : null;
+
+    $user = NoerdUser::factory()->create();
+    $tenant = Tenant::factory()->create();
+    $user->tenants()->attach($tenant->id);
+    TenantHelper::setSelectedTenantId($tenant->id);
+    $this->actingAs($user);
+});
+
+afterEach(function (): void {
+    if ($this->topBarBackup !== null) {
+        file_put_contents($this->topBarPath, $this->topBarBackup);
+    } elseif (file_exists($this->topBarPath)) {
+        unlink($this->topBarPath);
+    }
+});
+
+function writeTopBar(string $path, array $items): void
+{
+    file_put_contents($path, Yaml::dump(['items' => $items], 10, 2));
+}
+
+it('renders an icon link for each configured item', function (): void {
+    Route::get('/dummy-target', fn() => '')->name('dummy-target');
+
+    writeTopBar($this->topBarPath, [
+        ['route' => 'dummy-target', 'heroicon' => 'squares-2x2', 'label' => 'Dummy'],
+    ]);
+
+    Livewire::test('noerd::layout.top-bar')
+        ->assertOk()
+        ->assertSee(route('dummy-target', absolute: false))
+        ->assertSee('Dummy');
+});
+
+/**
+ * The load-bearing guard: uninstalling a module leaves its entry behind in the
+ * YAML. Without Route::has() the route() call would take down every page.
+ */
+it('skips an item whose route does not exist instead of throwing', function (): void {
+    writeTopBar($this->topBarPath, [
+        ['route' => 'route-from-an-uninstalled-module', 'heroicon' => 'squares-2x2', 'label' => 'Gone'],
+    ]);
+
+    Livewire::test('noerd::layout.top-bar')
+        ->assertOk()
+        ->assertDontSee('Gone');
+});
+
+it('renders without items when the config file is absent', function (): void {
+    if (file_exists($this->topBarPath)) {
+        unlink($this->topBarPath);
+    }
+
+    Livewire::test('noerd::layout.top-bar')
+        ->assertOk()
+        ->assertSet('topBarItems', []);
+});


### PR DESCRIPTION
- Group all setup routes under a `/setup` URL prefix; route names stay unchanged as the public contract, and redundant `setup-` path segments are dropped in favour of the prefix
- Replace the hardcoded Layouts button in the top bar with items read from `app-configs/top-bar.yml`, guarded by `Route::has()` so a leftover entry from an uninstalled module cannot break every page
- Add `ensureTopBarItem()` and `ensureSetupNavigation()` to `HasModuleInstallation` so modules can register their own entries
- Build the setup-collections navigation link via `route()` instead of a hardcoded path
- Drop noerd-pro references from the layout-override docblocks