### PR TITLE
Dedicated noerd auth guard (zero intrusion)

### DIFF
--- a/config/noerd.php
+++ b/config/noerd.php
@@ -13,6 +13,24 @@
 */
 
 return [
+    'auth' => [
+        // Guard noerd registers and authenticates against. Set to 'web' to
+        // restore the legacy behavior (host default guard).
+        'guard' => env('NOERD_AUTH_GUARD', 'noerd'),
+
+        // Authenticatable model backing the noerd user provider.
+        'model' => env('NOERD_AUTH_MODEL', Noerd\Models\NoerdUser::class),
+
+        // Provider / password-broker names registered into auth.providers
+        // and auth.passwords at runtime (skipped when the host defines them).
+        'provider' => 'noerd_users',
+        'passwords' => 'noerd_users',
+
+        // When true, noerd also becomes the app's DEFAULT guard at runtime —
+        // escape hatch for hosts with unmigrated bare-'auth' routes.
+        'set_as_default' => env('NOERD_AUTH_DEFAULT', false),
+    ],
+
     'features' => [
         'multi_tenant' => env('NOERD_MULTI_TENANT', true),
         'new_tenant' => env('NOERD_NEW_TENANT_FEATURE_ENABLED', true),

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Documentation for the Noerd framework — a YAML-driven modular framework for La
 ## Contents
 
 - [Installation](installation.md)
+- [Authentication](auth.md)
 - [Creating Apps](create-app.md)
 - [Creating Modules](creating-modules.md)
 - [List View](list-view.md)

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,122 @@
+# Authentication
+
+noerd ships its own auth stack and never claims the host application's default guard — "zero
+intrusion into your application" applies to authentication too. At boot, `NoerdServiceProvider`
+registers three things **at runtime** (your `config/auth.php` and `.env` are never written to):
+
+| Key | Default value |
+|-----|---------------|
+| `auth.guards.noerd` | `['driver' => 'session', 'provider' => 'noerd_users']` |
+| `auth.providers.noerd_users` | `['driver' => 'eloquent', 'model' => Noerd\Models\NoerdUser::class]` |
+| `auth.passwords.noerd_users` | `['provider' => 'noerd_users', 'table' => 'password_reset_tokens', 'expire' => 60, 'throttle' => 60]` |
+
+**A key your application already defines always wins** — the runtime registration only fills in
+keys that are absent. To override any part (a different session driver, your own broker table,
+another user model), define the key in your `config/auth.php` and noerd will use it as-is.
+
+## Configuration (`config/noerd.php`)
+
+```php
+'auth' => [
+    'guard' => env('NOERD_AUTH_GUARD', 'noerd'),
+    'model' => env('NOERD_AUTH_MODEL', Noerd\Models\NoerdUser::class),
+    'provider' => 'noerd_users',
+    'passwords' => 'noerd_users',
+    'set_as_default' => env('NOERD_AUTH_DEFAULT', false),
+],
+```
+
+- `guard` — the guard noerd registers and authenticates against. Setting `NOERD_AUTH_GUARD=web`
+  restores the legacy behavior: the guard already exists, nothing is injected, and noerd runs on
+  the host's default guard exactly as before.
+- `model` — the Authenticatable backing the noerd user provider.
+- `set_as_default` — when `true`, noerd also flips `auth.defaults.guard` / `auth.defaults.passwords`
+  to the noerd guard at runtime. This is an escape hatch for hosts that still protect routes with
+  the bare `auth` middleware alias (which resolves the default guard). Leave it `false` when noerd
+  coexists with another auth stack (Nova, Breeze, ...) that owns the default guard.
+
+## Route middleware groups
+
+`NoerdServiceProvider` registers two shared route middleware groups:
+
+```php
+$router->middlewareGroup('noerd', ['web', 'auth:noerd', 'verified']);
+$router->middlewareGroup('noerd-guest', ['web', 'guest:noerd']);
+```
+
+Every noerd-based module protects its routes with `['noerd']` (plus module-specific aliases such
+as `app-access:crm`) instead of `['web', 'auth', 'verified']`. The `noerd:module` scaffolder
+generates routes with the `noerd` group.
+
+The `auth:noerd` middleware does the heavy lifting for guard propagation: Laravel's `Authenticate`
+middleware calls `Auth::shouldUse('noerd')` for the matched guard, which makes `noerd` the default
+guard **for the remainder of that request** — every guard-less `auth()->user()`, `@auth`,
+`$request->user()` and Gate check inside a noerd route resolves the noerd guard without any code
+change. Livewire re-applies the route's persistent middleware (including `auth:noerd`) on every
+component update, so this holds for Livewire actions too.
+
+## The `NoerdAuth` helper
+
+Framework internals that may run **outside** a noerd route (global middleware, tenant scoping on
+models a host route touches, queued jobs, console commands) must not rely on the request's default
+guard. They resolve the user explicitly through `Noerd\Helpers\NoerdAuth`:
+
+```php
+use Noerd\Helpers\NoerdAuth;
+
+NoerdAuth::guardName();   // 'noerd' (configured guard)
+NoerdAuth::guard();       // StatefulGuard instance
+NoerdAuth::user();        // ?Authenticatable
+NoerdAuth::id();          // int|string|null
+NoerdAuth::check();       // bool
+NoerdAuth::broker();      // PasswordBroker for the noerd broker
+```
+
+`TenantScope`, `BelongsToTenant`, `TenantHelper`, the noerd middleware and the noerd-plus
+permission resolvers all resolve through `NoerdAuth` — a host guard's user can never influence
+(or bypass) tenant scoping or noerd permissions. Module code that only ever runs inside noerd
+routes may keep using plain `auth()->user()`.
+
+## Coexistence with a host auth stack (e.g. Laravel Nova)
+
+A host that already owns the `web` guard (Nova admin users in a `users` table, Breeze, a custom
+login) needs no special setup:
+
+1. Install noerd as usual — `config/auth.php` keeps the host's `users` provider and default guard.
+2. Keep `NOERD_AUTH_DEFAULT` unset (or `false`).
+3. noerd users live in `noerd_users` and log in via noerd's `/login` against the `noerd` guard;
+   host users keep logging in via their own stack against `web`.
+
+Both guards share the session cookie but store independent login keys
+(`login_noerd_<hash>` vs `login_web_<hash>`) and separate remember-me cookies — a user can be
+logged in to both sides at once. noerd's logout only ends the noerd session and clears noerd's
+session state (`noerd.*` keys); the host session survives.
+
+**Caveat — packages with their own guard list:** packages that resolve the acting user from a
+configured guard list (e.g. `owen-it/laravel-auditing` via `config/audit.php` → `user.guards`)
+must have `noerd` added to that list, or actions performed by noerd users are attributed to no one.
+
+**Caveat — password reset tokens:** the noerd broker uses the standard `password_reset_tokens`
+table, keyed by email. If a host user and a noerd user share the same email address, requesting a
+reset on one side invalidates the other side's pending token. Define `auth.passwords.noerd_users`
+with your own `table` in `config/auth.php` to separate them.
+
+## Upgrading existing installations
+
+Before this guard existed, `noerd:install` wrote `AUTH_MODEL=Noerd\Models\NoerdUser` to `.env` and
+noerd ran on the host's default `web` guard. After updating:
+
+- The default `guard => 'noerd'` takes effect immediately. Sessions are stored per guard name, so
+  every user is logged out **once** and simply logs in again — no data changes.
+- Remember-me cookies are also per guard name and are re-issued on the next "remember" login.
+- A stale `AUTH_MODEL` entry in `.env` is harmless and can be removed.
+- To defer the switch, set `NOERD_AUTH_GUARD=web` — this restores the previous behavior unchanged
+  (the legacy `.env` `AUTH_MODEL` hijack keeps working where the host's `config/auth.php` reads it).
+
+## Testing
+
+The test environments point `auth.defaults.guard` at the noerd guard (see
+`app-modules/noerd/tests/TestCase.php` and the host `tests/TestCase.php`), so guard-less
+`actingAs($user)` calls authenticate on the same guard the `noerd` route group checks. Mechanics
+are covered by `app-modules/noerd/tests/Feature/NoerdGuardTest.php` — including the coexistence
+scenario (a second guard's user must never affect tenant scoping) and logout isolation.

--- a/docs/extension-registries.md
+++ b/docs/extension-registries.md
@@ -247,5 +247,5 @@ Gate::define(AccessHelper::APP_GATE, function (?Authenticatable $user, string $a
 **Important:**
 
 - The `$user` parameter MUST be nullable (`?Authenticatable`) — some call sites (public apps, config discovery) run for guests, and a non-nullable closure silently denies every guest check
-- The Gate resolves the user from the default auth guard
+- The gate user is resolved from noerd's own auth guard (`AccessHelper` checks via `Gate::forUser(NoerdAuth::user())`), never from the host application's default guard — see `docs/auth.md`
 - Once a gate is defined, host-app `Gate::before`/`after` hooks apply to it (standard Laravel semantics); undefined gates are never touched

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -51,6 +51,14 @@ If you skip any of these steps, you can run them later with the respective [Arti
 | `setup_collection_definitions` | Collection schemas when `noerd.collections.mode` is `database` |
 | `setup_languages` | Per-tenant admin-panel languages |
 
+### Authentication
+
+noerd ships its own auth stack: at runtime it registers a dedicated `noerd` guard, a `noerd_users`
+provider (backed by `Noerd\Models\NoerdUser`) and a matching password broker. Your application's
+`config/auth.php` and `.env` are **never modified** — noerd coexists with any existing auth setup
+(Laravel Nova, Breeze, a custom guard, ...). See [Authentication](auth.md) for details, overrides
+and the coexistence recipe.
+
 ## Configuration
 
 `noerd:install` publishes `config/noerd.php`. Notable flags:
@@ -58,6 +66,8 @@ If you skip any of these steps, you can run them later with the respective [Arti
 - `features.multi_tenant` (`NOERD_MULTI_TENANT`) — tenant switcher and multi-tenant UI
 - `features.currency` (`NOERD_CURRENCY_ENABLED`) — set to `false` to hide currency-related UI on
   installations that don't need it
+- `auth.guard` (`NOERD_AUTH_GUARD`) / `auth.set_as_default` (`NOERD_AUTH_DEFAULT`) — noerd's
+  dedicated auth guard (see [Authentication](auth.md))
 - `theme.default` / `theme.enforced` — system-wide form theme (see [Themes](themes.md))
 - `brand.active` — color palette (see [Brand](brand.md))
 

--- a/resources/views/components/auth/forgot-password.blade.php
+++ b/resources/views/components/auth/forgot-password.blade.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Password;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
+use Noerd\Helpers\NoerdAuth;
 
 new #[Layout('noerd::layouts.auth')] class extends Component {
     public string $email = '';
@@ -16,7 +16,7 @@ new #[Layout('noerd::layouts.auth')] class extends Component {
             'email' => ['required', 'string', 'email'],
         ]);
 
-        Password::sendResetLink(['email' => $this->email]);
+        NoerdAuth::broker()->sendResetLink(['email' => $this->email]);
 
         session()->flash('status', __('A reset link will be sent if the account exists.'));
     }

--- a/resources/views/components/auth/login.blade.php
+++ b/resources/views/components/auth/login.blade.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Auth\Events\Lockout;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Session;
@@ -10,6 +9,7 @@ use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Validate;
 use Livewire\Component;
+use Noerd\Helpers\NoerdAuth;
 
 new #[Layout('noerd::layouts.auth')] class extends Component {
     #[Validate('required|string|email')]
@@ -29,7 +29,7 @@ new #[Layout('noerd::layouts.auth')] class extends Component {
 
         $this->ensureIsNotRateLimited();
 
-        if (!Auth::attempt(['email' => $this->email, 'password' => $this->password], $this->remember)) {
+        if (!NoerdAuth::guard()->attempt(['email' => $this->email, 'password' => $this->password], $this->remember)) {
             RateLimiter::hit($this->throttleKey());
 
             throw ValidationException::withMessages([
@@ -40,7 +40,7 @@ new #[Layout('noerd::layouts.auth')] class extends Component {
         RateLimiter::clear($this->throttleKey());
         Session::regenerate();
 
-        Auth::user()->update(['last_login_at' => now()]);
+        NoerdAuth::user()->update(['last_login_at' => now()]);
 
         $this->redirect(session()->pull('url.intended', route('noerd-apps', absolute: false)), navigate: false);
     }

--- a/resources/views/components/auth/reset-password.blade.php
+++ b/resources/views/components/auth/reset-password.blade.php
@@ -9,6 +9,7 @@ use Illuminate\Validation\Rules;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Locked;
 use Livewire\Component;
+use Noerd\Helpers\NoerdAuth;
 
 new #[Layout('noerd::layouts.auth')] class extends Component {
     #[Locked]
@@ -38,7 +39,7 @@ new #[Layout('noerd::layouts.auth')] class extends Component {
             'password' => ['required', 'string', 'confirmed', Rules\Password::defaults()],
         ]);
 
-        $status = Password::reset(
+        $status = NoerdAuth::broker()->reset(
             $this->only('email', 'password', 'password_confirmation', 'token'),
             function ($user) {
                 $user->forceFill([

--- a/resources/views/components/layout/impersonation-banner.blade.php
+++ b/resources/views/components/layout/impersonation-banner.blade.php
@@ -1,7 +1,7 @@
 <?php
 
-use Illuminate\Support\Facades\Auth;
 use Livewire\Component;
+use Noerd\Helpers\NoerdAuth;
 use Noerd\Helpers\TenantHelper;
 
 new class extends Component {
@@ -12,7 +12,7 @@ new class extends Component {
     {
         if (session('impersonating_from')) {
             $this->isImpersonating = true;
-            $this->userName = Auth::user()?->name ?? '';
+            $this->userName = NoerdAuth::user()?->name ?? '';
         }
     }
 
@@ -24,7 +24,7 @@ new class extends Component {
         // Clear tenant session so InitializeTenantSession will set the correct tenant
         TenantHelper::clear();
 
-        Auth::loginUsingId($originalUserId);
+        NoerdAuth::guard()->loginUsingId($originalUserId);
 
         return redirect('/');
     }

--- a/resources/views/components/layout/top-bar.blade.php
+++ b/resources/views/components/layout/top-bar.blade.php
@@ -1,7 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Session;
 use Livewire\Component;
+use Noerd\Helpers\NoerdAuth;
 use Noerd\Services\TopBarRegistry;
 
 new class () extends Component {
@@ -20,9 +21,13 @@ new class () extends Component {
 
     public function logout(): void
     {
-        Auth::guard('web')->logout();
+        NoerdAuth::guard()->logout();
 
-        Session::invalidate();
+        // Drop noerd's session state but do NOT invalidate the whole
+        // session: a host guard (e.g. Nova) may share the session cookie.
+        Session::forget('noerd');
+        Session::forget('impersonating_from');
+        Session::regenerate();
         Session::regenerateToken();
 
         $this->redirect('/login');

--- a/resources/views/components/noerd-users-list.blade.php
+++ b/resources/views/components/noerd-users-list.blade.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Auth;
 use Livewire\Component;
+use Noerd\Helpers\NoerdAuth;
 use Noerd\Helpers\TenantHelper;
 use Noerd\Models\NoerdUser;
 use Noerd\Traits\NoerdList;
@@ -36,12 +37,12 @@ new class () extends Component {
         if (in_array($userId, $allowedUserIds) === false) {
             abort(401);
         }
-        session(['impersonating_from' => Auth::id()]);
+        session(['impersonating_from' => NoerdAuth::id()]);
 
         // Clear tenant session so InitializeTenantSession will set the correct tenant
         TenantHelper::clear();
 
-        Auth::loginUsingId($userId);
+        NoerdAuth::guard()->loginUsingId($userId);
 
         return redirect('/');
     }

--- a/routes/noerd-routes.php
+++ b/routes/noerd-routes.php
@@ -7,7 +7,7 @@ use Noerd\Controllers\DashboardController;
 // (navigation.yml `route:` keys, tenant_apps.route, route() calls) and stay
 // unprefixed — only the URLs carry the prefix, so the redundant `setup-` in
 // paths like `setup-collections` is dropped in favour of the group prefix.
-Route::group(['prefix' => 'setup', 'middleware' => ['auth', 'verified', 'setup', 'web']], function (): void {
+Route::group(['prefix' => 'setup', 'middleware' => ['noerd', 'setup']], function (): void {
     Route::livewire('/', 'noerd::noerd-users-list')->name('setup');
     Route::livewire('tenant-apps', 'noerd::tenant-apps-list')->name('tenant-apps');
     Route::livewire('users', 'noerd::noerd-users-list')->name('users');
@@ -27,25 +27,25 @@ Route::group(['prefix' => 'setup', 'middleware' => ['auth', 'verified', 'setup',
     Route::livewire('system-settings', 'noerd::system-settings-page')->name('system-settings');
 });
 
-Route::group(['middleware' => ['auth', 'verified', 'web']], function (): void {
+Route::group(['middleware' => ['noerd']], function (): void {
     Route::livewire('/component-page/{componentName}', 'noerd::generic-component-page')->name('component-page');
 });
 
-Route::group(['middleware' => ['auth', 'web']], function (): void {
+Route::group(['middleware' => ['noerd']], function (): void {
     Route::livewire('noerd-apps', 'noerd::noerd-apps')->name('noerd-apps');
     Route::redirect('noerd-home', 'noerd-apps');
 });
 
-Route::group(['middleware' => ['auth', 'web']], function (): void {
+Route::group(['middleware' => ['noerd']], function (): void {
     Route::livewire('no-tenant', 'noerd::no-tenant')->name('no-tenant');
 });
 
-Route::group(['middleware' => ['auth', 'verified', 'web']], function (): void {
+Route::group(['middleware' => ['noerd']], function (): void {
     Route::get('/dashboard', DashboardController::class)->name('dashboard');
     Route::view('profile', 'noerd::profile')->name('profile');
 });
 
-Route::middleware(['web', 'guest'])->group(function (): void {
+Route::middleware(['noerd-guest'])->group(function (): void {
     Route::livewire('login', 'noerd::auth.login')->name('login');
     Route::livewire('forgot-password', 'noerd::auth.forgot-password')->name('password.request');
 });

--- a/src/Commands/NoerdInstallCommand.php
+++ b/src/Commands/NoerdInstallCommand.php
@@ -90,6 +90,7 @@ class NoerdInstallCommand extends Command
 
             $this->info('Noerd content successfully installed!');
             $this->newLine();
+            $this->line('Noerd registers its own "noerd" auth guard at runtime — config/auth.php and .env were not modified.');
             $this->line('Visit your application at: <info>' . url('/noerd-apps') . '</info>');
 
             return 0;
@@ -197,9 +198,6 @@ class NoerdInstallCommand extends Command
 
             // Create tailwind.config.js
             $this->createTailwindConfig();
-
-            // Update auth configuration
-            $this->updateAuthConfig();
 
             // Update Livewire component layout
             $this->updateLivewireConfig();
@@ -334,53 +332,6 @@ export default {
 
         file_put_contents($configPath, $configContent);
         $this->line('<info>Created tailwind.config.js.</info>');
-    }
-
-    /**
-     * Update .env file to set AUTH_MODEL to Noerd User model and install Breeze
-     */
-    protected function updateAuthConfig(): void
-    {
-        // Set AUTH_MODEL in .env
-        $this->setAuthModelEnv();
-    }
-
-    /**
-     * Set AUTH_MODEL in the .env and .env.example files
-     */
-    protected function setAuthModelEnv(): void
-    {
-        foreach (['.env', '.env.example'] as $envFile) {
-            $this->addAuthModelToEnvFile($envFile);
-        }
-    }
-
-    /**
-     * Add AUTH_MODEL to a single env file if it is missing
-     */
-    protected function addAuthModelToEnvFile(string $envFile): void
-    {
-        $envPath = base_path($envFile);
-
-        if (!file_exists($envPath)) {
-            $this->warn("{$envFile} file not found, skipping AUTH_MODEL configuration.");
-            return;
-        }
-
-        $envContent = file_get_contents($envPath);
-
-        if (preg_match('/^AUTH_MODEL=/m', $envContent)) {
-            $this->line("<comment>AUTH_MODEL already configured in {$envFile} file.</comment>");
-            return;
-        }
-
-        $authModelLine = "\nAUTH_MODEL=Noerd\\Models\\NoerdUser\n";
-
-        if (file_put_contents($envPath, $envContent . $authModelLine) !== false) {
-            $this->line("<info>Added AUTH_MODEL to {$envFile} file.</info>");
-        } else {
-            $this->warn("Failed to update {$envFile} file. Please manually add: AUTH_MODEL=Noerd\\Models\\NoerdUser");
-        }
     }
 
     /**

--- a/src/Commands/stubs/module/routes.stub
+++ b/src/Commands/stubs/module/routes.stub
@@ -5,7 +5,7 @@ use Illuminate\Support\Facades\Route;
 
 Route::prefix('{{module-name}}')
     ->as('{{module-name}}.')
-    ->middleware(['web', 'auth', 'verified'])
+    ->middleware(['noerd'])
     ->group(function (): void {
         Route::livewire('/', '{{models}}-list')->name('index');
     });

--- a/src/Controllers/DashboardController.php
+++ b/src/Controllers/DashboardController.php
@@ -4,12 +4,13 @@ namespace Noerd\Controllers;
 
 use Illuminate\Http\RedirectResponse;
 use Noerd\Helpers\AccessHelper;
+use Noerd\Helpers\NoerdAuth;
 
 class DashboardController
 {
     public function __invoke(): RedirectResponse
     {
-        $route = auth()->user()->selectedTenant()?->tenantApps
+        $route = NoerdAuth::user()->selectedTenant()?->tenantApps
             ->first(fn($tenantApp) => AccessHelper::canAccessApp($tenantApp->name))
             ?->route;
 

--- a/src/Helpers/AccessHelper.php
+++ b/src/Helpers/AccessHelper.php
@@ -13,8 +13,9 @@ use Illuminate\Support\Facades\Gate;
  *
  * Gate closures MUST accept a nullable user (`?Authenticatable $user`):
  * some call sites (public apps, config discovery) run for guests, and a
- * non-nullable closure would silently deny them. Note that the Gate resolves
- * the user from the default auth guard.
+ * non-nullable closure would silently deny them. The gate user is resolved
+ * from noerd's own auth guard (see NoerdAuth), never from the host
+ * application's default guard.
  */
 final class AccessHelper
 {
@@ -35,7 +36,7 @@ final class AccessHelper
             return true;
         }
 
-        return !Gate::has(self::APP_GATE) || Gate::allows(self::APP_GATE, $appName);
+        return !Gate::has(self::APP_GATE) || Gate::forUser(NoerdAuth::user())->allows(self::APP_GATE, $appName);
     }
 
     /**
@@ -68,6 +69,6 @@ final class AccessHelper
             return true;
         }
 
-        return !Gate::has($gate) || Gate::allows($gate, $modelClass);
+        return !Gate::has($gate) || Gate::forUser(NoerdAuth::user())->allows($gate, $modelClass);
     }
 }

--- a/src/Helpers/CurrencyHelper.php
+++ b/src/Helpers/CurrencyHelper.php
@@ -49,7 +49,7 @@ class CurrencyHelper
 
     public static function configForTenant(?int $tenantId = null): array
     {
-        $tenantId ??= auth()->user()?->selected_tenant_id;
+        $tenantId ??= NoerdAuth::user()?->selected_tenant_id;
 
         if ($tenantId === null) {
             return config('noerd.currency', self::CURRENCY_PRESETS['EUR']);

--- a/src/Helpers/NoerdAuth.php
+++ b/src/Helpers/NoerdAuth.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noerd\Helpers;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\PasswordBroker;
+use Illuminate\Contracts\Auth\StatefulGuard;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Password;
+use Noerd\Models\NoerdUser;
+
+/**
+ * Resolves noerd's dedicated auth guard, user provider and password broker.
+ *
+ * Noerd never relies on the host application's default guard: all framework
+ * internals (tenant scoping, middleware, permission resolvers) resolve the
+ * current user through this helper, so noerd coexists with any host auth
+ * stack (Nova, Breeze, ...) that owns the default guard.
+ */
+final class NoerdAuth
+{
+    public static function guardName(): string
+    {
+        return config('noerd.auth.guard', 'noerd');
+    }
+
+    public static function guard(): StatefulGuard
+    {
+        /** @var StatefulGuard */
+        return Auth::guard(self::guardName());
+    }
+
+    public static function user(): ?Authenticatable
+    {
+        return self::guard()->user();
+    }
+
+    public static function id(): int|string|null
+    {
+        return self::guard()->id();
+    }
+
+    public static function check(): bool
+    {
+        return self::guard()->check();
+    }
+
+    public static function providerName(): string
+    {
+        return config('noerd.auth.provider', 'noerd_users');
+    }
+
+    public static function brokerName(): string
+    {
+        return config('noerd.auth.passwords', 'noerd_users');
+    }
+
+    public static function broker(): PasswordBroker
+    {
+        return Password::broker(self::brokerName());
+    }
+
+    public static function userModel(): string
+    {
+        return config('noerd.auth.model', NoerdUser::class);
+    }
+}

--- a/src/Helpers/StaticConfigHelper.php
+++ b/src/Helpers/StaticConfigHelper.php
@@ -437,7 +437,7 @@ class StaticConfigHelper
         // Includes the user id: the allowed app folders (and everything derived
         // from them, e.g. config search roots) vary per user once app
         // permissions filter them.
-        return (TenantHelper::getSelectedTenantId() ?? 0) . '|' . (self::getCurrentApp() ?? '') . '|' . (auth()->id() ?? 0);
+        return (TenantHelper::getSelectedTenantId() ?? 0) . '|' . (self::getCurrentApp() ?? '') . '|' . (NoerdAuth::id() ?? 0);
     }
 
     /**
@@ -615,7 +615,7 @@ class StaticConfigHelper
     {
         // Keyed by user too: app permissions filter the folders, so one user's
         // set must never leak to another within one process.
-        $cacheKey = 'allowedFolders.' . (TenantHelper::getSelectedTenantId() ?? 0) . '.' . (auth()->id() ?? 0);
+        $cacheKey = 'allowedFolders.' . (TenantHelper::getSelectedTenantId() ?? 0) . '.' . (NoerdAuth::id() ?? 0);
 
         return self::$runtimeCache[$cacheKey] ??= (function (): array {
             $tenant = TenantHelper::getSelectedTenant();
@@ -803,7 +803,7 @@ class StaticConfigHelper
                 return false;
             }
 
-            if (isset($nav['superAdmin']) && $nav['superAdmin'] && !auth()->user()?->isSuperAdmin()) {
+            if (isset($nav['superAdmin']) && $nav['superAdmin'] && !NoerdAuth::user()?->isSuperAdmin()) {
                 return false;
             }
 

--- a/src/Helpers/TenantHelper.php
+++ b/src/Helpers/TenantHelper.php
@@ -32,8 +32,8 @@ class TenantHelper
     {
         session(['noerd.selected_tenant_id' => $tenantId]);
 
-        if (auth()->check()) {
-            auth()->user()->setting->update(['selected_tenant_id' => $tenantId]);
+        if (NoerdAuth::check()) {
+            NoerdAuth::user()->setting->update(['selected_tenant_id' => $tenantId]);
         }
     }
 

--- a/src/Listeners/InitializeTenantSession.php
+++ b/src/Listeners/InitializeTenantSession.php
@@ -3,12 +3,19 @@
 namespace Noerd\Listeners;
 
 use Illuminate\Auth\Events\Login;
+use Noerd\Helpers\NoerdAuth;
 use Noerd\Helpers\TenantHelper;
 
 class InitializeTenantSession
 {
     public function handle(Login $event): void
     {
+        // The Login event fires for every guard — only react to noerd logins
+        // (a host or website-guard user has no noerd tenant session).
+        if ($event->guard !== NoerdAuth::guardName()) {
+            return;
+        }
+
         $user = $event->user;
 
         if (! TenantHelper::hasTenant()) {

--- a/src/Middleware/AppAccessMiddleware.php
+++ b/src/Middleware/AppAccessMiddleware.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Http\Request;
 use Noerd\Exceptions\NoerdException;
 use Noerd\Helpers\AccessHelper;
+use Noerd\Helpers\NoerdAuth;
 use Noerd\Helpers\TenantHelper;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -19,7 +20,7 @@ class AppAccessMiddleware
     public function handle(Request $request, Closure $next, string ...$appNames): Response
     {
         $appName = implode(',', $appNames);
-        $user = auth()->user();
+        $user = NoerdAuth::user();
 
         if (!$user) {
             return redirect('/login');

--- a/src/Middleware/PublicAppMiddleware.php
+++ b/src/Middleware/PublicAppMiddleware.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Http\Request;
 use Noerd\Exceptions\NoerdException;
 use Noerd\Helpers\AccessHelper;
+use Noerd\Helpers\NoerdAuth;
 use Noerd\Helpers\TenantHelper;
 use Noerd\Models\TenantApp;
 use Symfony\Component\HttpFoundation\Response;
@@ -37,7 +38,7 @@ class PublicAppMiddleware
             return $next($request);
         }
 
-        $user = auth()->user();
+        $user = NoerdAuth::user();
 
         if (!$user) {
             return redirect('/login');

--- a/src/Middleware/SetUserLocale.php
+++ b/src/Middleware/SetUserLocale.php
@@ -5,15 +5,19 @@ namespace Noerd\Middleware;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\App;
-use Illuminate\Support\Facades\Auth;
+use Noerd\Helpers\NoerdAuth;
 use Symfony\Component\HttpFoundation\Response;
 
 class SetUserLocale
 {
     public function handle(Request $request, Closure $next): Response
     {
-        if (Auth::check() && Auth::user()->locale) {
-            App::setLocale(Auth::user()->locale);
+        // This middleware runs in the global 'web' group, so it must resolve
+        // the noerd guard explicitly — never a host guard's user.
+        $user = NoerdAuth::user();
+
+        if ($user && $user->locale) {
+            App::setLocale($user->locale);
         }
 
         return $next($request);

--- a/src/Middleware/SetupMiddleware.php
+++ b/src/Middleware/SetupMiddleware.php
@@ -4,7 +4,7 @@ namespace Noerd\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
+use Noerd\Helpers\NoerdAuth;
 use Noerd\Helpers\TenantHelper;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -17,7 +17,7 @@ class SetupMiddleware
      */
     public function handle(Request $request, Closure $next): Response
     {
-        $user = auth()->user();
+        $user = NoerdAuth::user();
         if (! TenantHelper::getSelectedTenantId()) {
             $firstTenantId = $user->tenants->first()?->id;
 
@@ -30,7 +30,7 @@ class SetupMiddleware
 
         TenantHelper::setSelectedApp('SETUP');
 
-        if (! Auth::user()->isAdmin()) {
+        if (! $user->isAdmin()) {
             abort(401);
         }
 

--- a/src/Providers/NoerdServiceProvider.php
+++ b/src/Providers/NoerdServiceProvider.php
@@ -34,6 +34,7 @@ use Noerd\Commands\NoerdUpdateCommand;
 use Noerd\Commands\PublishHomeCommand;
 use Noerd\Contracts\MediaResolverContract;
 use Noerd\Contracts\SetupCollectionDefinitionRepositoryContract;
+use Noerd\Helpers\NoerdAuth;
 use Noerd\Helpers\SetupCollectionHelper;
 use Noerd\Helpers\StaticConfigHelper;
 use Noerd\Helpers\ThemeHelper;
@@ -75,6 +76,8 @@ class NoerdServiceProvider extends ServiceProvider
         // Merge module defaults so noerd.* keys resolve even when the project
         // root config/noerd.php is absent (e.g., module-only test boots).
         $this->mergeConfigFrom(__DIR__ . '/../../config/noerd.php', 'noerd');
+
+        $this->registerNoerdGuard();
 
         // Register the quick-create exit hook in the register phase: Livewire wires
         // its ComponentHookRegistry during its own boot(), so a boot()-phase
@@ -153,6 +156,14 @@ class NoerdServiceProvider extends ServiceProvider
         TenantApp::deleted(fn() => StaticConfigHelper::flushRuntimeCaches());
 
         $router = $this->app['router'];
+        // Shared route middleware groups: every noerd-based module protects
+        // its routes with the 'noerd' group instead of the bare 'auth' alias,
+        // so authentication always runs against noerd's own guard. The
+        // 'verified' middleware resolves $request->user() after auth's
+        // shouldUse() call, so it is guard-correct (and currently inert —
+        // NoerdUser does not implement MustVerifyEmail).
+        $router->middlewareGroup('noerd', ['web', 'auth:' . NoerdAuth::guardName(), 'verified']);
+        $router->middlewareGroup('noerd-guest', ['web', 'guest:' . NoerdAuth::guardName()]);
         $router->aliasMiddleware('setup', SetupMiddleware::class);
         $router->aliasMiddleware('app-access', AppAccessMiddleware::class);
         $router->aliasMiddleware('public-app', PublicAppMiddleware::class);
@@ -318,6 +329,50 @@ class NoerdServiceProvider extends ServiceProvider
                 PublishHomeCommand::class,
                 ImportSetupCollectionDefinitionsCommand::class,
                 ExportSetupCollectionDefinitionsCommand::class,
+            ]);
+        }
+    }
+
+    /**
+     * Register noerd's dedicated auth guard, user provider and password
+     * broker at runtime. The host's config/auth.php is never written to,
+     * and any key the host already defines wins over the injection.
+     */
+    private function registerNoerdGuard(): void
+    {
+        $guard = NoerdAuth::guardName();
+        $provider = NoerdAuth::providerName();
+        $broker = NoerdAuth::brokerName();
+
+        if (config("auth.guards.{$guard}") === null) {
+            config(["auth.guards.{$guard}" => [
+                'driver' => 'session',
+                'provider' => $provider,
+            ]]);
+        }
+
+        if (config("auth.providers.{$provider}") === null) {
+            config(["auth.providers.{$provider}" => [
+                'driver' => 'eloquent',
+                'model' => NoerdAuth::userModel(),
+            ]]);
+        }
+
+        if (config("auth.passwords.{$broker}") === null) {
+            config(["auth.passwords.{$broker}" => [
+                'provider' => $provider,
+                'table' => 'password_reset_tokens',
+                'expire' => 60,
+                'throttle' => 60,
+            ]]);
+        }
+
+        // Escape hatch for hosts whose routes still use the bare 'auth'
+        // middleware: make the noerd guard the application default.
+        if (config('noerd.auth.set_as_default')) {
+            config([
+                'auth.defaults.guard' => $guard,
+                'auth.defaults.passwords' => $broker,
             ]);
         }
     }

--- a/src/Repositories/DatabaseSetupCollectionDefinitionRepository.php
+++ b/src/Repositories/DatabaseSetupCollectionDefinitionRepository.php
@@ -3,8 +3,8 @@
 namespace Noerd\Repositories;
 
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Auth;
 use Noerd\Contracts\SetupCollectionDefinitionRepositoryContract;
+use Noerd\Helpers\NoerdAuth;
 use Noerd\Helpers\TenantHelper;
 use Noerd\Models\SetupCollectionDefinition;
 use Noerd\Support\SetupCollectionDefinitionData;
@@ -96,7 +96,7 @@ class DatabaseSetupCollectionDefinitionRepository implements SetupCollectionDefi
             $existing->update($attributes);
             $model = $existing;
         } else {
-            $attributes['created_by'] = Auth::id();
+            $attributes['created_by'] = NoerdAuth::id();
             $model = SetupCollectionDefinition::create($attributes);
         }
 
@@ -126,7 +126,7 @@ class DatabaseSetupCollectionDefinitionRepository implements SetupCollectionDefi
             'title_list' => $source->title_list . '2',
             'description' => $source->description,
             'fields' => $source->fields,
-            'created_by' => Auth::id(),
+            'created_by' => NoerdAuth::id(),
         ]);
 
         self::resetCache();

--- a/src/Scopes/TenantScope.php
+++ b/src/Scopes/TenantScope.php
@@ -7,14 +7,19 @@ namespace Noerd\Scopes;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
-use Illuminate\Support\Facades\Auth;
+use Noerd\Helpers\NoerdAuth;
 
 class TenantScope implements Scope
 {
     public function apply(Builder $builder, Model $model): void
     {
-        if (Auth::check() && Auth::user()->selected_tenant_id) {
-            $builder->where($model->getTable() . '.tenant_id', Auth::user()->selected_tenant_id);
+        // Resolve the user through noerd's own guard: on a host route where a
+        // different guard is the default (e.g. Nova), the default guard's user
+        // must never influence — or bypass — tenant scoping.
+        $user = NoerdAuth::user();
+
+        if ($user && $user->selected_tenant_id) {
+            $builder->where($model->getTable() . '.tenant_id', $user->selected_tenant_id);
         }
     }
 }

--- a/src/Traits/BelongsToTenant.php
+++ b/src/Traits/BelongsToTenant.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Noerd\Traits;
 
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Support\Facades\Auth;
+use Noerd\Helpers\NoerdAuth;
 use Noerd\Models\Tenant;
 use Noerd\Scopes\TenantScope;
 
@@ -16,8 +16,12 @@ trait BelongsToTenant
         static::addGlobalScope(new TenantScope());
 
         static::creating(function ($model): void {
-            if (Auth::check() && Auth::user()->selected_tenant_id && ! $model->tenant_id) {
-                $model->tenant_id = Auth::user()->selected_tenant_id;
+            // Resolve through noerd's own guard so a host guard's user (e.g.
+            // Nova) never stamps — or skips stamping — the tenant id.
+            $user = NoerdAuth::user();
+
+            if ($user && $user->selected_tenant_id && ! $model->tenant_id) {
+                $model->tenant_id = $user->selected_tenant_id;
             }
         });
     }

--- a/src/Traits/HasEmailPreview.php
+++ b/src/Traits/HasEmailPreview.php
@@ -7,6 +7,7 @@ use Illuminate\Mail\Markdown;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\HtmlString;
+use Noerd\Helpers\NoerdAuth;
 
 trait HasEmailPreview
 {
@@ -62,7 +63,7 @@ trait HasEmailPreview
             return;
         }
 
-        $user = auth()->user();
+        $user = NoerdAuth::user();
         $email = $user->email;
 
         if (! $email) {
@@ -106,6 +107,6 @@ trait HasEmailPreview
 
     protected function getTestEmailCacheKey(): string
     {
-        return 'test-email-cooldown:' . $this->getEmailRateLimitPrefix() . ':' . auth()->id();
+        return 'test-email-cooldown:' . $this->getEmailRateLimitPrefix() . ':' . NoerdAuth::id();
     }
 }

--- a/src/Traits/TenantFilterTrait.php
+++ b/src/Traits/TenantFilterTrait.php
@@ -2,7 +2,7 @@
 
 namespace Noerd\Traits;
 
-use Illuminate\Support\Facades\Auth;
+use Noerd\Helpers\NoerdAuth;
 
 trait TenantFilterTrait
 {
@@ -13,7 +13,7 @@ trait TenantFilterTrait
         $filter['type'] = 'Picklist';
         $filter['options'] = [];
 
-        $tenants = Auth::user()->adminTenants;
+        $tenants = NoerdAuth::user()->adminTenants;
 
         foreach ($tenants as $tenant) {
             $filter['options'][$tenant->id] = $tenant->name;

--- a/stubs/noerd.php.stub
+++ b/stubs/noerd.php.stub
@@ -3,6 +3,33 @@
 return [
     /*
     |--------------------------------------------------------------------------
+    | Authentication
+    |--------------------------------------------------------------------------
+    |
+    | Noerd registers its own auth guard, user provider and password broker
+    | at runtime — config/auth.php is never modified. Any of the keys that
+    | already exist in the host's auth config are left untouched, so a host
+    | can override every part by defining it itself.
+    |
+    | 'guard'          Guard noerd authenticates against. Set to 'web' to
+    |                  restore the legacy behavior (host default guard).
+    | 'model'          Authenticatable model backing the noerd user provider.
+    | 'set_as_default' When true, noerd also becomes the app's DEFAULT guard
+    |                  at runtime — escape hatch for hosts with unmigrated
+    |                  bare-'auth' routes. Leave false when noerd coexists
+    |                  with another auth stack (Nova, Breeze, ...).
+    |
+    */
+    'auth' => [
+        'guard' => env('NOERD_AUTH_GUARD', 'noerd'),
+        'model' => env('NOERD_AUTH_MODEL', Noerd\Models\NoerdUser::class),
+        'provider' => 'noerd_users',
+        'passwords' => 'noerd_users',
+        'set_as_default' => env('NOERD_AUTH_DEFAULT', false),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Feature Flags
     |--------------------------------------------------------------------------
     |

--- a/tests/Feature/NoerdGuardTest.php
+++ b/tests/Feature/NoerdGuardTest.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Auth\Events\Login;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Livewire;
+use Noerd\Helpers\NoerdAuth;
+use Noerd\Helpers\TenantHelper;
+use Noerd\Listeners\InitializeTenantSession;
+use Noerd\Models\NoerdUser;
+use Noerd\Models\SetupLanguage;
+use Noerd\Models\Tenant;
+use Noerd\Providers\NoerdServiceProvider;
+use Noerd\Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+function reRunGuardRegistration(): void
+{
+    $provider = new NoerdServiceProvider(app());
+    (new ReflectionMethod($provider, 'registerNoerdGuard'))->invoke($provider);
+}
+
+describe('runtime guard registration', function (): void {
+    it('registers guard, provider and password broker with the expected shapes', function (): void {
+        expect(config('auth.guards.noerd'))->toBe([
+            'driver' => 'session',
+            'provider' => 'noerd_users',
+        ]);
+
+        expect(config('auth.providers.noerd_users'))->toBe([
+            'driver' => 'eloquent',
+            'model' => NoerdUser::class,
+        ]);
+
+        expect(config('auth.passwords.noerd_users'))->toMatchArray([
+            'provider' => 'noerd_users',
+            'table' => 'password_reset_tokens',
+        ]);
+    });
+
+    it('never clobbers a host-defined guard, provider or broker', function (): void {
+        $hostGuard = ['driver' => 'session', 'provider' => 'users'];
+        $hostProvider = ['driver' => 'eloquent', 'model' => 'App\Models\HostUser'];
+        $hostBroker = ['provider' => 'users', 'table' => 'host_reset_tokens', 'expire' => 30, 'throttle' => 30];
+
+        config([
+            'auth.guards.noerd' => $hostGuard,
+            'auth.providers.noerd_users' => $hostProvider,
+            'auth.passwords.noerd_users' => $hostBroker,
+        ]);
+
+        reRunGuardRegistration();
+
+        expect(config('auth.guards.noerd'))->toBe($hostGuard);
+        expect(config('auth.providers.noerd_users'))->toBe($hostProvider);
+        expect(config('auth.passwords.noerd_users'))->toBe($hostBroker);
+    });
+
+    it('leaves the default guard untouched when set_as_default is false', function (): void {
+        config([
+            'noerd.auth.set_as_default' => false,
+            'auth.defaults.guard' => 'web',
+            'auth.defaults.passwords' => 'users',
+        ]);
+
+        reRunGuardRegistration();
+
+        expect(config('auth.defaults.guard'))->toBe('web');
+        expect(config('auth.defaults.passwords'))->toBe('users');
+    });
+
+    it('takes over the default guard when set_as_default is true', function (): void {
+        config([
+            'noerd.auth.set_as_default' => true,
+            'auth.defaults.guard' => 'web',
+            'auth.defaults.passwords' => 'users',
+        ]);
+
+        reRunGuardRegistration();
+
+        expect(config('auth.defaults.guard'))->toBe('noerd');
+        expect(config('auth.defaults.passwords'))->toBe('noerd_users');
+    });
+});
+
+describe('login flow', function (): void {
+    it('authenticates on the noerd guard and not on a host guard', function (): void {
+        $user = NoerdUser::factory()->create(['password' => bcrypt('password')]);
+
+        Livewire::test('noerd::auth.login')
+            ->set('email', $user->email)
+            ->set('password', 'password')
+            ->call('login')
+            ->assertRedirect('/noerd-apps');
+
+        expect(Auth::guard('noerd')->check())->toBeTrue();
+        expect(Auth::guard('noerd')->id())->toBe($user->id);
+        expect(Auth::guard('web')->check())->toBeFalse();
+        expect($user->fresh()->last_login_at)->not->toBeNull();
+    });
+
+    it('redirects an authenticated noerd user away from the login page', function (): void {
+        $user = NoerdUser::factory()->create();
+        $this->actingAs($user, 'noerd');
+
+        $this->get('/login')->assertRedirect();
+    });
+});
+
+describe('tenant scoping via the noerd guard', function (): void {
+    it('scopes and stamps by the noerd user even when a host guard is the request default', function (): void {
+        $tenantA = Tenant::factory()->create();
+        $tenantB = Tenant::factory()->create();
+
+        $noerdUser = NoerdUser::factory()->create();
+        $noerdUser->tenants()->attach($tenantB->id);
+        $this->actingAs($noerdUser, 'noerd');
+        TenantHelper::setSelectedTenantId($tenantB->id);
+
+        // Simulate the coexistence host: a different guard with a different
+        // user is the request default (e.g. Nova's web guard).
+        $hostUser = NoerdUser::factory()->create();
+        Auth::guard('web')->setUser($hostUser);
+        config(['auth.defaults.guard' => 'web']);
+
+        $visible = SetupLanguage::query()->get();
+        expect($visible)->not->toBeEmpty();
+        expect($visible->pluck('tenant_id')->unique()->all())->toBe([$tenantB->id]);
+
+        $created = SetupLanguage::create([
+            'code' => 'fr',
+            'name' => 'Français',
+            'is_active' => true,
+            'is_default' => false,
+            'sort_order' => 99,
+        ]);
+        expect($created->tenant_id)->toBe($tenantB->id);
+    });
+
+    it('applies no tenant scope when no noerd user is authenticated', function (): void {
+        Tenant::factory()->create();
+        Tenant::factory()->create();
+
+        $tenantIds = SetupLanguage::query()->get()->pluck('tenant_id')->unique();
+        expect($tenantIds->count())->toBeGreaterThan(1);
+    });
+});
+
+describe('logout isolation', function (): void {
+    it('logs out only the noerd guard and keeps a host guard session alive', function (): void {
+        $tenant = Tenant::factory()->create();
+        $noerdUser = NoerdUser::factory()->create();
+        $hostUser = NoerdUser::factory()->create();
+
+        $this->actingAs($hostUser, 'web');
+        $this->actingAs($noerdUser, 'noerd');
+        TenantHelper::setSelectedTenantId($tenant->id);
+
+        Livewire::test('noerd::layout.top-bar')
+            ->call('logout')
+            ->assertRedirect('/login');
+
+        expect(Auth::guard('noerd')->check())->toBeFalse();
+        expect(Auth::guard('web')->check())->toBeTrue();
+        expect(session()->has('noerd.selected_tenant_id'))->toBeFalse();
+        expect(session()->has('impersonating_from'))->toBeFalse();
+    });
+});
+
+describe('tenant session listener', function (): void {
+    it('ignores Login events fired by other guards', function (): void {
+        // A host-guard user has no noerd tenant session and may not even have
+        // a setting relation — the listener must not touch it.
+        $user = NoerdUser::factory()->create();
+
+        (new InitializeTenantSession())->handle(new Login('web', $user, false));
+
+        expect(TenantHelper::hasTenant())->toBeFalse();
+    });
+
+    it('initializes the tenant session for noerd-guard logins', function (): void {
+        $tenant = Tenant::factory()->create();
+        $user = NoerdUser::factory()->create();
+        $user->tenants()->attach($tenant->id);
+
+        (new InitializeTenantSession())->handle(new Login(NoerdAuth::guardName(), $user, false));
+
+        expect(TenantHelper::getSelectedTenantId())->toBe($tenant->id);
+    });
+});
+
+describe('password broker', function (): void {
+    it('creates and validates reset tokens through the noerd broker regardless of the default broker', function (): void {
+        config(['auth.defaults.passwords' => 'users']);
+
+        $user = NoerdUser::factory()->create();
+
+        $token = NoerdAuth::broker()->createToken($user);
+
+        expect($token)->toBeString()->not->toBeEmpty();
+        expect(NoerdAuth::broker()->tokenExists($user, $token))->toBeTrue();
+    });
+});

--- a/tests/Feature/UserSettingTest.php
+++ b/tests/Feature/UserSettingTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Illuminate\Auth\Events\Login;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Noerd\Helpers\NoerdAuth;
 use Noerd\Helpers\TenantHelper;
 use Noerd\Listeners\InitializeTenantSession;
 use Noerd\Models\NoerdUser;
@@ -205,7 +206,7 @@ describe('InitializeTenantSession', function (): void {
 
         // Simulate login
         $listener = new InitializeTenantSession();
-        $listener->handle(new Login('web', $user, false));
+        $listener->handle(new Login(NoerdAuth::guardName(), $user, false));
 
         expect(TenantHelper::getSelectedTenantId())->toBe($tenant->id);
     });
@@ -222,7 +223,7 @@ describe('InitializeTenantSession', function (): void {
         TenantHelper::clear();
 
         $listener = new InitializeTenantSession();
-        $listener->handle(new Login('web', $user, false));
+        $listener->handle(new Login(NoerdAuth::guardName(), $user, false));
 
         expect(TenantHelper::getSelectedTenantId())->toBe($tenant->id);
     });
@@ -235,7 +236,7 @@ describe('InitializeTenantSession', function (): void {
         TenantHelper::clear();
 
         $listener = new InitializeTenantSession();
-        $listener->handle(new Login('web', $user, false));
+        $listener->handle(new Login(NoerdAuth::guardName(), $user, false));
 
         expect(TenantHelper::getSelectedTenantId())->toBe($tenant->id);
     });
@@ -253,7 +254,7 @@ describe('InitializeTenantSession', function (): void {
         $user->setting->update(['selected_tenant_id' => $tenant2->id]);
 
         $listener = new InitializeTenantSession();
-        $listener->handle(new Login('web', $user, false));
+        $listener->handle(new Login(NoerdAuth::guardName(), $user, false));
 
         // Session tenant should remain unchanged
         expect(TenantHelper::getSelectedTenantId())->toBe($tenant1->id);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -90,6 +90,12 @@ abstract class TestCase extends BaseTestCase
         $app['config']->set('app.key', 'base64:' . base64_encode(str_repeat('a', 32)));
         $app['config']->set('auth.providers.users.model', NoerdUser::class);
 
+        // Guard-less actingAs() calls resolve the default guard — point it at
+        // noerd's own guard (registered by NoerdServiceProvider) so tests hit
+        // the same guard the 'noerd' route middleware group authenticates.
+        $app['config']->set('auth.defaults.guard', 'noerd');
+        $app['config']->set('auth.defaults.passwords', 'noerd_users');
+
         // noerd:install points the Livewire page layout at the module's own
         // layout in real projects — mirror that here.
         $app['config']->set('livewire.component_layout', 'noerd::layouts.app');


### PR DESCRIPTION
## Summary

noerd no longer hijacks the host application's default auth. Instead of writing `AUTH_MODEL` to `.env` and authenticating over the default `web` guard, noerd now registers its own auth stack **at runtime** — `config/auth.php` and `.env` are never modified:

- guard `noerd` (session) + provider `noerd_users` (`NoerdUser`) + password broker `noerd_users`, each injected only when the host has not defined the key (host override always wins)
- shared route middleware groups `noerd` (`web` + `auth:noerd` + `verified`) and `noerd-guest`; all noerd routes and the module scaffolder stub use them. `auth:noerd` triggers `Auth::shouldUse()`, so guard-less `auth()->user()` calls in Livewire components keep working unchanged (Livewire re-applies persistent middleware on every update)
- new `Noerd\Helpers\NoerdAuth` helper; framework internals that may run outside noerd routes (TenantScope, BelongsToTenant, TenantHelper, middleware, AccessHelper gates) resolve the user explicitly through it — a host guard's user can never influence or bypass tenant scoping
- logout no longer invalidates the whole session (a host guard may share the session cookie); login/password reset/impersonation use the noerd guard/broker explicitly; `InitializeTenantSession` ignores Login events from other guards
- `noerd:install` no longer writes `AUTH_MODEL` to `.env`
- new config block `noerd.auth` (guard/model/provider/passwords/set_as_default) in all three config locations; escape hatches: `NOERD_AUTH_GUARD=web` (exact legacy behavior) and `NOERD_AUTH_DEFAULT=true` (make noerd the default guard for hosts with unmigrated bare-`auth` routes)
- new `docs/auth.md` incl. coexistence recipe (Nova hosts) and upgrade notes (one-time re-login)

## Motivation

In a customer project running Laravel Nova, noerd's login broke: the Laravel-10-style `config/auth.php` hardcodes `App\Models\User`, so the `AUTH_MODEL` env hijack never applied and `Auth::attempt` resolved the host's `users` table while noerd users live in `noerd_users`. Nova's users own the `web` guard — noerd must not claim it.

## Tests

- new `tests/Feature/NoerdGuardTest.php`: registration shapes, host-override wins, `set_as_default` toggle, login on the noerd guard, the Nova coexistence scenario (second guard's user never affects tenant scoping/stamping), logout isolation, listener guard filter, broker round-trip, `guest:noerd`
- test environments set `auth.defaults.guard = noerd` so the existing guard-less `actingAs()` calls keep working
- noerd suite: 781 passed; host suite across all modules: 3933 passed, 0 failed

Companion commits in the host repo and sibling modules switch all module route files from `['web', 'auth', 'verified']` to the `noerd` group (kept local until this PR merges, since the group ships with this change).