### PR TITLE
Add generic YAML-driven grid display mode for lists

### DIFF
--- a/docs/list-view.md
+++ b/docs/list-view.md
@@ -76,6 +76,8 @@ columns:
 | `bulkActions` | Array of bulk-action buttons shown when one or more rows are selected (see Multi-Select & Bulk Actions below) |
 | `searchableColumns` | Restrict the search to specific fields (see [List Search](list-search.md)) |
 | `notSortableColumns` | Fields whose header must not be sortable (see [List Search](list-search.md)) |
+| `displayMode` | `table` (default) or `grid` — render the rows as a card grid instead of a table (see Grid Mode below) |
+| `gridColumns` | Cards per row in grid mode at the largest breakpoint, `1`–`6` (default: `4`) |
 | `columns` | Array of column definitions |
 
 ## Column Properties
@@ -610,6 +612,56 @@ protected function prepareCsvExport(): array
 - `formatCsvValue($value, $column)` formats each cell by column type (`bool` → Yes/No, `badge` →
   the translated option label, dates/currency accordingly) — override it for custom formats
 - `prepareExportRow($row)` is an optional per-row hook (e.g. to eager-compute accessors)
+
+## Grid Mode (Card Layout)
+
+Any list can render its rows as a **card grid** instead of the table — purely through the list
+YAML, with zero changes to the component's Blade file:
+
+```yaml
+title: POS
+description: Select a customer to start a new order.
+displayMode: grid
+gridColumns: 4
+columns:
+  - field: name
+    label: Name
+  - field: company_name
+    label: Company
+  - field: city
+    label: City
+searchableColumns:
+  - name
+  - company_name
+  - city
+```
+
+Grid mode swaps only the rows block (`noerd::components.list.grid`) — the list header (title,
+search, view switcher, actions, filter chips), the pagination footer, the picker/bulk footers and
+the object-permission handling stay exactly as in table mode.
+
+**Card content** is derived from the `columns` array: the first column with a non-empty value
+renders as the bold card title, every remaining column as a secondary line; empty values are
+skipped entirely (so a missing `name` falls through to the next column as the title). Column types
+are honored like in minimal mode: `currency`, `date`, `datetime`, `bool` are formatted, `badge`
+renders as a translated pill; everything else renders as text (`data_get`, so dotted fields work).
+
+**Cards per row**: `gridColumns` (`1`–`6`, default `4`) sets the count at the largest breakpoint;
+smaller viewports collapse responsively (1 column on mobile, 2 from `sm`, 3 from `lg`). The classes
+come from a static map — Tailwind cannot generate class names at runtime, so only these values are
+supported; an unknown value falls back to `4`.
+
+**Row click** behaves exactly like a table row click (`openListRow` → `$detailRoute` /
+`$detailComponent`, or a custom `listAction()` override), including the keyboard navigation
+(arrow keys + Enter) and picker mode. In `multiSelect` mode each card gets a checkbox in its
+top-right corner wired to `toggleRecordSelection`.
+
+**Not rendered in grid mode** (thead-only features): column sort headers (the default sort from
+`setDefaultSort()` still applies), the Excel-style column-filter funnels (active filters still
+apply to the query and stay visible/clearable via the header filter chips), the select-all
+checkbox, `showLineNumbers` and the summary footer.
+
+A list mounted as a **minimal widget** ignores `displayMode` — minimal mode takes precedence.
 
 ## Minimal Mode (List Widgets)
 

--- a/resources/views/components/list/grid.blade.php
+++ b/resources/views/components/list/grid.blade.php
@@ -1,0 +1,152 @@
+{{-- Card-grid display mode, included from list/index.blade.php in place of the
+     table when the list YAML sets `displayMode: grid`. Runs in the index scope,
+     so $rows, $table, $listId, $listSettings, $multiSelect, $selectedRecordIds,
+     $actions and $relations are available. Thead-only features (sort headers,
+     column filters, select-all, line numbers, summary) are not rendered here —
+     active column filters still apply and stay clearable via the header chips. --}}
+@php
+    // Tailwind cannot generate class names at runtime — every supported
+    // gridColumns value maps to a literal class list so the scanner picks it up.
+    $gridColumnClasses = [
+        1 => 'grid-cols-1',
+        2 => 'grid-cols-1 sm:grid-cols-2',
+        3 => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
+        4 => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4',
+        5 => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5',
+        6 => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6',
+    ];
+    $gridClass = $gridColumnClasses[(int) ($listSettings['gridColumns'] ?? 4)] ?? $gridColumnClasses[4];
+
+    // Same type handling as list/minimal.blade.php so YAML/auto column types are honored
+    $formatGridValue = function (mixed $value, array $column): string {
+        return match ($column['type'] ?? 'text') {
+            'currency' => is_numeric($value) ? \Noerd\Helpers\CurrencyHelper::format((float) $value) : (string) ($value ?? ''),
+            'date' => $value ? \Carbon\Carbon::parse($value)->format('d.m.Y') : '',
+            'datetime' => $value ? \Carbon\Carbon::parse($value)->format(app()->getLocale() === 'de' ? 'd.m.Y H:i' : 'Y-m-d H:i') : '',
+            'bool', 'boolean' => $value ? __('Yes') : __('No'),
+            default => (string) ($value ?? ''),
+        };
+    };
+@endphp
+
+<div class="min-w-full pb-2 align-middle">
+    @if (count($rows))
+        <div class="grid {{ $gridClass }} gap-3">
+            @foreach ($rows as $key => $row)
+                @php
+                    // Card content from the YAML columns: the first column with a
+                    // non-empty value renders as the bold card title, the remaining
+                    // columns as secondary lines; empty values are skipped entirely.
+                    $cells = [];
+                    foreach ($table as $column) {
+                        if (($column['field'] ?? null) === 'action') {
+                            continue;
+                        }
+                        $value = data_get($row, $column['field'] ?? null);
+                        $value = $value instanceof \BackedEnum ? $value->value : ($value instanceof \UnitEnum ? $value->name : $value);
+                        $isBadge = ($column['type'] ?? 'text') === 'badge';
+                        if ($isBadge) {
+                            $text = (string) ($value ?? '');
+                            foreach ($column['options'] ?? [] as $option) {
+                                if (isset($option['value']) && (string) $option['value'] === $text) {
+                                    $text = (string) ($option['label'] ?? $text);
+                                    break;
+                                }
+                            }
+                        } else {
+                            $text = $formatGridValue($value, $column);
+                        }
+                        if ($text === '') {
+                            continue;
+                        }
+                        $cells[] = ['text' => $text, 'isBadge' => $isBadge];
+                    }
+                    $rowChecked = $multiSelect && in_array($this->normalizeRecordId($row['id'] ?? 0), $selectedRecordIds, true);
+                @endphp
+                <button
+                    type="button"
+                    :key="{{ $key }}"
+                    wire:key="grid-{{ $listId }}-{{ $row['id'] ?? $key }}"
+                    :class="{'ring-2 ring-brand-primary': selectedRow{{ $listId }} == {{ $key }} }"
+                    @click="selectedRow{{ $listId }} = '{{ $key }}'"
+                    wire:click="openListRow('{{ $row['id'] ?? '' }}')"
+                    class="group hover:border-brand-primary relative flex cursor-pointer flex-col items-start gap-1 rounded-lg border bg-white p-4 text-left transition hover:shadow-sm {{ $rowChecked ? 'border-brand-primary' : 'border-gray-200' }}"
+                >
+                    @if ($multiSelect)
+                        <div class="absolute top-3 right-3" @click.stop>
+                            {{-- The checked state is part of the wire:key so the input is
+                                 recreated when the selection clears — otherwise a user-toggled
+                                 checkbox keeps its DOM checked state through the morph. --}}
+                            <input
+                                type="checkbox"
+                                wire:key="grid-cb-{{ $listId }}-{{ $row['id'] ?? $key }}-{{ $rowChecked ? 1 : 0 }}"
+                                wire:click.stop="toggleRecordSelection('{{ $row['id'] ?? '' }}')"
+                                @checked($rowChecked)
+                                class="text-brand-primary focus:ring-brand-border block h-4 w-4 cursor-pointer rounded border-gray-300"
+                            />
+                        </div>
+                    @endif
+                    @foreach ($cells as $index => $cell)
+                        @if ($cell['isBadge'])
+                            <span class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-700">
+                                {{ __($cell['text']) }}
+                            </span>
+                        @elseif ($index === 0)
+                            <span class="group-hover:text-brand-primary font-medium text-gray-900">
+                                {{ $cell['text'] }}
+                            </span>
+                        @else
+                            <span class="text-sm text-gray-500">
+                                {{ $cell['text'] }}
+                            </span>
+                        @endif
+                    @endforeach
+                    @if ($cells === [])
+                        <span class="font-medium text-gray-400">&mdash;</span>
+                    @endif
+                </button>
+            @endforeach
+        </div>
+    @else
+        @php
+            $primaryAction = $actions[0] ?? null;
+        @endphp
+        <div class="rounded-lg border border-dashed border-gray-300 px-6 py-12 text-center">
+            <p class="text-sm text-gray-500">
+                {{ __('No entries yet') }}
+            </p>
+            @if ($primaryAction)
+                @php
+                    // Mirrors the header action: route: opens a modal,
+                    // action: calls a method on the list component.
+                    $emptyStateRoute = $primaryAction['route'] ?? null;
+                    $emptyStateRoute = $emptyStateRoute && \Illuminate\Support\Facades\Route::has($emptyStateRoute)
+                        ? $emptyStateRoute
+                        : null;
+                @endphp
+                <div class="mt-4 flex justify-center">
+                    @if ($emptyStateRoute)
+                        <x-noerd::button
+                            variant="primary"
+                            :icon="$primaryAction['heroicon'] ?? 'plus'"
+                            class="h-8"
+                            x-data
+                            x-on:click.prevent="$modalRoute({{ Js::from($emptyStateRoute) }}, {{ Js::from($primaryAction['arguments'] ?? []) }})"
+                        >
+                            {{ __($primaryAction['label']) }}
+                        </x-noerd::button>
+                    @elseif (! empty($primaryAction['action']))
+                        <x-noerd::button
+                            variant="primary"
+                            :icon="$primaryAction['heroicon'] ?? 'plus'"
+                            class="h-8"
+                            wire:click.prevent="{{ $primaryAction['action'] }}(null, {{ Js::from($relations ?? []) }})"
+                        >
+                            {{ __($primaryAction['label']) }}
+                        </x-noerd::button>
+                    @endif
+                </div>
+            @endif
+        </div>
+    @endif
+</div>

--- a/resources/views/components/list/index.blade.php
+++ b/resources/views/components/list/index.blade.php
@@ -4,6 +4,7 @@
     'summary' => null,
     'compact' => null,
     'minimal' => null,
+    'hideHead' => false,
 ])
 
 @php
@@ -49,6 +50,9 @@
         $showSummary = $listSettings['showSummary'] ?? true;
         $table = $listSettings['columns'] ?? [];
 
+        // Grid mode renders the rows as a card grid instead of the table (YAML `displayMode: grid`)
+        $displayMode = $listSettings['displayMode'] ?? 'table';
+
         $listAction = $this->listActionMethod ?? 'listAction';
 
         // Multi-select: a leading checkbox column plus a footer that is either a picker
@@ -85,7 +89,10 @@
     @endphp
 
     <div>
-        @unless ($compact)
+        {{-- hideHead: for a list embedded below another component's page header (e.g.
+             inside a tab panel) — the slot registered by list-header would land on the
+             nearest enclosing component instead of the page and silently disappear. --}}
+        @unless ($compact || $hideHead)
             @include('noerd::components.table.list-header')
         @endunless
 
@@ -144,7 +151,7 @@
                 @keydown.window.arrow-up="if (canHandleListKey()) { $event.preventDefault(); selectedRow{{ $listId }}-- }"
                 @keydown.window.enter="if (canHandleListKey()) { $event.preventDefault(); $wire.findListAction(selectedRow{{ $listId }}) }"
             >
-                @if ((!isset($hideHead) || $hideHead !== true) && !$compact)
+                @if (! $hideHead && ! $compact)
                     <div>
                         @include('noerd::components.table.title-search', [
                             'title' => $title,
@@ -160,6 +167,9 @@
                 @endif
 
                 @isset($table)
+                    @if ($displayMode === 'grid')
+                        @include('noerd::components.list.grid')
+                    @else
                     <div class="min-w-full pb-2 align-middle">
                         <div>
                             <div class="flow-root">
@@ -344,6 +354,7 @@
                             </div>
                         </div>
                     </div>
+                    @endif
 
                     @if (!$compact && isset($rows) && count($rows) > 0 && !is_array($rows))
                         <div>{{ $rows->links('noerd::pagination') }}</div>

--- a/tests/Components/ListGridModeTest.php
+++ b/tests/Components/ListGridModeTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Component;
+use Livewire\Livewire;
+use Noerd\Tests\TestCase;
+use Noerd\Traits\NoerdList;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+$rows = [
+    ['id' => 1, 'name' => 'Alice', 'city' => 'Berlin'],
+    ['id' => 2, 'name' => 'Bob', 'city' => ''],
+];
+
+$columns = [
+    ['field' => 'name', 'label' => 'Name', 'type' => 'text'],
+    ['field' => 'city', 'label' => 'City', 'type' => 'text'],
+];
+
+it('renders cards instead of a table when displayMode grid is set in the config', function () use ($rows, $columns): void {
+    $html = Livewire::test(TestableGridListComponent::class)
+        ->set('rowsData', $rows)
+        ->set('configData', ['displayMode' => 'grid', 'columns' => $columns])
+        ->html();
+
+    expect($html)->toContain('wire:key="grid-')
+        ->toContain("wire:click=\"openListRow('1')\"")
+        ->not->toContain('<table')
+        ->not->toContain('<thead');
+});
+
+it('renders the table when the config does not set a display mode', function () use ($rows, $columns): void {
+    $html = Livewire::test(TestableGridListComponent::class)
+        ->set('rowsData', $rows)
+        ->set('configData', ['columns' => $columns])
+        ->html();
+
+    expect($html)->toContain('<table')
+        ->not->toContain('wire:key="grid-');
+});
+
+it('maps gridColumns onto the responsive grid classes with a fallback of four', function () use ($rows, $columns): void {
+    $htmlFor = fn (array $config): string => Livewire::test(TestableGridListComponent::class)
+        ->set('rowsData', $rows)
+        ->set('configData', $config)
+        ->html();
+
+    $base = ['displayMode' => 'grid', 'columns' => $columns];
+
+    assertElementHasClasses($htmlFor([...$base, 'gridColumns' => 3]), ['grid', 'lg:grid-cols-3']);
+    assertElementHasClasses($htmlFor($base), ['grid', 'xl:grid-cols-4']);
+    assertElementHasClasses($htmlFor([...$base, 'gridColumns' => 9]), ['grid', 'xl:grid-cols-4']);
+});
+
+it('uses the first non-empty column value as the card title', function () use ($columns): void {
+    $html = Livewire::test(TestableGridListComponent::class)
+        ->set('rowsData', [['id' => 5, 'name' => '', 'city' => 'Hamburg']])
+        ->set('configData', ['displayMode' => 'grid', 'columns' => $columns])
+        ->html();
+
+    expect(preg_match('/font-medium[^>]*>\s*Hamburg\s*</', $html))->toBe(1);
+});
+
+it('skips empty secondary values on the card', function () use ($rows, $columns): void {
+    $html = Livewire::test(TestableGridListComponent::class)
+        ->set('rowsData', $rows)
+        ->set('configData', ['displayMode' => 'grid', 'columns' => $columns])
+        ->html();
+
+    expect($html)->toContain('Berlin')
+        ->and(preg_match('/text-gray-500[^>]*>\s*<\/span>/', $html))->toBe(0);
+});
+
+it('renders badge columns as translated pills instead of the raw value', function (): void {
+    $html = Livewire::test(TestableGridListComponent::class)
+        ->set('rowsData', [['id' => 1, 'name' => 'Alice', 'status' => 'draft']])
+        ->set('configData', [
+            'displayMode' => 'grid',
+            'columns' => [
+                ['field' => 'name', 'label' => 'Name', 'type' => 'text'],
+                [
+                    'field' => 'status',
+                    'label' => 'Status',
+                    'type' => 'badge',
+                    'options' => [
+                        ['value' => 'draft', 'label' => 'Draft label'],
+                    ],
+                ],
+            ],
+        ])
+        ->html();
+
+    expect($html)->toContain('rounded-full')
+        ->toContain('Draft label')
+        ->not->toContain('>draft<');
+});
+
+it('renders the empty state when the grid has no rows', function () use ($columns): void {
+    $html = Livewire::test(TestableGridListComponent::class)
+        ->set('rowsData', [])
+        ->set('configData', ['displayMode' => 'grid', 'columns' => $columns])
+        ->html();
+
+    expect($html)->toContain(__('No entries yet'));
+});
+
+it('renders per-card checkboxes wired to toggleRecordSelection in multi-select mode', function () use ($rows, $columns): void {
+    $html = Livewire::test(TestableGridListComponent::class)
+        ->set('rowsData', $rows)
+        ->set('configData', ['displayMode' => 'grid', 'multiSelect' => true, 'columns' => $columns])
+        ->html();
+
+    expect($html)->toContain('wire:key="grid-cb-')
+        ->toContain("toggleRecordSelection('1')");
+});
+
+/**
+ * Minimal list component that renders the generic noerd list view from a directly
+ * provided array config, so the grid display mode can be tested in isolation.
+ */
+class TestableGridListComponent extends Component
+{
+    use NoerdList;
+
+    /** @var array<int, array<string, mixed>> */
+    public array $rowsData = [];
+
+    /** @var array<string, mixed> */
+    public array $configData = [];
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function with(): array
+    {
+        return [
+            'listConfig' => $this->buildList($this->rowsData, $this->configData),
+        ];
+    }
+
+    public function render(): string
+    {
+        return '<div><x-noerd::list /></div>';
+    }
+}


### PR DESCRIPTION
## Summary

Any NoerdList-based list can now render its rows as a **card grid** instead of the table — purely via the list YAML, with zero changes in the component's Blade file:

```yaml
displayMode: grid
gridColumns: 4
```

- `list/index.blade.php` reads `displayMode` from the list settings and swaps only the rows block for the new `noerd::components.list.grid` partial — list header (title, search, view switcher, actions, filter chips), pagination, picker/bulk footers and object-permission handling stay unchanged
- Card content derives from the YAML `columns`: the first column with a non-empty value renders as the bold card title, remaining columns as secondary lines; empty values are skipped. Column types are honored like in minimal mode (`currency`, `date`, `datetime`, `bool`, `badge` pill)
- `gridColumns` (1–6, default 4) maps to a static responsive Tailwind class list (1 col mobile, 2 from `sm`, 3 from `lg`); unknown values fall back to 4
- Row click behaves exactly like a table row (`openListRow` → detail route/component or a custom `listAction()` override), including keyboard navigation, picker mode and per-card multi-select checkboxes
- Thead-only features are not rendered in grid mode: sort headers, column-filter funnels (active filters still apply and stay clearable via the header chips), select-all, line numbers, summary footer. Minimal mode takes precedence over `displayMode`
- Docs: new "Grid Mode (Card Layout)" section in `list-view.md` plus the two new list properties

First consumer: the POS start screen (`pos::pos-customers-list`, noerd-dev/pos).

## Tests

`tests/Components/ListGridModeTest.php` — 8 cases with synthetic configs (grid vs. table rendering, `gridColumns` mapping incl. fallback, title fallback, empty-value skipping, badge pills, empty state, multi-select wiring). Full noerd suite: 733 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)