### PR TITLE
Show active column filters as labeled chips in the list header

### DIFF
--- a/docs/list-filters.md
+++ b/docs/list-filters.md
@@ -40,11 +40,28 @@ A column is filterable when it is declared in the list YAML `columns`, is not `a
 - The header "Clear all filters" button (`clearAllListFilters()`) clears the column filters too; each popover also offers a per-column clear
 - CSV export respects active column filters when the export query builds on `listQuery()`
 
+### Header chips
+
+Every active column filter renders as a chip next to the list title, so the user always sees WHICH
+field is filtered by WHICH value — e.g. `PLZ: 95028 ✕`. Each chip carries its own ✕ that clears
+exactly that filter (`clearColumnFilter()`). The global "Clear all filters" ✕ only appears when more
+than one chip is active or header `listFilters` are set on top — with a single chip its own ✕ suffices.
+
+The chip resolves both parts for display via `NoerdList::activeColumnFilterChips()`:
+
+- **Label**: the column's translated `label` from the list YAML (falls back to the field name)
+- **Value**: bool columns show Yes/No instead of `1`/`0`; picklist/badge columns show the translated
+  option label (from the list column's own `options` or the paired detail YAML, same resolution as
+  the badge cells); everything else shows the expression as typed (`>=10`, `=Rot`, …)
+
+The type resolution (explicit YAML type → DB schema type) mirrors `applyColumnFilters()`, so a chip
+always describes the filter the query actually applies.
+
 ### Architecture
 
 - Expression parsing + query application: `Noerd\Services\ColumnFilterParser` (fixed operator set, values only ever bound as parameters — user input never reaches SQL text)
 - State + whitelist: `NoerdList::$listColumnFilters`, `setColumnFilter()`, `clearColumnFilter()`, `filterableColumnFields()`, `applyColumnFilters()` (hooked inside `listQuery()`)
-- Header UI: `noerd::components.table.column-filter`, included from `table-sort.blade.php`
+- Header UI: `noerd::components.table.column-filter`, included from `table-sort.blade.php`; active-filter chips: `NoerdList::activeColumnFilterChips()`, rendered in `noerd::components.table.list-header`
 - Tests: `app-modules/noerd/tests/Unit/ColumnFilterParserTest.php`, `app-modules/noerd/tests/Traits/NoerdListColumnFilterTest.php`
 
 ## How Filters Work

--- a/resources/views/components/table/list-header.blade.php
+++ b/resources/views/components/table/list-header.blade.php
@@ -50,10 +50,10 @@
         </div>
 
         @php
-            $columnFiltersActive = collect($this->listColumnFilters ?? [])->filter()->isNotEmpty();
+            $activeColumnFilterChips = $this->activeColumnFilterChips();
         @endphp
-        @if ($this->tableFilters() || $columnFiltersActive)
-            <div class="ml-4 flex items-center">
+        @if ($this->tableFilters() || $activeColumnFilterChips !== [])
+            <div class="ml-4 flex flex-wrap items-center gap-1">
                 @foreach ($this->tableFilters() as $tableFilter)
                     @if (in_array($tableFilter['type'] ?? 'Picklist', ['ShowFrom', 'ShowUntil']))
                         <x-noerd::filters.date-dropdown
@@ -67,7 +67,24 @@
                         />
                     @endif
                 @endforeach
-                @if (collect($this->listFilters)->filter()->isNotEmpty() || $columnFiltersActive)
+                @foreach ($activeColumnFilterChips as $filterChip)
+                    <span
+                        wire:key="column-filter-chip-{{ $filterChip['field'] }}"
+                        class="flex items-center gap-1 rounded-full bg-gray-100 py-0.5 pr-1 pl-2.5 text-xs font-normal whitespace-nowrap text-gray-700"
+                    >
+                        <span class="font-medium">{{ $filterChip['label'] }}:</span>
+                        {{ $filterChip['value'] }}
+                        <button
+                            type="button"
+                            wire:click="clearColumnFilter('{{ $filterChip['field'] }}')"
+                            title="{{ __('Clear filter') }}"
+                            class="rounded-full p-0.5 text-gray-500 hover:bg-gray-200 hover:text-gray-700"
+                        >
+                            <x-dynamic-component component="heroicons::mini.solid.x-mark" class="size-3" />
+                        </button>
+                    </span>
+                @endforeach
+                @if (collect($this->listFilters)->filter()->isNotEmpty() || count($activeColumnFilterChips) > 1)
                     <x-noerd::button
                         variant="icon"
                         size="sm"
@@ -75,7 +92,6 @@
                         type="button"
                         wire:click="clearAllListFilters"
                         :title="__('Clear all filters')"
-                        class="-ml-3"
                     />
                 @endif
             </div>

--- a/src/Traits/NoerdList.php
+++ b/src/Traits/NoerdList.php
@@ -436,6 +436,61 @@ trait NoerdList
     }
 
     /**
+     * Active Excel-style column filters resolved for display in the list header:
+     * one chip per filter carrying the translated column label and a
+     * human-readable value (option labels for picklist/badge columns, Yes/No for
+     * booleans, the raw expression as typed otherwise).
+     *
+     * @return array<int, array{field: string, label: string, value: string}>
+     */
+    public function activeColumnFilterChips(): array
+    {
+        $active = array_filter(
+            $this->listColumnFilters,
+            fn($value): bool => is_string($value) && mb_trim($value) !== '',
+        );
+
+        if ($active === []) {
+            return [];
+        }
+
+        $columns = collect($this->getListConfig($this->listQueryConfigName)['columns'] ?? [])
+            ->filter(fn($column): bool => isset($column['field']))
+            ->keyBy('field');
+        $picklistOptions = $this->picklistOptionsFromDetail();
+        $schemaTypes = $this->resolvedModelClass !== null
+            ? $this->schemaColumnTypeMap((new $this->resolvedModelClass())->getTable())
+            : [];
+
+        $chips = [];
+        foreach ($active as $field => $raw) {
+            $column = $columns->get($field, []);
+            $type = $column['type'] ?? $schemaTypes[$field] ?? null;
+            $options = $column['options'] ?? $picklistOptions[$field] ?? [];
+
+            $value = mb_trim($raw);
+            if (in_array($type, ['bool', 'boolean', 'inversebool'], true)) {
+                $value = $value === '1' ? __('Yes') : __('No');
+            } else {
+                foreach ($options as $option) {
+                    if ((string) ($option['value'] ?? '') === $value) {
+                        $value = __($option['label'] ?? $value);
+                        break;
+                    }
+                }
+            }
+
+            $chips[] = [
+                'field' => $field,
+                'label' => __($column['label'] ?? $field),
+                'value' => $value,
+            ];
+        }
+
+        return $chips;
+    }
+
+    /**
      * Open a row by its POSITION in the current page — the keyboard path only
      * (arrow keys track a positional index, Enter submits it). Resolving the
      * position costs a full listData() round; mouse clicks know the model id

--- a/tests/Traits/NoerdListColumnFilterTest.php
+++ b/tests/Traits/NoerdListColumnFilterTest.php
@@ -252,6 +252,59 @@ it('renders no funnel buttons in compact mode', function (): void {
     expect($html)->not->toContain('column-filter-name-');
 });
 
+it('resolves active column filters into labeled header chips', function (): void {
+    NoerdUser::factory()->create(['name' => 'Rotkohl', 'super_admin' => true]);
+
+    $component = Livewire::test(TestableColumnFilterChipListComponent::class)
+        ->call('setColumnFilter', 'name', 'rot')
+        ->call('setColumnFilter', 'super_admin', '1')
+        ->call('setColumnFilter', 'email', 'open@example.com');
+
+    filterListIds($component);
+
+    expect($component->instance()->activeColumnFilterChips())->toBe([
+        ['field' => 'name', 'label' => 'Name', 'value' => 'rot'],
+        ['field' => 'super_admin', 'label' => 'Admin', 'value' => 'Yes'],
+        ['field' => 'email', 'label' => 'Status', 'value' => 'Open'],
+    ]);
+});
+
+it('resolves a bool zero filter chip to No', function (): void {
+    NoerdUser::factory()->create(['super_admin' => false]);
+
+    $component = Livewire::test(TestableColumnFilterChipListComponent::class)
+        ->call('setColumnFilter', 'super_admin', '0');
+
+    filterListIds($component);
+
+    expect($component->instance()->activeColumnFilterChips())->toBe([
+        ['field' => 'super_admin', 'label' => 'Admin', 'value' => 'No'],
+    ]);
+});
+
+it('returns no chips without active column filters', function (): void {
+    NoerdUser::factory()->create();
+
+    $component = Livewire::test(TestableColumnFilterChipListComponent::class);
+
+    expect($component->instance()->activeColumnFilterChips())->toBe([]);
+});
+
+it('renders active column filter chips in the list header', function (): void {
+    $tenant = Tenant::factory()->create();
+    $user = NoerdUser::factory()->create();
+    TenantHelper::setSelectedTenantId($tenant->id);
+    TenantHelper::setSelectedApp('SETUP');
+    test()->actingAs($user);
+
+    $html = Livewire::test(TestableColumnFilterPageRenderComponent::class)
+        ->call('setColumnFilter', 'name', 'rot')
+        ->html();
+
+    expect($html)->toContain('column-filter-chip-name')
+        ->toContain('clearColumnFilter');
+});
+
 /**
  * List component with an inline YAML config over the noerd_users table.
  */
@@ -299,5 +352,45 @@ class TestableColumnFilterRenderComponent extends TestableColumnFilterListCompon
     public function render(): string
     {
         return '<div><x-noerd::list /></div>';
+    }
+}
+
+/**
+ * Same list wrapped in the page component, so the header slot (and with it the
+ * filter chips) actually renders.
+ */
+class TestableColumnFilterPageRenderComponent extends TestableColumnFilterListComponent
+{
+    public function render(): string
+    {
+        return '<div><x-noerd::page><x-noerd::list /></x-noerd::page></div>';
+    }
+}
+
+/**
+ * Synthetic config exercising every chip value resolution: plain text, an
+ * auto-typed bool column and a badge column with inline options.
+ */
+class TestableColumnFilterChipListComponent extends TestableColumnFilterListComponent
+{
+    public const COMPONENT = 'testable-column-filter-chip-list';
+
+    protected function getListConfig(?string $customName = null): array
+    {
+        return [
+            'title' => 'Testable Users',
+            'columns' => [
+                ['field' => 'name', 'label' => 'Name'],
+                ['field' => 'super_admin', 'label' => 'Admin'],
+                [
+                    'field' => 'email',
+                    'label' => 'Status',
+                    'type' => 'badge',
+                    'options' => [
+                        ['value' => 'open@example.com', 'label' => 'Open'],
+                    ],
+                ],
+            ],
+        ];
     }
 }


### PR DESCRIPTION
## Summary

Active Excel-style column filters (`?cf[...]`) were only signaled by a bare ✕ next to the list title — the user could not see which field was filtered by which value.

- New `NoerdList::activeColumnFilterChips()` resolves every active column filter for display: translated column label from the list YAML, plus a human-readable value (Yes/No for bool columns, translated option labels for picklist/badge columns via the list column options or the paired detail YAML, the raw expression otherwise). Type resolution mirrors `applyColumnFilters()`.
- `list-header.blade.php` renders one chip per active filter (e.g. `PLZ: 95028 ✕`) with its own remove button (`clearColumnFilter`). The global "Clear all filters" ✕ now only appears with more than one chip or additional header `listFilters`.
- Docs updated (`docs/list-filters.md`, new "Header chips" section).

## Tests

Four new Pest tests in `NoerdListColumnFilterTest` covering label/value resolution (text, bool Yes/No, badge option label), the empty state, and header rendering through an `x-noerd::page` wrapper. Full file: 24 passed.