### PR TITLE
Add phone and email field types with tel:/mailto: action buttons

### DIFF
--- a/app-configs/setup/details/noerd-user-detail.yml
+++ b/app-configs/setup/details/noerd-user-detail.yml
@@ -3,7 +3,7 @@ description: ''
 fields:
   - name: detailData.email
     label: Email
-    type: text
+    type: email
   - name: detailData.name
     label: Name
     type: text

--- a/docs/field-types.md
+++ b/docs/field-types.md
@@ -26,7 +26,13 @@ fields:
     colspan: 6
     required: true
 
-  # text (email) - Email input
+  # phone - Phone input with tel: call button
+  - name: detailData.phone
+    label: Phone
+    type: phone
+    colspan: 6
+
+  # email - Email input with mailto: button
   - name: detailData.email
     label: Email
     type: email
@@ -289,7 +295,9 @@ fields:
 
 | Type | Description | Component |
 |------|-------------|-----------|
-| `text` | Standard text input (also email, number, date, time, datetime-local) | `input.blade.php` |
+| `text` | Standard text input (also number, date, time, datetime-local) | `input.blade.php` |
+| `phone` | Phone input with a `tel:` call button (opens the local phone app, e.g. FaceTime) | `phone.blade.php` |
+| `email` | Email input with a `mailto:` button (opens the local mail client) | `email.blade.php` |
 | `currency` | Amount input formatted with the tenant's currency (symbol, separators) | `input-currency.blade.php` |
 | `colorHex` | Color picker with HEX value | `color-hex.blade.php` |
 | `textarea` | Multi-line text field | `input-textarea.blade.php` |
@@ -312,7 +320,7 @@ fields:
 | `block` | Container for nested fields | (in `block.blade.php`) |
 
 **Fallback behavior:** A `type` that is not registered (and does not end in `Relation`) renders as
-a generic HTML input with that type attribute — this is how `email`, `number`, `date`, `time` and
+a generic HTML input with that type attribute — this is how `number`, `date`, `time` and
 `datetime-local` work. Unregistered `*Relation` types throw instead (see
 [Relation Field Types](relation-field-types.md)).
 
@@ -359,13 +367,13 @@ field type in every theme (`default`, `compact`, `numbered`).
 
 ### text
 
-Standard text input field. Also handles HTML5 input types like `email`, `number`, `date`, `time`, and `datetime-local`.
+Standard text input field. Also handles HTML5 input types like `number`, `date`, `time`, and `datetime-local`.
 
 **Options:**
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `type` | string | `text` | Input type: `text`, `email`, `number`, `date`, `time`, `datetime-local` |
+| `type` | string | `text` | Input type: `text`, `number`, `date`, `time`, `datetime-local` |
 | `readonly` | bool | `false` | Make field read-only |
 | `live` | bool | `false` | Enable real-time updates |
 | `required` | bool | `false` | Show required indicator |
@@ -378,13 +386,6 @@ Standard text input field. Also handles HTML5 input types like `email`, `number`
   label: Name
   type: text
   colspan: 6
-
-# Email field
-- name: detailData.email
-  label: Email
-  type: email
-  colspan: 6
-  required: true
 
 # Number field
 - name: detailData.quantity
@@ -422,6 +423,48 @@ Standard text input field. Also handles HTML5 input types like `email`, `number`
 **Notes:**
 - `date` type automatically truncates datetime values to date only (YYYY-MM-DD)
 - `time` type automatically truncates to HH:MM format
+
+---
+
+### phone
+
+Phone input (`<input type="tel">`) with a trailing call button that opens `tel:{number}` via the
+local phone app (e.g. FaceTime on macOS). The link always uses the CURRENT input value — edited
+but unsaved values included — and strips all formatting except digits and a leading `+`
+(`+49 (0)171 / 123-456` → `tel:+490171123456`). The button is hidden while the field is empty and
+stays clickable on read-only fields (calling is a read action).
+
+**YAML Example:**
+
+```yaml
+- name: detailData.phone
+  label: Phone
+  type: phone
+  colspan: 6
+```
+
+---
+
+### email
+
+Email input (`<input type="email">`) with a trailing button that opens `mailto:{address}` in the
+local mail client (e.g. Apple Mail on macOS). The link always uses the CURRENT input value —
+edited but unsaved values included. The button is hidden while the field is empty and stays
+clickable on read-only fields.
+
+`email` used to be an unregistered fallback type rendering a plain HTML email input; it is now a
+registered field type, so existing YAMLs with `type: email` get the mailto button automatically —
+no configuration change needed.
+
+**YAML Example:**
+
+```yaml
+- name: detailData.email
+  label: Email
+  type: email
+  colspan: 6
+  required: true
+```
 
 ---
 

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -380,5 +380,7 @@
     "No": "Nein",
     "e.g. >0 or <=10": "z. B. >0 oder <=10",
     "e.g. >=2026-01-01": "z. B. >=2026-01-01",
-    "e.g. =value or text": "z. B. =Wert oder Text"
+    "e.g. =value or text": "z. B. =Wert oder Text",
+    "Call": "Anrufen",
+    "Send email": "E-Mail senden"
 }

--- a/resources/views/components/block-phone-email-test.blade.php
+++ b/resources/views/components/block-phone-email-test.blade.php
@@ -1,0 +1,17 @@
+<?php
+
+use Livewire\Component;
+
+new class extends Component {
+    public array $model = [];
+}; ?>
+
+<div>
+    @include('noerd::components.detail.block', [
+        'fields' => [
+            ['name' => 'model.phone', 'label' => 'Phone', 'type' => 'phone', 'colspan' => 6],
+            ['name' => 'model.email', 'label' => 'Email', 'type' => 'email', 'colspan' => 6],
+            ['name' => 'model.roPhone', 'label' => 'RO Phone', 'type' => 'phone', 'readonly' => true, 'colspan' => 6],
+        ],
+    ])
+</div>

--- a/resources/views/components/forms/email.blade.php
+++ b/resources/views/components/forms/email.blade.php
@@ -1,0 +1,2 @@
+{{-- Delegating shim: the element template lives in the default theme folder (resources/views/themes/default/). --}}
+@include('themes::default.email')

--- a/resources/views/components/forms/phone.blade.php
+++ b/resources/views/components/forms/phone.blade.php
@@ -1,0 +1,2 @@
+{{-- Delegating shim: the element template lives in the default theme folder (resources/views/themes/default/). --}}
+@include('themes::default.phone')

--- a/resources/views/themes/compact/email.blade.php
+++ b/resources/views/themes/compact/email.blade.php
@@ -1,0 +1,56 @@
+{{-- Compact variant of forms.email: label sits to the LEFT of the input. --}}
+@props([
+    'field' => null,
+    'name' => '',
+    'label' => '',
+    'readonly' => false,
+    'live' => false,
+    'required' => false,
+])
+
+@php
+    $name = $field['name'] ?? $name;
+    $label = $field['label'] ?? $label;
+    $readonly = $field['readonly'] ?? $readonly;
+    $live = $field['live'] ?? $live;
+    $required = $field['required'] ?? $required;
+@endphp
+
+<div class="flex items-center gap-2">
+    <x-noerd::input-label
+        for="{{ $name }}"
+        :value="__($label)"
+        :required="$required"
+        :title="__($label)"
+        class="w-36 shrink-0 truncate !pb-0"
+    />
+
+    <div class="min-w-0 flex-1">
+        <div class="flex" x-data="{ v: $wire.entangle('{{ $name }}') }">
+            <input
+                {{ $readonly ? 'readonly' : '' }}
+                autocomplete="off"
+                class="focus:ring-brand-border block h-7 w-full appearance-none rounded-sm border border-zinc-200 bg-white py-1 ps-2 pe-2 text-base text-zinc-700 placeholder-zinc-400 read-only:text-zinc-500 read-only:placeholder-zinc-400/70 focus:ring-1 focus:outline-none sm:text-sm"
+                type="email"
+                id="{{ $name }}"
+                name="{{ $name }}"
+                @if ($live)
+                    wire:model.live.debounce="{{ $name }}"
+                @else
+                    wire:model="{{ $name }}"
+                @endif
+            />
+
+            <a
+                x-cloak
+                x-show="String(v ?? '').trim() !== ''"
+                x-bind:href="'mailto:' + String(v ?? '').trim()"
+                class="!mt-0 !ml-1 inline-flex h-7 shrink-0 items-center rounded-sm border border-zinc-200 bg-white px-1.5 text-zinc-500 hover:text-zinc-700"
+                title="{{ __('Send email') }}"
+            >
+                <x-icon name="envelope" class="h-4 w-4" />
+            </a>
+        </div>
+        <x-noerd::input-error :messages="$errors->get($name)" class="mt-2" />
+    </div>
+</div>

--- a/resources/views/themes/compact/phone.blade.php
+++ b/resources/views/themes/compact/phone.blade.php
@@ -1,0 +1,56 @@
+{{-- Compact variant of forms.phone: label sits to the LEFT of the input. --}}
+@props([
+    'field' => null,
+    'name' => '',
+    'label' => '',
+    'readonly' => false,
+    'live' => false,
+    'required' => false,
+])
+
+@php
+    $name = $field['name'] ?? $name;
+    $label = $field['label'] ?? $label;
+    $readonly = $field['readonly'] ?? $readonly;
+    $live = $field['live'] ?? $live;
+    $required = $field['required'] ?? $required;
+@endphp
+
+<div class="flex items-center gap-2">
+    <x-noerd::input-label
+        for="{{ $name }}"
+        :value="__($label)"
+        :required="$required"
+        :title="__($label)"
+        class="w-36 shrink-0 truncate !pb-0"
+    />
+
+    <div class="min-w-0 flex-1">
+        <div class="flex" x-data="{ v: $wire.entangle('{{ $name }}') }">
+            <input
+                {{ $readonly ? 'readonly' : '' }}
+                autocomplete="off"
+                class="focus:ring-brand-border block h-7 w-full appearance-none rounded-sm border border-zinc-200 bg-white py-1 ps-2 pe-2 text-base text-zinc-700 placeholder-zinc-400 read-only:text-zinc-500 read-only:placeholder-zinc-400/70 focus:ring-1 focus:outline-none sm:text-sm"
+                type="tel"
+                id="{{ $name }}"
+                name="{{ $name }}"
+                @if ($live)
+                    wire:model.live.debounce="{{ $name }}"
+                @else
+                    wire:model="{{ $name }}"
+                @endif
+            />
+
+            <a
+                x-cloak
+                x-show="String(v ?? '').trim() !== ''"
+                x-bind:href="'tel:' + (String(v ?? '').trim().startsWith('+') ? '+' : '') + String(v ?? '').replace(/\D/g, '')"
+                class="!mt-0 !ml-1 inline-flex h-7 shrink-0 items-center rounded-sm border border-zinc-200 bg-white px-1.5 text-zinc-500 hover:text-zinc-700"
+                title="{{ __('Call') }}"
+            >
+                <x-icon name="phone" class="h-4 w-4" />
+            </a>
+        </div>
+        <x-noerd::input-error :messages="$errors->get($name)" class="mt-2" />
+    </div>
+</div>

--- a/resources/views/themes/default/email.blade.php
+++ b/resources/views/themes/default/email.blade.php
@@ -1,0 +1,47 @@
+@props([
+    'field' => null,
+    'name' => '',
+    'label' => '',
+    'readonly' => false,
+    'live' => false,
+    'required' => false,
+])
+
+@php
+    $name = $field['name'] ?? $name;
+    $label = $field['label'] ?? $label;
+    $readonly = $field['readonly'] ?? $readonly;
+    $live = $field['live'] ?? $live;
+    $required = $field['required'] ?? $required;
+@endphp
+
+<div>
+    <x-noerd::input-label for="{{ $name }}" :value="__($label)" :required="$required" />
+
+    <div class="flex" x-data="{ v: $wire.entangle('{{ $name }}') }">
+        <input
+            {{ $readonly ? 'readonly' : '' }}
+            autocomplete="off"
+            class="focus:ring-brand-border block h-8 w-full appearance-none rounded-lg border border-zinc-200 border-b-zinc-300/80 bg-white py-2 ps-3 pe-3 text-base leading-[1.375rem] text-zinc-700 placeholder-zinc-400 shadow-xs read-only:border-b-zinc-200 read-only:text-zinc-500 read-only:placeholder-zinc-400/70 read-only:shadow-none focus:ring-2 focus:ring-offset-2 focus:outline-none sm:text-sm"
+            type="email"
+            id="{{ $name }}"
+            name="{{ $name }}"
+            @if ($live)
+                wire:model.live.debounce="{{ $name }}"
+            @else
+                wire:model="{{ $name }}"
+            @endif
+        />
+
+        <a
+            x-cloak
+            x-show="String(v ?? '').trim() !== ''"
+            x-bind:href="'mailto:' + String(v ?? '').trim()"
+            class="!mt-0 !ml-1 inline-flex h-8 shrink-0 items-center rounded-lg border border-zinc-200 border-b-zinc-300/80 bg-white px-2 text-zinc-500 shadow-xs hover:text-zinc-700"
+            title="{{ __('Send email') }}"
+        >
+            <x-icon name="envelope" class="h-4 w-4" />
+        </a>
+    </div>
+    <x-noerd::input-error :messages="$errors->get($name)" class="mt-2" />
+</div>

--- a/resources/views/themes/default/phone.blade.php
+++ b/resources/views/themes/default/phone.blade.php
@@ -1,0 +1,47 @@
+@props([
+    'field' => null,
+    'name' => '',
+    'label' => '',
+    'readonly' => false,
+    'live' => false,
+    'required' => false,
+])
+
+@php
+    $name = $field['name'] ?? $name;
+    $label = $field['label'] ?? $label;
+    $readonly = $field['readonly'] ?? $readonly;
+    $live = $field['live'] ?? $live;
+    $required = $field['required'] ?? $required;
+@endphp
+
+<div>
+    <x-noerd::input-label for="{{ $name }}" :value="__($label)" :required="$required" />
+
+    <div class="flex" x-data="{ v: $wire.entangle('{{ $name }}') }">
+        <input
+            {{ $readonly ? 'readonly' : '' }}
+            autocomplete="off"
+            class="focus:ring-brand-border block h-8 w-full appearance-none rounded-lg border border-zinc-200 border-b-zinc-300/80 bg-white py-2 ps-3 pe-3 text-base leading-[1.375rem] text-zinc-700 placeholder-zinc-400 shadow-xs read-only:border-b-zinc-200 read-only:text-zinc-500 read-only:placeholder-zinc-400/70 read-only:shadow-none focus:ring-2 focus:ring-offset-2 focus:outline-none sm:text-sm"
+            type="tel"
+            id="{{ $name }}"
+            name="{{ $name }}"
+            @if ($live)
+                wire:model.live.debounce="{{ $name }}"
+            @else
+                wire:model="{{ $name }}"
+            @endif
+        />
+
+        <a
+            x-cloak
+            x-show="String(v ?? '').trim() !== ''"
+            x-bind:href="'tel:' + (String(v ?? '').trim().startsWith('+') ? '+' : '') + String(v ?? '').replace(/\D/g, '')"
+            class="!mt-0 !ml-1 inline-flex h-8 shrink-0 items-center rounded-lg border border-zinc-200 border-b-zinc-300/80 bg-white px-2 text-zinc-500 shadow-xs hover:text-zinc-700"
+            title="{{ __('Call') }}"
+        >
+            <x-icon name="phone" class="h-4 w-4" />
+        </a>
+    </div>
+    <x-noerd::input-error :messages="$errors->get($name)" class="mt-2" />
+</div>

--- a/src/Providers/NoerdServiceProvider.php
+++ b/src/Providers/NoerdServiceProvider.php
@@ -253,6 +253,14 @@ class NoerdServiceProvider extends ServiceProvider
             'noerd::components.forms.spacer',
             resolver: fn(array $field, mixed $component, mixed $detailData, mixed $modelId): array => ['field' => $field],
         ));
+        $fieldTypeRegistry->register('phone', FieldTypeDefinition::include(
+            'noerd::components.forms.phone',
+            resolver: fn(array $field, mixed $component, mixed $detailData, mixed $modelId): array => ['field' => $field],
+        ));
+        $fieldTypeRegistry->register('email', FieldTypeDefinition::include(
+            'noerd::components.forms.email',
+            resolver: fn(array $field, mixed $component, mixed $detailData, mixed $modelId): array => ['field' => $field],
+        ));
         $fieldTypeRegistry->register('icon', FieldTypeDefinition::include(
             'noerd::components.forms.icon',
             resolver: fn(array $field, mixed $component, mixed $detailData, mixed $modelId): array => [

--- a/tests/Feature/PhoneEmailFieldTest.php
+++ b/tests/Feature/PhoneEmailFieldTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Noerd\Models\NoerdUser;
+use Noerd\Services\FieldTypeRegistry;
+use Noerd\Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+it('registers the phone and email field types as includes', function (): void {
+    $registry = app(FieldTypeRegistry::class);
+
+    expect($registry->has('phone'))->toBeTrue();
+    expect($registry->has('email'))->toBeTrue();
+
+    $phone = $registry->resolve('phone');
+    expect($phone?->kind)->toBe('include');
+    expect($phone?->target)->toBe('noerd::components.forms.phone');
+
+    $email = $registry->resolve('email');
+    expect($email?->kind)->toBe('include');
+    expect($email?->target)->toBe('noerd::components.forms.email');
+});
+
+it('renders phone and email inputs with tel and mailto action links', function (): void {
+    $admin = NoerdUser::factory()->adminUser()->withSelectedApp('setup')->create();
+    $this->actingAs($admin);
+
+    Livewire::test('noerd::block-phone-email-test')
+        ->assertSuccessful()
+        ->assertSeeHtml('type="tel"')
+        ->assertSeeHtml('type="email"')
+        ->assertSeeHtml('wire:model="model.phone"')
+        ->assertSeeHtml('wire:model="model.email"')
+        ->assertSeeHtml("'tel:' +")
+        ->assertSeeHtml("'mailto:' +");
+});
+
+it('keeps the call link available on readonly phone fields', function (): void {
+    $admin = NoerdUser::factory()->adminUser()->withSelectedApp('setup')->create();
+    $this->actingAs($admin);
+
+    Livewire::test('noerd::block-phone-email-test')
+        ->assertSuccessful()
+        ->assertSeeHtml('wire:model="model.roPhone"')
+        ->assertSeeHtml("\$wire.entangle('model.roPhone')");
+});


### PR DESCRIPTION
## Summary

Adds two registered detail-form field types:

- **`phone`** — phone input (`<input type="tel">`) with a trailing button that opens `tel:{number}` via the local phone app (e.g. FaceTime on macOS). The link strips all formatting except digits and a leading `+` (`+49 (0)171 / 123-456` → `tel:+490171123456`).
- **`email`** — email input (`<input type="email">`) with a trailing button that opens `mailto:{address}` in the local mail client (e.g. Apple Mail). `email` was previously an unregistered HTML fallback type; existing YAMLs with `type: email` get the mailto button automatically, no config change needed.

Both buttons use the CURRENT client-side value via Alpine (`$wire.entangle`), so edited-but-unsaved values produce the correct link. The button is hidden while the field is empty and stays clickable on read-only fields (calling/mailing is a read action).

## Changes

- Register `phone`/`email` in `FieldTypeRegistry` (`NoerdServiceProvider`)
- Shim views `components/forms/phone.blade.php` + `email.blade.php`, element templates for the `default` and `compact` themes (`numbered` falls back to default)
- Translations: `"Call": "Anrufen"`, `"Send email": "E-Mail senden"`
- `setup/details/noerd-user-detail.yml`: email field `type: text` → `type: email`
- Docs: `docs/field-types.md` (overview table, `### phone`/`### email` sections, fallback paragraph)

## Tests

- New `tests/Feature/PhoneEmailFieldTest.php` (registry, rendering, readonly behavior) with synthetic layout component `block-phone-email-test.blade.php`
- Full noerd module suite green (769 passed); verified in the browser on customer/account details (default theme, live link updates, empty-value hiding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F68TqDjta5HLHzVwVRkEDN