### PR TITLE
Support Laravel 12 alongside Laravel 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,18 @@ concurrency:
 
 jobs:
   tests:
+    name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - laravel: 13
+            php: '8.4'
+          - laravel: 12
+            php: '8.3'
 
     steps:
       - uses: actions/checkout@v4
@@ -23,7 +33,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: ${{ matrix.php }}
           extensions: pdo_sqlite, sqlite3, mbstring, zip, exif, pcntl, bcmath, gd
           tools: composer:v2
           coverage: none
@@ -37,11 +47,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: composer-${{ runner.os }}-${{ hashFiles('composer.json') }}
-          restore-keys: composer-${{ runner.os }}-
+          key: composer-${{ runner.os }}-L${{ matrix.laravel }}-${{ hashFiles('composer.json') }}
+          restore-keys: composer-${{ runner.os }}-L${{ matrix.laravel }}-
 
       - name: Install dependencies
-        run: composer install --no-interaction --no-progress --prefer-dist
+        run: composer update --no-interaction --no-progress --prefer-dist --with "laravel/framework:^${{ matrix.laravel }}.0"
 
       - name: Run tests
         run: vendor/bin/pest --colors=always --compact

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ https://demo.noerd.dev
 
 ## Requirements
 
-- PHP 8.4+
-- Laravel 12+
+- PHP 8.3+
+- Laravel 12 or 13
 - Livewire 4+
 
 ## Quickstart

--- a/composer.json
+++ b/composer.json
@@ -2,18 +2,19 @@
     "name": "noerd/noerd",
     "description": "",
     "type": "library",
-    "version": "v0.9.9",
+    "version": "v0.9.10",
     "license": "MIT",
     "require": {
-        "laravel/framework": "^13.0",
+        "php": "^8.3",
+        "laravel/framework": "^12.0 || ^13.0",
         "livewire/livewire": "^4.0",
-        "noerd/modal": "^0.3",
+        "noerd/modal": "^0.3.23",
         "composer/composer": "^2.9",
         "wireui/heroicons": "^2.9",
         "symfony/yaml": "^7.1 || ^8.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^11.1",
+        "orchestra/testbench": "^10.6 || ^11.1",
         "pestphp/pest": "^4.0"
     },
     "autoload": {

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,8 +15,8 @@ noerd is a Laravel Livewire boilerplate for building admin panels and business a
 
 ## Requirements
 
-- PHP 8.4+
-- Laravel 12+
+- PHP 8.3+
+- Laravel 12 or 13
 - Livewire 4+
 
 ## Install Noerd


### PR DESCRIPTION
## Why

`composer require noerd/noerd` on a Laravel 12 project silently installed **v0.9.1** — the last tag before `laravel/framework: ^13.0` was introduced in v0.9.2. Composer picks the highest *satisfiable* version, so a constraint added later never blocks, it just downgrades without a word.

The `^13.0` pin came in `fea0a1a` together with the `orchestra/testbench ^10.6 → ^11.1` bump — housekeeping from the host project's upgrade, not a code dependency on Laravel 13.

## Changes

- `laravel/framework`: `^13.0` → `^12.0 || ^13.0`
- `orchestra/testbench`: `^11.1` → `^10.6 || ^11.1` (Composer picks 10.x on L12, 11.x on L13)
- `php: ^8.3` declared explicitly — was missing entirely
- `noerd/modal`: `^0.3` → `^0.3.23`. Without the lower bound, `^0.3` falls back to v0.3.21 on Laravel 12 (the last modal tag without the `^13` pin) — the same silent-downgrade trap one level down. Requires noerd/modal v0.3.23, released alongside this
- CI: matrix over Laravel 13/PHP 8.4 and Laravel 12/PHP 8.3
- README + docs/installation.md: requirements corrected to PHP 8.3+ / Laravel 12 or 13 (they claimed "PHP 8.4+ / Laravel 12+", wrong in both directions)

## Verification

Full suite, both legs, using the CI commands with noerd/modal as a path repo:

| Leg | Resolution | Result |
|---|---|---|
| Laravel 12 / PHP 8.3 | framework 12.66, testbench 10.11, symfony 7.4 | 769 passed, 1 skipped |
| Laravel 13 / PHP 8.4 | framework 13.25, testbench 11.2, symfony 8.1 | 769 passed, 1 skipped |

Identical to the pre-change baseline on L13.

An API diff of the full `Illuminate` surface (11,859 vs 12,523 public methods) yielded 170 method names that exist only in Laravel 13 — none of them are called anywhere in this package. All 76 imported `Illuminate\*` classes exist in Laravel 12.

## Note

The app modules (crm, cms, accounting, …) still pin `^13.0`, so only the core is installable on Laravel 12 for now.