### PR TITLE
Align modal tab underline with the tab rail and mark it with an icon

### DIFF
--- a/resources/views/components/tab.blade.php
+++ b/resources/views/components/tab.blade.php
@@ -57,14 +57,18 @@
             @click="if (! $event.metaKey && ! $event.ctrlKey) { $event.preventDefault(); {{ $clickExpression }}; }"
             class="cursor-pointer text-gray-600 focus:outline-none focus-visible:outline-none"
         >
-            <span class="group inline-flex items-center rounded-sm p-0 py-3 text-sm"> {{ $slot }} </span>
+            <span class="group inline-flex items-center rounded-sm border-b-2 border-transparent p-0 py-3 text-sm">
+                {{-- Marks the tab as opening its own modal instead of an inline panel. --}}
+                <x-icon name="square-2-stack" data-modal-tab-icon="true" class="mr-1.5 h-4 w-4 shrink-0 text-gray-400" />
+                {{ $slot }}
+            </span>
         </a>
         @if ($componentRouteUrl)
             <a
                 href="{{ $componentRouteUrl }}"
                 target="_blank"
                 rel="noopener"
-                class="py-3 pl-2 text-gray-500 hover:text-black focus:outline-none focus-visible:outline-none"
+                class="border-b-2 border-transparent py-3 pl-2 text-gray-500 hover:text-black focus:outline-none focus-visible:outline-none"
                 aria-label="{{ __('Open in new tab') }}"
             >
                 <x-noerd::icons.external />

--- a/resources/views/components/tab.blade.php
+++ b/resources/views/components/tab.blade.php
@@ -58,9 +58,11 @@
             class="cursor-pointer text-gray-600 focus:outline-none focus-visible:outline-none"
         >
             <span class="group inline-flex items-center rounded-sm border-b-2 border-transparent p-0 py-3 text-sm">
-                {{-- Marks the tab as opening its own modal instead of an inline panel. --}}
-                <x-icon name="square-2-stack" data-modal-tab-icon="true" class="mr-1.5 h-4 w-4 shrink-0 text-gray-400" />
+                {{-- The label stays the first flex item: an SVG in front would become the
+                     span's baseline source and shift the whole tab against its siblings. --}}
                 {{ $slot }}
+                {{-- Marks the tab as opening its own modal instead of an inline panel. --}}
+                <x-icon name="square-2-stack" data-modal-tab-icon="true" class="ml-1 h-4 w-4 shrink-0 text-gray-400" />
             </span>
         </a>
         @if ($componentRouteUrl)

--- a/tests/Feature/TabModalRouteTest.php
+++ b/tests/Feature/TabModalRouteTest.php
@@ -97,6 +97,37 @@ it('opens a component tab as a modal with the record id resolved', function (): 
         ->toBe(['recordType' => 'Zz\\Models\\Record', 'modelId' => 42]);
 });
 
+it('gives every tab variant the same content height so the underlines share the rail', function (): void {
+    $html = renderLayoutTabs([
+        ['label' => 'General', 'number' => 1],
+        ['label' => 'Overview', 'route' => 'zz.tab.page'],
+        ['label' => 'Related Records', 'component' => 'zz::records-list'],
+    ], 42);
+
+    preg_match_all('/<span class="(group inline-flex[^"]*)"/', $html, $matches);
+
+    expect($matches[1])->toHaveCount(3)
+        ->and(array_unique($matches[1]))->toHaveCount(1)
+        ->and($matches[1][0])->toContain('border-b-2 border-transparent');
+});
+
+it('marks tabs that open their own modal with an icon', function (): void {
+    $modalTabs = renderLayoutTabs([
+        ['label' => 'Related Records', 'component' => 'zz::records-list'],
+        ['label' => 'Related Record', 'modalRoute' => 'zz.tab.record', 'arguments' => ['modelId' => '$modelId']],
+    ], 42);
+
+    expect(mb_substr_count($modalTabs, 'data-modal-tab-icon'))->toBe(2)
+        ->and($modalTabs)->toContain('<svg');
+
+    $inlineTabs = renderLayoutTabs([
+        ['label' => 'General', 'number' => 1],
+        ['label' => 'Overview', 'route' => 'zz.tab.page'],
+    ], 42);
+
+    expect($inlineTabs)->not->toContain('data-modal-tab-icon');
+});
+
 it('hides a requiresId tab until the record is saved', function (): void {
     $tab = [
         'label' => 'Related Records',

--- a/tests/Feature/TabModalRouteTest.php
+++ b/tests/Feature/TabModalRouteTest.php
@@ -120,6 +120,11 @@ it('marks tabs that open their own modal with an icon', function (): void {
     expect(mb_substr_count($modalTabs, 'data-modal-tab-icon'))->toBe(2)
         ->and($modalTabs)->toContain('<svg');
 
+    // The icon must trail the label: as the first flex item an SVG would become the
+    // span's baseline source and shift the whole tab against its siblings.
+    expect(mb_strpos($modalTabs, 'Related Records'))
+        ->toBeLessThan(mb_strpos($modalTabs, 'data-modal-tab-icon'));
+
     $inlineTabs = renderLayoutTabs([
         ['label' => 'General', 'number' => 1],
         ['label' => 'Overview', 'route' => 'zz.tab.page'],


### PR DESCRIPTION
## Problem

In detail components with mixed tabs (numbered tabs plus tabs that open their own modal), the underline of a modal-opening tab rendered ~2px above the shared tab rail — visible on hover next to the active tab's underline.

## Cause

`resources/views/components/tab.blade.php` renders three tab variants. The numbered and route variants wrap their label in `<span class="… border-b-2 border-transparent … py-3">`, where that transparent 2px border acts as a spacer. The modal-opening variant dropped it, so its content box was 2px shorter. Since all tabs align on the text baseline, its bottom border ended 2px above the `border-b border-gray-300` rail.

## Changes

- Added `border-b-2 border-transparent` to the modal tab's label span, and to the adjacent external-link anchor so `items-center` keeps the icon on the same baseline.
- Added a `square-2-stack` heroicon **behind** the label of every tab that opens its own modal (both `component:` and `modalRoute:` tabs), so it is recognizable that the tab opens in a modal rather than an inline panel.

The icon position matters beyond aesthetics: as the *first* flex item an SVG becomes the baseline source of the `inline-flex` span, which shifts the whole tab against its siblings. Keeping the label first preserves the text baseline.

The icon uses `h-4 w-4 ml-1` — `h-3.5`/`w-3.5`/`ml-1.5` are not present in the compiled CSS, so smaller sizing would need an asset rebuild.

## Tests

Three cases in `tests/Feature/TabModalRouteTest.php`:

- all three tab variants share one label-span class list (i.e. one content-box height, so the underlines share the rail) — verified to fail on the old markup
- modal-opening tabs render the indicator icon, numbered and route tabs do not
- the icon trails the label in the markup, guarding the baseline regression above

Full module suite: 766 passed, 1 skipped. Pint clean. Verified in the browser on a delivery customer detail: the hover underline of a modal tab now sits on the same rail as the active tab's underline, with all labels on one baseline.