### PR TITLE
Enable column filters on custom attribute (JSON path) columns

### DIFF
--- a/docs/list-filters.md
+++ b/docs/list-filters.md
@@ -24,7 +24,15 @@ Invalid input (non-numeric value on a number column, unparseable date, operator 
 
 ### Which columns are filterable
 
-A column is filterable when it is declared in the list YAML `columns`, is not `action`, is not a dotted field (`relation.name`, `custom_attributes.x`), and exists as a real column on the model's table — the same rule as sorting. Lists that build a fully custom query (never calling `listQuery()`) show no funnels and apply no column filters.
+A column is filterable when it is declared in the list YAML `columns`, is not `action`, and either
+exists as a real column on the model's table (the same rule as sorting) or is a **path into a
+JSON-cast column** (e.g. `custom_attributes.sap_number`): the segment before the first dot must be a
+real table column that the model casts to an array/object — the filter then applies through the JSON
+arrow operator (`custom_attributes->sap_number`). Relation paths (`customer.name`) have no such base
+column and stay unfilterable (and every dotted field stays unsortable). A JSON path has no DB schema
+type, so its filter type comes from the list column's explicit `type:`/`options` or the paired detail
+picklist, with `text` as the fallback. Lists that build a fully custom query (never calling
+`listQuery()`) show no funnels and apply no column filters.
 
 ### Behavior
 

--- a/src/Services/ColumnFilterParser.php
+++ b/src/Services/ColumnFilterParser.php
@@ -71,7 +71,11 @@ final class ColumnFilterParser
             return;
         }
 
-        $query->where($field, $op ?? '=', (float) $value);
+        // Integral thresholds bind as int: PDO binds floats as strings, and SQLite
+        // compares json_extract() results (JSON-path columns) by type — a string
+        // would never match a JSON number.
+        $number = (float) $value;
+        $query->where($field, $op ?? '=', $number === (float) (int) $number ? (int) $number : $number);
     }
 
     private static function applyDate(Builder $query, string $field, string $raw): void

--- a/src/Traits/NoerdList.php
+++ b/src/Traits/NoerdList.php
@@ -183,7 +183,8 @@ trait NoerdList
     /**
      * Whether a column field addresses a nested path rather than a real DB column — e.g. a custom
      * attribute (`custom_attributes.sap_number`) or a relation (`customer.name`). Such fields resolve at
-     * render time via data_get(); the database cannot sort or search on them.
+     * render time via data_get(); the database cannot sort or search on them. Column filters are the
+     * exception: a path into a JSON-cast column filters via the arrow operator (see isJsonColumnPath()).
      */
     public static function isDottedField(string $field): bool
     {
@@ -967,8 +968,9 @@ trait NoerdList
 
     /**
      * Fields the user may filter on via the header funnel: every YAML column that
-     * is not dotted, not 'action', and a real column on the resolved model's
-     * table — the same rule as sorting. Empty until listQuery() has resolved the
+     * is not 'action' and either a real column on the resolved model's table
+     * (the same rule as sorting) or a path into a JSON-cast column
+     * (`custom_attributes.x`). Empty until listQuery() has resolved the
      * model class, so lists with fully custom queries get no funnels.
      *
      * @return array<int, string>
@@ -989,10 +991,31 @@ trait NoerdList
             ->pluck('field')
             ->filter(fn($field): bool => is_string($field)
                 && $field !== 'action'
-                && !self::isDottedField($field)
-                && Schema::hasColumn($table, $field))
+                && (self::isDottedField($field)
+                    ? $this->isJsonColumnPath($field)
+                    : Schema::hasColumn($table, $field)))
             ->values()
             ->all();
+    }
+
+    /**
+     * Whether a dotted column field addresses a path inside a JSON column of the
+     * resolved model (e.g. `custom_attributes.sap_number`): the base segment must
+     * be a real table column that the model casts to an array/object, so the
+     * query can filter it via the JSON arrow operator. Relation paths
+     * (`customer.name`) have no such column and stay unfilterable.
+     */
+    protected function isJsonColumnPath(string $field): bool
+    {
+        if ($this->resolvedModelClass === null) {
+            return false;
+        }
+
+        $model = new $this->resolvedModelClass();
+        $base = Str::before($field, '.');
+
+        return Schema::hasColumn($model->getTable(), $base)
+            && $model->hasCast($base, ['array', 'json', 'object', 'collection']);
     }
 
     /**
@@ -1033,7 +1056,12 @@ trait NoerdList
             }
             $type ??= $schemaTypes[$field] ?? 'text';
 
-            ColumnFilterParser::apply($query, $field, $type, $raw);
+            // A JSON path (custom_attributes.x) filters via the arrow operator on
+            // its base column; it has no schema type, so YAML/picklist typing
+            // applies with text as the fallback.
+            $column = self::isDottedField($field) ? str_replace('.', '->', $field) : $field;
+
+            ColumnFilterParser::apply($query, $column, $type, $raw);
         }
     }
 

--- a/tests/Traits/NoerdListColumnFilterTest.php
+++ b/tests/Traits/NoerdListColumnFilterTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
 use Livewire\Component;
 use Livewire\Livewire;
 use Noerd\Helpers\TenantHelper;
@@ -16,6 +19,19 @@ uses(TestCase::class, RefreshDatabase::class);
 function filterListIds(mixed $component): array
 {
     return $component->instance()->visibleRowIds();
+}
+
+function createColumnFilterJsonItemsTable(): void
+{
+    if (Schema::hasTable('column_filter_json_items')) {
+        return;
+    }
+
+    Schema::create('column_filter_json_items', function (Blueprint $table): void {
+        $table->id();
+        $table->string('name');
+        $table->json('custom_attributes')->nullable();
+    });
 }
 
 it('filters a text column with a like match by default', function (): void {
@@ -107,13 +123,85 @@ it('ignores filters on columns not present in the list yaml', function (): void 
     expect(filterListIds($component))->toHaveCount(2);
 });
 
-it('ignores filters on dotted fields', function (): void {
+it('ignores filters on dotted fields without a json base column', function (): void {
     NoerdUser::factory()->count(2)->create();
 
     $component = Livewire::test(TestableColumnFilterListComponent::class)
         ->call('setColumnFilter', 'custom_attributes.color', 'rot');
 
     expect(filterListIds($component))->toHaveCount(2);
+});
+
+it('ignores filters on dotted fields whose base column is not json cast', function (): void {
+    NoerdUser::factory()->count(2)->create();
+
+    $component = Livewire::test(TestableColumnFilterListComponent::class)
+        ->call('setColumnFilter', 'email.domain', 'example');
+
+    expect(filterListIds($component))->toHaveCount(2);
+});
+
+it('filters a custom attribute path with a like match by default', function (): void {
+    createColumnFilterJsonItemsTable();
+    $red = ColumnFilterJsonItem::create(['name' => 'A', 'custom_attributes' => ['color' => 'dunkelrot']]);
+    ColumnFilterJsonItem::create(['name' => 'B', 'custom_attributes' => ['color' => 'blau']]);
+    ColumnFilterJsonItem::create(['name' => 'C', 'custom_attributes' => null]);
+
+    $component = Livewire::test(TestableJsonColumnFilterListComponent::class)
+        ->call('setColumnFilter', 'custom_attributes.color', 'rot');
+
+    expect(filterListIds($component))->toBe([$red->id]);
+});
+
+it('filters a custom attribute path with an exact match on =', function (): void {
+    createColumnFilterJsonItemsTable();
+    ColumnFilterJsonItem::create(['name' => 'A', 'custom_attributes' => ['color' => 'dunkelrot']]);
+    $exact = ColumnFilterJsonItem::create(['name' => 'B', 'custom_attributes' => ['color' => 'rot']]);
+
+    $component = Livewire::test(TestableJsonColumnFilterListComponent::class)
+        ->call('setColumnFilter', 'custom_attributes.color', '=rot');
+
+    expect(filterListIds($component))->toBe([$exact->id]);
+});
+
+it('filters a numeric custom attribute path with comparison operators', function (): void {
+    createColumnFilterJsonItemsTable();
+    $cheap = ColumnFilterJsonItem::create(['name' => 'A', 'custom_attributes' => ['price' => 5]]);
+    $expensive = ColumnFilterJsonItem::create(['name' => 'B', 'custom_attributes' => ['price' => 20]]);
+
+    $component = Livewire::test(TestableJsonColumnFilterListComponent::class)
+        ->call('setColumnFilter', 'custom_attributes.price', '>10');
+
+    expect(filterListIds($component))->toBe([$expensive->id]);
+
+    $component->call('setColumnFilter', 'custom_attributes.price', '<=5');
+    expect(filterListIds($component))->toBe([$cheap->id]);
+});
+
+it('filters a badge custom attribute path by option value', function (): void {
+    createColumnFilterJsonItemsTable();
+    $weekly = ColumnFilterJsonItem::create(['name' => 'A', 'custom_attributes' => ['cycle' => 'weekly']]);
+    ColumnFilterJsonItem::create(['name' => 'B', 'custom_attributes' => ['cycle' => 'monthly']]);
+
+    $component = Livewire::test(TestableJsonColumnFilterListComponent::class)
+        ->call('setColumnFilter', 'custom_attributes.cycle', 'weekly');
+
+    expect(filterListIds($component))->toBe([$weekly->id]);
+});
+
+it('exposes json custom attribute paths as filterable', function (): void {
+    createColumnFilterJsonItemsTable();
+    ColumnFilterJsonItem::create(['name' => 'A', 'custom_attributes' => []]);
+
+    $component = Livewire::test(TestableJsonColumnFilterListComponent::class);
+    $listConfig = $component->instance()->with()['listConfig'];
+
+    expect($listConfig['filterableColumns'])->toBe([
+        'name',
+        'custom_attributes.color',
+        'custom_attributes.price',
+        'custom_attributes.cycle',
+    ]);
 });
 
 it('persists column filters per component in the session and restores them', function (): void {
@@ -240,6 +328,19 @@ it('renders funnel buttons only for filterable columns', function (): void {
         ->not->toContain('column-filter-custom_attributes.color');
 });
 
+it('renders funnel buttons for json custom attribute columns', function (): void {
+    createColumnFilterJsonItemsTable();
+    $tenant = Tenant::factory()->create();
+    $user = NoerdUser::factory()->create();
+    TenantHelper::setSelectedTenantId($tenant->id);
+    TenantHelper::setSelectedApp('SETUP');
+    test()->actingAs($user);
+
+    $html = Livewire::test(TestableJsonColumnFilterRenderComponent::class)->html();
+
+    expect($html)->toContain('column-filter-custom_attributes.color-');
+});
+
 it('renders no funnel buttons in compact mode', function (): void {
     $tenant = Tenant::factory()->create();
     $user = NoerdUser::factory()->create();
@@ -339,8 +440,83 @@ class TestableColumnFilterListComponent extends Component
                 ['field' => 'id', 'label' => 'Id'],
                 ['field' => 'created_at', 'label' => 'Created'],
                 ['field' => 'custom_attributes.color', 'label' => 'Color'],
+                ['field' => 'email.domain', 'label' => 'Domain'],
             ],
         ];
+    }
+}
+
+/**
+ * Model over a runtime-created table with a JSON custom_attributes column, so
+ * the JSON-path column filters can be exercised without touching real tables.
+ */
+class ColumnFilterJsonItem extends Model
+{
+    public $timestamps = false;
+
+    protected $table = 'column_filter_json_items';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'custom_attributes' => 'array',
+    ];
+}
+
+/**
+ * List component over the JSON model: one plain column plus custom-attribute
+ * paths in every filterable flavour (text, number, badge with options).
+ */
+class TestableJsonColumnFilterListComponent extends Component
+{
+    use NoerdList;
+
+    public const COMPONENT = 'testable-json-column-filter-list';
+
+    public function with(): array
+    {
+        return [
+            'listConfig' => $this->buildList(
+                $this->listQuery(ColumnFilterJsonItem::class)->paginate($this->perPage),
+            ),
+        ];
+    }
+
+    public function render(): string
+    {
+        return '<div></div>';
+    }
+
+    protected function getListConfig(?string $customName = null): array
+    {
+        return [
+            'title' => 'Testable Json Items',
+            'columns' => [
+                ['field' => 'name', 'label' => 'Name'],
+                ['field' => 'custom_attributes.color', 'label' => 'Color'],
+                ['field' => 'custom_attributes.price', 'label' => 'Price', 'type' => 'number'],
+                [
+                    'field' => 'custom_attributes.cycle',
+                    'label' => 'Cycle',
+                    'type' => 'badge',
+                    'options' => [
+                        ['value' => 'weekly', 'label' => 'Weekly'],
+                        ['value' => 'monthly', 'label' => 'Monthly'],
+                    ],
+                ],
+            ],
+        ];
+    }
+}
+
+/**
+ * Same JSON list, but rendering the real list Blade so the header funnels appear.
+ */
+class TestableJsonColumnFilterRenderComponent extends TestableJsonColumnFilterListComponent
+{
+    public function render(): string
+    {
+        return '<div><x-noerd::list /></div>';
     }
 }
 

--- a/tests/Unit/ColumnFilterParserTest.php
+++ b/tests/Unit/ColumnFilterParserTest.php
@@ -64,7 +64,7 @@ it('applies text operators as direct comparisons', function (string $raw, string
     'string greater than' => ['>m', '>', 'm'],
 ]);
 
-it('applies number filters with the parsed operator', function (string $raw, string $operator, float $value): void {
+it('applies number filters with the parsed operator', function (string $raw, string $operator, int|float $value): void {
     $query = filterQuery();
     ColumnFilterParser::apply($query, 'amount', 'number', $raw);
 
@@ -73,9 +73,9 @@ it('applies number filters with the parsed operator', function (string $raw, str
         ->and($wheres[0]['operator'])->toBe($operator)
         ->and($wheres[0]['value'])->toBe($value);
 })->with([
-    'greater than zero' => ['>0', '>', 0.0],
-    'less or equal ten' => ['<=10', '<=', 10.0],
-    'plain number is exact' => ['5', '=', 5.0],
+    'greater than zero' => ['>0', '>', 0],
+    'less or equal ten' => ['<=10', '<=', 10],
+    'plain number is exact' => ['5', '=', 5],
     'comma decimal' => ['>=2,5', '>=', 2.5],
 ]);
 


### PR DESCRIPTION
## Summary

Excel-style header column filters (`cf[...]`) previously only worked on real DB columns — a list column over a custom attribute (e.g. `custom_attributes.anrufzyklus` on the customers list) rendered no filter funnel and could not be filtered.

- `NoerdList::filterableColumnFields()` now also accepts dotted fields that address a path inside a JSON column: the base segment must be a real table column that the model casts to an array/object (`isJsonColumnPath()`). Relation paths (`customer.name`) stay excluded, and dotted fields remain unsortable.
- `applyColumnFilters()` rewrites such fields to the Eloquent JSON arrow syntax (`custom_attributes->anrufzyklus`) before handing them to `ColumnFilterParser`, so all filter flavours work: text (like/exact), number comparisons, and badge/select option pickers (options resolve from the list YAML or the paired detail picklist, exactly as before).
- `ColumnFilterParser::applyNumber()` now binds integral thresholds as `int` instead of `float`: PDO binds floats as strings, and SQLite compares `json_extract()` results by type — a string-bound number would never match a JSON number.
- No UI changes needed: the funnel popover, header chips, URL mirroring (`?cf[custom_attributes.x]=...`) and session persistence all key by field name and work unchanged.

## Tests

- New coverage in `NoerdListColumnFilterTest`: like/exact/number/badge filtering on JSON paths, the filterable-column whitelist, funnel rendering, and two negative cases (dotted field without a JSON base column, base column present but not JSON-cast).
- `ColumnFilterParserTest` number dataset updated for the int binding.
- `php artisan test` on both files: 59 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F68TqDjta5HLHzVwVRkEDN