### PR TITLE
Make column filter chip test assertions locale-agnostic

### DIFF
--- a/tests/Traits/NoerdListColumnFilterTest.php
+++ b/tests/Traits/NoerdListColumnFilterTest.php
@@ -264,8 +264,8 @@ it('resolves active column filters into labeled header chips', function (): void
 
     expect($component->instance()->activeColumnFilterChips())->toBe([
         ['field' => 'name', 'label' => 'Name', 'value' => 'rot'],
-        ['field' => 'super_admin', 'label' => 'Admin', 'value' => 'Yes'],
-        ['field' => 'email', 'label' => 'Status', 'value' => 'Open'],
+        ['field' => 'super_admin', 'label' => 'Admin', 'value' => __('Yes')],
+        ['field' => 'email', 'label' => 'Status', 'value' => __('Open')],
     ]);
 });
 
@@ -278,7 +278,7 @@ it('resolves a bool zero filter chip to No', function (): void {
     filterListIds($component);
 
     expect($component->instance()->activeColumnFilterChips())->toBe([
-        ['field' => 'super_admin', 'label' => 'Admin', 'value' => 'No'],
+        ['field' => 'super_admin', 'label' => 'Admin', 'value' => __('No')],
     ]);
 });
 


### PR DESCRIPTION
## Summary
Two tests in `NoerdListColumnFilterTest` asserted the English literals `Yes` / `No` / `Open` for the column filter chip values. `NoerdList::activeColumnFilterChips()` deliberately translates these values via `__()`, and the module's own `de.json` ships `"Yes": "Ja"`, `"No": "Nein"`, `"Open": "Offen"` — so the tests failed in any host project that runs its test suite with `app.locale = de`.

The assertions now expect `__('Yes')` / `__('No')` / `__('Open')`, which keeps proving that the chips carry the translated label while being independent of the configured test locale.

## Test plan
- `php artisan test --compact app-modules/noerd/tests/Traits/NoerdListColumnFilterTest.php` — 24 passed (default `en` locale)
- `APP_LOCALE=de php artisan test --compact app-modules/noerd/tests/Traits/NoerdListColumnFilterTest.php` — 24 passed (reproduces the failing scenario)

🤖 Generated with [Claude Code](https://claude.com/claude-code)