### PR TITLE
Inject generic list header controls via modal-title for every NoerdList host

### DIFF
--- a/docs/header-actions.md
+++ b/docs/header-actions.md
@@ -4,7 +4,7 @@ Header actions let a module contribute small Livewire components to the header o
 
 ## Concept
 
-- **Separate slots for lists and details.** The registry keeps two independent lists: list actions render in the list header (`list-header`), detail actions render in the detail header (`modal-title`). An action that should appear in both contexts must be registered twice — there is no shared slot.
+- **Separate slots for lists and details.** The registry keeps two independent lists: list actions render in the list header controls (injected by `modal-title` via `table/list-controls` for every `NoerdList` host — including custom header slots), detail actions render in the detail header (`modal-title`). An action that should appear in both contexts must be registered twice — there is no shared slot.
 - **One action, one function, one Livewire component.** Every action is its own minimal Livewire component. It renders exactly one button (or nothing) and contains no logic for the other context.
 - **Actions own their visibility.** The core always mounts every registered action. The action itself decides in `mount()` whether it has something to show (permissions, current app, available configuration) and renders an empty root when hidden.
 

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -20,7 +20,7 @@ Format: `'modifier+key'` — e.g. `'s'`, `'/'`, `'ctrl+enter'`, `'shift+k'`. Sup
 
 | Config key | Default | What it does | Where it applies |
 |------------|---------|--------------|------------------|
-| `search_focus` | `s` | Focuses the search input | Every list header (`x-noerd::table.list-header`); Escape blurs the field again |
+| `search_focus` | `s` | Focuses the search input | Every list header (`noerd::components.table.list-controls`, injected by `modal-title`); Escape blurs the field again |
 | `new_entry` | `n` | Triggers the first action button (the "New …" button) | Every list header — see the note on per-action keys below |
 | `save` | `ctrl+enter` | Calls `store()` on the open detail/page | Every `x-noerd::page` whose component has a `store()` method |
 | `delete` | `ctrl+backspace` | Asks for confirmation, then calls `delete()` | Every `x-noerd::page` whose component has a `delete()` method |
@@ -70,8 +70,8 @@ e.key.toLowerCase() === "enter" && (e.ctrlKey || e.metaKey)
 
 ### Lists (helper-driven)
 
-The list header (`app-modules/noerd/resources/views/components/table/list-header.blade.php`) is
-the reference consumer — one `parse()` call feeds both the window listener and the `<kbd>` badge:
+The list header controls (`app-modules/noerd/resources/views/components/table/list-controls.blade.php`)
+are the reference consumer — one `parse()` call feeds both the window listener and the `<kbd>` badge:
 
 ```blade
 @php

--- a/docs/list-view.md
+++ b/docs/list-view.md
@@ -309,6 +309,20 @@ actions:
 - Buttons are displayed side by side
 - No `actions` key means no button is rendered
 
+**Where the controls render (generic injection):** the header controls — search, CSV export,
+registry list actions and the YAML action buttons — are injected by `x-noerd::modal-title`
+(`noerd::components.table.list-controls`) for EVERY component using the `NoerdList` trait. This
+covers the standard list header (`list-header` contributes only title, count, view switcher and
+filter chips) AND components with their own custom `<x-slot:header>` (e.g. a list nested in tab
+panels like the object manager): wrap the custom title in `<x-noerd::modal-title>` and the
+controls appear top right automatically — never hand-roll a search field or action buttons in a
+list header. Two props on `x-noerd::modal-title` tune the injection:
+
+| Prop | Description |
+|------|-------------|
+| `:listControls="false"` | Suppresses the injection (for headers without a real list behind them) |
+| `listControlsShow` | Alpine expression gating the controls' visibility, e.g. `currentTab === 2` |
+
 **Standard single action (most common):**
 
 ```yaml

--- a/resources/views/components/list/index.blade.php
+++ b/resources/views/components/list/index.blade.php
@@ -16,13 +16,11 @@
     @include('noerd::components.list.minimal')
 @else
     @php
-        // Auto-fetch listConfig from parent Livewire component if not provided: a
-        // component with its own with() keeps its custom query; the slim syntax
-        // (only $listModel declared) gets the generic trait query via listData().
-        $listConfig = $listConfig
-            ?? (method_exists($this, 'with') ? ($this->with()['listConfig'] ?? null) : null)
-            ?? (isset($this->listModel) ? $this->listData() : null)
-            ?? [];
+        // Auto-fetch listConfig from parent Livewire component if not provided.
+        // builtListConfig() memoizes the buildList() result, so a with()-style
+        // component (whose view data Livewire already computed) is not queried
+        // a second time; slim components ($listModel only) compute it here.
+        $listConfig = $listConfig ?? $this->builtListConfig();
         // Compact mode hides the list header and the pagination footer (e.g. for embedded lists)
         $compact ??= ($this->compact ?? false);
 
@@ -154,14 +152,7 @@
                 @if (! $hideHead && ! $compact)
                     <div>
                         @include('noerd::components.table.title-search', [
-                            'title' => $title,
                             'description' => $description ?? '',
-                            'actions' => $actions,
-                            'disableSearch' => $disableSearch ?? false,
-                            'relations' => $relations ?? [],
-                            'action' => $action ?? $listAction,
-                            'states' => $this->listStates(),
-                            'listFilters' => $this->listFilters(),
                         ])
                     </div>
                 @endif

--- a/resources/views/components/modal-title.blade.php
+++ b/resources/views/components/modal-title.blade.php
@@ -1,8 +1,16 @@
+@props([
+    /** Set to false to suppress the generic list header controls for a NoerdList host. */
+    'listControls' => true,
+    /** Optional Alpine expression gating the list controls' visibility (e.g. 'currentTab === 2'). */
+    'listControlsShow' => null,
+    /** Relations forwarded to YAML `action:` buttons — passed through by list-header. */
+    'listRelations' => [],
+])
+
 @php
     // Detail headers get the module-contributed header actions (HeaderActionsRegistry)
     // injected here — modal-title is the one generic component every *-detail header
-    // goes through. Lists inject theirs in list-header (their component ends in -list),
-    // and the slim quick-create dialogs are no place for admin tooling.
+    // goes through. The slim quick-create dialogs are no place for admin tooling.
     $headerActionHost = isset($__livewire) && str_ends_with($__livewire->getName(), '-detail')
         && ! ($__livewire->quickCreate ?? false)
         ? $__livewire
@@ -10,12 +18,51 @@
     $detailHeaderActions = $headerActionHost !== null
         ? app(\Noerd\Services\HeaderActionsRegistry::class)->detailActions()
         : [];
+
+    // List headers get their generic controls (search, CSV, registry list actions,
+    // YAML action buttons) injected here for every NoerdList host — whether this
+    // modal-title came from the generic list-header or from a component's own
+    // custom header slot (e.g. a list nested in tab panels). Opt out per header
+    // with :listControls="false".
+    $listControlsHost = $listControls
+        && isset($__livewire)
+        && in_array(\Noerd\Traits\NoerdList::class, class_uses_recursive($__livewire), true)
+        && ! ($__livewire->quickCreate ?? false)
+        && ! ($__livewire->compact ?? false)
+        && ! ($__livewire->minimal ?? false)
+        ? $__livewire
+        : null;
+
+    $listControlsConfig = $listControlsHost?->builtListConfig() ?? [];
+    $listControlsSettings = $listControlsConfig['listSettings'] ?? [];
+    $listObjectAccessDenied = $listControlsConfig['objectAccessDenied'] ?? false;
+    $listIsPicker = $listControlsHost->returnsSelection ?? false;
+    $hasListControls = $listControlsHost !== null && (
+        (! ($listControlsSettings['disableSearch'] ?? false) && ! $listObjectAccessDenied)
+        || ($listControlsHost->enableCsvExport ?? false)
+        || (! $listIsPicker && ($listControlsSettings['actions'] ?? []) !== [])
+        || (! $listIsPicker && app(\Noerd\Services\HeaderActionsRegistry::class)->listActions() !== [])
+    );
 @endphp
 <div class="border-b border-gray-300 px-6 py-6 lg:flex">
     <x-noerd::title>
         {{ $slot }}
-        @if (isset($actions) || $detailHeaderActions !== [])
+        @if (isset($actions) || $detailHeaderActions !== [] || $hasListControls)
             <div class="ml-auto flex shrink-0 items-center gap-4" :class="isModal ? modalControlsClass : ''">
+                @if ($hasListControls)
+                    @if ($listControlsShow)
+                        <div x-show="{{ $listControlsShow }}" x-cloak class="flex shrink-0 items-center gap-4">
+                    @endif
+                    @include('noerd::components.table.list-controls', [
+                        'host' => $listControlsHost,
+                        'listSettings' => $listControlsSettings,
+                        'objectAccessDenied' => $listObjectAccessDenied,
+                        'listRelations' => $listRelations,
+                    ])
+                    @if ($listControlsShow)
+                        </div>
+                    @endif
+                @endif
                 @if ($detailHeaderActions !== [])
                     {{-- Grouped so the icon buttons keep the 8px rhythm of the modal
                          panel controls. Collapses when every action hid itself —

--- a/resources/views/components/table/list-controls.blade.php
+++ b/resources/views/components/table/list-controls.blade.php
@@ -1,0 +1,133 @@
+{{--
+    Generic list header controls: CSV export, search, registry list actions and
+    the YAML `actions` buttons. Included by x-noerd::modal-title for every
+    NoerdList host — whether the title came from the generic list-header or
+    from a component's own custom header slot. Expects:
+    $host (the NoerdList Livewire component), $listSettings, $objectAccessDenied,
+    $listRelations. Positioning (ml-auto, modal controls offset) is owned by the
+    modal-title wrapper — never add offsets here.
+--}}
+@php
+    $searchShortcut = \Noerd\Helpers\KeyboardShortcutHelper::parse('search_focus', 's');
+    $showCsvExport = $host->enableCsvExport ?? false;
+    $isPicker = $host->returnsSelection ?? false;
+    // A read-denied list keeps its header but loses the data affordances; the
+    // YAML actions were already stripped by buildList().
+    $searchEnabled = ! ($listSettings['disableSearch'] ?? false) && ! $objectAccessDenied;
+    $listYamlActions = $isPicker ? [] : ($listSettings['actions'] ?? []);
+    $listRegistryActions = $isPicker ? [] : app(\Noerd\Services\HeaderActionsRegistry::class)->listActions();
+@endphp
+
+@if ($searchEnabled || $showCsvExport)
+    <div class="flex items-center gap-2">
+        @if ($showCsvExport)
+            <x-noerd::button
+                variant="secondary"
+                icon="arrow-down-tray"
+                class="h-8"
+                title="{{ __('Export CSV') }}"
+                wire:click="exportCsv"
+            >
+                CSV
+            </x-noerd::button>
+        @endif
+        @if ($searchEnabled)
+            <div
+                x-data="{ searchFocused: false }"
+                @keydown.window="let e = $event; if ({{ $searchShortcut['js'] }}) { e.preventDefault(); $refs.searchInput.focus(); }"
+            >
+                <div class="relative">
+                    <x-noerd::text-input
+                        x-ref="searchInput"
+                        @focus="searchFocused = true"
+                        @blur="searchFocused = false"
+                        @keydown.escape="$refs.searchInput.blur()"
+                        placeholder="{{ __('Search') }}"
+                        wire:model.live="search"
+                        type="text"
+                        class="!mt-0 mb-3 h-8 min-w-[200px] pr-8 lg:mb-0"
+                    />
+                    <kbd
+                        x-show="! searchFocused"
+                        x-transition:enter="transition ease-out duration-100"
+                        x-transition:enter-start="opacity-0"
+                        x-transition:enter-end="opacity-100"
+                        x-transition:leave="transition ease-in duration-75"
+                        x-transition:leave-start="opacity-100"
+                        x-transition:leave-end="opacity-0"
+                        class="pointer-events-none absolute top-1/2 right-1.5 -translate-y-1/2 rounded border border-gray-300 bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500"
+                    >{{ $searchShortcut['badge'] }}</kbd>
+                </div>
+            </div>
+        @endif
+    </div>
+@endif
+
+@if ($listRegistryActions !== [])
+    {{-- Collapses when every action hid itself: the children are
+         server-rendered before Alpine initializes, so probing for a
+         button is reliable. Without this an empty wrapper would still
+         carry the parent's gap. --}}
+    <div
+        x-data="{ hasActions: false }"
+        x-init="hasActions = $el.querySelector('button') !== null"
+        x-show="hasActions"
+        x-cloak
+        class="flex shrink-0 items-center gap-2"
+    >
+        @foreach ($listRegistryActions as $listHeaderAction)
+            @livewire($listHeaderAction, [
+                'model' => $host->listModel ?? null,
+                'component' => $host->getComponentName(),
+            ], key('list-header-action-' . $listHeaderAction))
+        @endforeach
+    </div>
+@endif
+
+@if ($listYamlActions !== [])
+    <div class="flex gap-2">
+        @foreach ($listYamlActions as $actionIndex => $actionItem)
+            @php
+                $isSecondary = ($actionItem['style'] ?? '') === 'secondary';
+                $effectiveShortcut = $actionItem['shortcut']
+                    ?? ($actionIndex === 0 ? 'n' : null);
+                $hasShortcut = $effectiveShortcut !== null;
+                $shortcut = $hasShortcut
+                    ? \Noerd\Helpers\KeyboardShortcutHelper::parse('action_' . ($actionItem['action'] ?? $actionItem['route'] ?? ''), $effectiveShortcut)
+                    : null;
+                // An action either opens a named Livewire route as a modal
+                // (route:) or calls a method on the list component (action:).
+                $clickExpression = isset($actionItem['route'])
+                    ? '$modalRoute(' . Js::from($actionItem['route']) . ', ' . Js::from($actionItem['arguments'] ?? []) . ')'
+                    : '$wire.' . $actionItem['action'] . '(null, ' . Js::from($listRelations ?? []) . ')';
+            @endphp
+            @if ($hasShortcut)
+                <div
+                    x-data
+                    @keydown.window="let e = $event; if ({{ $shortcut['js'] }}) { e.preventDefault(); $refs.actionBtn{{ $actionIndex }}.click(); }"
+                >
+            @else
+                <div>
+            @endif
+            <x-noerd::button
+                :variant="$isSecondary ? 'secondary' : 'primary'"
+                :icon="$actionItem['heroicon'] ?? ($isSecondary ? null : 'plus')"
+                x-ref="actionBtn{{ $actionIndex }}"
+                class="relative h-8"
+                @click.prevent="{{ $clickExpression }}"
+            >
+                {{ __($actionItem['label']) }}
+                @if ($hasShortcut)
+                    <kbd
+                        @class([
+                            'ml-2 rounded px-1 py-0.5 text-xs',
+                            'border border-gray-300 bg-gray-100 text-gray-500' => $isSecondary,
+                            'border border-white/30 bg-white/20 text-brand-primary-text' => !$isSecondary,
+                        ])
+                    >{{ $shortcut['badge'] }}</kbd>
+                @endif
+            </x-noerd::button>
+            </div>
+        @endforeach
+    </div>
+@endif

--- a/resources/views/components/table/list-header.blade.php
+++ b/resources/views/components/table/list-header.blade.php
@@ -1,5 +1,9 @@
 <x-slot:header>
-    <x-noerd::modal-title>
+    {{-- The controls (search, CSV, registry list actions, YAML action buttons)
+         are injected generically by modal-title for every NoerdList host —
+         this file only contributes the title, count, view switcher and the
+         filter chips. Relations are forwarded for YAML `action:` buttons. --}}
+    <x-noerd::modal-title :listRelations="$relations ?? []">
         <div class="pb-3 lg:pb-0">
             @if (count($listViews ?? []) > 1)
                 {{-- List-view switcher: pick one of several YAML views for this list --}}
@@ -97,140 +101,5 @@
             </div>
         @endif
 
-        @php
-            $searchShortcut = \Noerd\Helpers\KeyboardShortcutHelper::parse('search_focus', 's');
-        @endphp
-
-        @php $showCsvExport = $this->enableCsvExport ?? false; @endphp
-
-        @php
-            // Action buttons are only rendered for non-picker lists. When they are absent
-            // (no actions, or picker/returnsSelection mode), the search must carry the modal
-            // controls offset itself so it doesn't slide under the close/fullscreen buttons.
-            $actionsRendered = !empty($actions) && !($this->returnsSelection ?? false);
-        @endphp
-
-        @if ((isset($disableSearch) && !$disableSearch) || $showCsvExport)
-            <div
-                @unless ($actionsRendered) :class="isModal ? modalControlsClass : ''" @endunless
-                class="mr-2 ml-auto flex items-center gap-2"
-            >
-                @if ($showCsvExport)
-                    <x-noerd::button
-                        variant="secondary"
-                        icon="arrow-down-tray"
-                        class="h-8"
-                        title="{{ __('Export CSV') }}"
-                        wire:click="exportCsv"
-                    >
-                        CSV
-                    </x-noerd::button>
-                @endif
-                @if (isset($disableSearch) && !$disableSearch)
-                    <div
-                        x-data="{ searchFocused: false }"
-                        @keydown.window="let e = $event; if ({{ $searchShortcut['js'] }}) { e.preventDefault(); $refs.searchInput.focus(); }"
-                    >
-                        <div class="relative">
-                            <x-noerd::text-input
-                                x-ref="searchInput"
-                                @focus="searchFocused = true"
-                                @blur="searchFocused = false"
-                                @keydown.escape="$refs.searchInput.blur()"
-                                placeholder="{{ __('Search') }}"
-                                wire:model.live="search"
-                                type="text"
-                                class="!mt-0 mb-3 h-8 min-w-[200px] pr-8 lg:mb-0"
-                            />
-                            <kbd
-                                x-show="! searchFocused"
-                                x-transition:enter="transition ease-out duration-100"
-                                x-transition:enter-start="opacity-0"
-                                x-transition:enter-end="opacity-100"
-                                x-transition:leave="transition ease-in duration-75"
-                                x-transition:leave-start="opacity-100"
-                                x-transition:leave-end="opacity-0"
-                                class="pointer-events-none absolute top-1/2 right-1.5 -translate-y-1/2 rounded border border-gray-300 bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500"
-                            >{{ $searchShortcut['badge'] }}</kbd>
-                        </div>
-                    </div>
-                @endif
-            </div>
-        @else
-            <div class="ml-auto"></div>
-        @endif
-        @unless ($this->returnsSelection ?? false)
-            @php
-                $listHeaderActions = app(\Noerd\Services\HeaderActionsRegistry::class)->listActions();
-            @endphp
-            @if ($listHeaderActions !== [])
-                {{-- Collapses when every action hid itself: the children are
-                     server-rendered before Alpine initializes, so probing for a
-                     button is reliable. Without this an empty wrapper would still
-                     carry its mr-2/modalControlsClass margins. --}}
-                <div
-                    x-data="{ hasActions: false }"
-                    x-init="hasActions = $el.querySelector('button') !== null"
-                    x-show="hasActions"
-                    x-cloak
-                    @unless ($actionsRendered) :class="isModal ? modalControlsClass : ''" @endunless
-                    class="mr-2 flex shrink-0 items-center gap-2"
-                >
-                    @foreach ($listHeaderActions as $listHeaderAction)
-                        @livewire($listHeaderAction, [
-                            'model' => $this->listModel ?? null,
-                            'component' => $this->getComponentName(),
-                        ], key('list-header-action-' . $listHeaderAction))
-                    @endforeach
-                </div>
-            @endif
-        @endunless
-        @if (!empty($actions) && !($this->returnsSelection ?? false))
-            <div :class="isModal ? modalControlsClass : ''" class="flex gap-2">
-                @foreach ($actions as $actionIndex => $actionItem)
-                    @php
-                        $isSecondary = ($actionItem['style'] ?? '') === 'secondary';
-                        $effectiveShortcut = $actionItem['shortcut']
-                            ?? ($actionIndex === 0 ? 'n' : null);
-                        $hasShortcut = $effectiveShortcut !== null;
-                        $shortcut = $hasShortcut
-                            ? \Noerd\Helpers\KeyboardShortcutHelper::parse('action_' . ($actionItem['action'] ?? $actionItem['route'] ?? ''), $effectiveShortcut)
-                            : null;
-                        // An action either opens a named Livewire route as a modal
-                        // (route:) or calls a method on the list component (action:).
-                        $clickExpression = isset($actionItem['route'])
-                            ? '$modalRoute(' . Js::from($actionItem['route']) . ', ' . Js::from($actionItem['arguments'] ?? []) . ')'
-                            : '$wire.' . $actionItem['action'] . '(null, ' . Js::from($relations ?? []) . ')';
-                    @endphp
-                    @if ($hasShortcut)
-                        <div
-                            x-data
-                            @keydown.window="let e = $event; if ({{ $shortcut['js'] }}) { e.preventDefault(); $refs.actionBtn{{ $actionIndex }}.click(); }"
-                        >
-                    @else
-                        <div>
-                    @endif
-                    <x-noerd::button
-                        :variant="$isSecondary ? 'secondary' : 'primary'"
-                        :icon="$actionItem['heroicon'] ?? ($isSecondary ? null : 'plus')"
-                        x-ref="actionBtn{{ $actionIndex }}"
-                        class="relative h-8"
-                        @click.prevent="{{ $clickExpression }}"
-                    >
-                        {{ __($actionItem['label']) }}
-                        @if ($hasShortcut)
-                            <kbd
-                                @class([
-                                    'ml-2 rounded px-1 py-0.5 text-xs',
-                                    'border border-gray-300 bg-gray-100 text-gray-500' => $isSecondary,
-                                    'border border-white/30 bg-white/20 text-brand-primary-text' => !$isSecondary,
-                                ])
-                            >{{ $shortcut['badge'] }}</kbd>
-                        @endif
-                    </x-noerd::button>
-                    </div>
-                @endforeach
-            </div>
-        @endif
     </x-noerd::modal-title>
 </x-slot:header>

--- a/src/Traits/NoerdList.php
+++ b/src/Traits/NoerdList.php
@@ -175,6 +175,9 @@ trait NoerdList
     /** @var array<int, string>|null Request cache for filterableColumnFields(). */
     protected ?array $filterableColumnCache = null;
 
+    /** @var array<string, mixed>|null Last buildList() result, memoized per request. */
+    protected ?array $builtListConfigCache = null;
+
     private static array $schemaColumnCache = [];
 
     /**
@@ -748,6 +751,20 @@ trait NoerdList
     }
 
     /**
+     * The buildList() result, computed at most once per request. The header
+     * chrome (modal-title's generic list controls) and the list body both read
+     * this — for with()-style components Livewire evaluates with() before the
+     * view renders, so the cache is already populated when a custom header
+     * slot executes; slim components compute it lazily here.
+     *
+     * @return array<string, mixed>
+     */
+    public function builtListConfig(): array
+    {
+        return $this->builtListConfigCache ??= $this->resolvedListConfig();
+    }
+
+    /**
      * The list config regardless of the component's style: lists declaring
      * $listModel build it via listData(), lists with a custom with() already
      * return it as view data. Lets generic trait features (row click, select-all,
@@ -1126,7 +1143,7 @@ trait NoerdList
             ));
         }
 
-        return [
+        return $this->builtListConfigCache = [
             'listId' => $this->listId,
             'sortField' => $this->sortField,
             'sortAsc' => $this->sortAsc,

--- a/tests/Components/ListControlsInjectionTest.php
+++ b/tests/Components/ListControlsInjectionTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Component;
+use Livewire\Livewire;
+use Noerd\Models\NoerdUser;
+use Noerd\Services\HeaderActionsRegistry;
+use Noerd\Tests\TestCase;
+use Noerd\Traits\NoerdList;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->actingAs(NoerdUser::factory()->adminUser()->withSelectedApp('setup')->create());
+
+    // Installed modules register themselves at boot, so start from a clean registry.
+    app()->instance(HeaderActionsRegistry::class, new HeaderActionsRegistry());
+    Livewire::addNamespace('header-actions-test', viewPath: __DIR__ . '/../Feature/fixtures/header-actions');
+});
+
+it('injects search and the YAML actions into a custom header of a list host', function (): void {
+    $html = Livewire::test(CustomHeaderListComponent::class)->assertOk()->html();
+
+    expect($html)->toContain('Custom Header')
+        ->toContain('wire:model.live="search"')
+        ->toContain('$wire.listAction(null, [])')
+        ->toContain('New Thing');
+});
+
+it('renders the controls exactly once for a standard list', function (): void {
+    $html = Livewire::test(StandardHeaderListComponent::class)->assertOk()->html();
+
+    expect(mb_substr_count($html, 'wire:model.live="search"'))->toBe(1)
+        ->and(mb_substr_count($html, '$wire.listAction(null, [])'))->toBe(1);
+});
+
+it('suppresses the injection with listControls=false', function (): void {
+    $html = Livewire::test(CustomHeaderListComponent::class, ['controls' => false])
+        ->assertOk()
+        ->html();
+
+    expect($html)->toContain('Custom Header')
+        ->not->toContain('wire:model.live="search"')
+        ->not->toContain('New Thing');
+});
+
+it('keeps the search but hides the actions in picker mode', function (): void {
+    $html = Livewire::test(CustomHeaderListComponent::class, ['returnsSelection' => true])
+        ->assertOk()
+        ->html();
+
+    expect($html)->toContain('wire:model.live="search"')
+        ->not->toContain('New Thing');
+});
+
+it('mounts registry list actions through a custom header', function (): void {
+    app(HeaderActionsRegistry::class)->registerListAction('header-actions-test::probe');
+
+    Livewire::test(CustomHeaderListComponent::class)
+        ->assertOk()
+        ->assertSee('HA-PROBE:');
+});
+
+it('wraps the injected controls in the listControlsShow expression', function (): void {
+    $html = Livewire::test(CustomHeaderListComponent::class, ['controlsShow' => 'currentTab === 2'])
+        ->assertOk()
+        ->html();
+
+    expect($html)->toContain('x-show="currentTab === 2"')
+        ->toContain('wire:model.live="search"');
+});
+
+/**
+ * List host with its OWN header slot (the tab-panel/object-manager pattern): the
+ * generic list-header never renders, so every control must come from the
+ * modal-title injection. The embedded list uses hideHead so its swallowed
+ * header slot cannot contribute anything.
+ */
+class CustomHeaderListComponent extends Component
+{
+    use NoerdList;
+
+    public bool $controls = true;
+
+    public ?string $controlsShow = null;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function with(): array
+    {
+        return [
+            'listConfig' => $this->buildList([['id' => 1, 'name' => 'Alice']], [
+                'title' => 'Things',
+                'actions' => [
+                    [
+                        'label' => 'New Thing',
+                        'action' => 'listAction',
+                    ],
+                ],
+                'columns' => [
+                    ['field' => 'name', 'label' => 'Name'],
+                ],
+            ]),
+        ];
+    }
+
+    public function render(): string
+    {
+        return <<<'BLADE'
+            <x-noerd::page>
+                <x-slot:header>
+                    <x-noerd::modal-title :listControls="$controls" :listControlsShow="$controlsShow">Custom Header</x-noerd::modal-title>
+                </x-slot:header>
+                <x-noerd::list hideHead />
+            </x-noerd::page>
+            BLADE;
+    }
+}
+
+/** Standard list: the header comes from the generic list-header — controls must not double up. */
+class StandardHeaderListComponent extends Component
+{
+    use NoerdList;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function with(): array
+    {
+        return [
+            'listConfig' => $this->buildList([['id' => 1, 'name' => 'Alice']], [
+                'title' => 'Things',
+                'actions' => [
+                    [
+                        'label' => 'New Thing',
+                        'action' => 'listAction',
+                    ],
+                ],
+                'columns' => [
+                    ['field' => 'name', 'label' => 'Name'],
+                ],
+            ]),
+        ];
+    }
+
+    public function render(): string
+    {
+        return '<x-noerd::page><x-noerd::list /></x-noerd::page>';
+    }
+}


### PR DESCRIPTION
## Motivation

List header controls (search, CSV export, registry list actions, YAML `actions` buttons) were rendered only by `table/list-header.blade.php`, which registers the page `<x-slot:header>`. A list that cannot claim that slot — a custom header with the list nested in a tab panel, like the object manager's custom-attributes modal — silently lost all controls, and modules started hand-rolling search fields and action buttons in their own headers.

## Changes

- **`modal-title` now injects the controls generically** for every component using the `NoerdList` trait — whether the title came from the generic `list-header` or from a component's own custom header slot. One code path for full pages, list modals and custom headers; the controls always sit top right, correctly offset from the modal close/fullscreen buttons (the three `modalControlsClass` "offset hop" sites collapse into the single wrapper).
- New shared partial `table/list-controls.blade.php` carries the markup (search with `s` shortcut, CSV button, HeaderActionsRegistry list actions, YAML action buttons with `n` shortcut).
- `list-header` now contributes only title, count, view switcher and filter chips; it forwards `$relations` to the injection via the new `listRelations` prop.
- New props on `x-noerd::modal-title`: `:listControls="false"` (opt-out for headers without a real list) and `listControlsShow` (Alpine expression gating visibility, e.g. `currentTab === 2`).
- `NoerdList::builtListConfig()` memoizes the `buildList()` result per request, so the header injection and the list body share one query (also removes the double `with()` call for lists rendered via a bare `<x-noerd::list />`).
- New `hideHead` prop on `x-noerd::list` for lists embedded below another component's header (their slot registration would land on the nearest enclosing component and disappear).
- Docs updated (`list-view.md`, `header-actions.md`, `keyboard-shortcuts.md`).

## Tests

- New `ListControlsInjectionTest` (6 cases): injection into custom headers, no duplication for standard lists, `listControls` opt-out, picker semantics (search stays, actions hidden), registry actions through custom headers, `listControlsShow` gating.
- Full noerd + crm suites green (954 passed).

Companion PRs adapt the modules (noerd-plus object manager, media, ancestral, booking, crm test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)