### PR TITLE
Move the tab panel's bottom padding inside the scroll container so in…

### DIFF
--- a/resources/views/components/tab-panel.blade.php
+++ b/resources/views/components/tab-panel.blade.php
@@ -6,12 +6,14 @@
     constant; each panel is its own scroll container. The optional `show` prop
     takes an Alpine expression that additionally toggles the panel via x-show.
     -mx-6/px-6 keep content aligned while moving the clip edge and scrollbar to
-    the page-body padding edge, so input focus rings are not cut off. Flush
-    panels (inside an already unpadded wrapper) opt out with `mx-0! px-0!`.
+    the page-body padding edge, so input focus rings are not cut off; -mb-8/pb-8
+    does the same vertically against the page chrome's bottom padding (the gap
+    above the footer stays, but lives inside the scroll container). Flush
+    panels (inside an already unpadded wrapper) opt out with `mx-0! px-0! mb-0! pb-0!`.
 --}}
 <div
     @if ($show) x-show="{{ $show }}" @endif
-    {{ $attributes->merge(['class' => 'min-h-0 overflow-y-auto -mx-6 px-6']) }}
+    {{ $attributes->merge(['class' => 'min-h-0 overflow-y-auto -mx-6 px-6 -mb-8 pb-8']) }}
     :class="currentTab === {{ $number }} ? 'visible' : 'invisible pointer-events-none'"
 >
     {{ $slot }}

--- a/tests/Components/TabContentPanelScrollTest.php
+++ b/tests/Components/TabContentPanelScrollTest.php
@@ -36,7 +36,7 @@ it('renders tab-panels and tab-panel as generic stacking components', function (
     expect($html)
         ->toContain('grid min-h-0 grid-rows-1')
         ->toContain('pt-4')
-        ->toContain('min-h-0 overflow-y-auto -mx-6 px-6 flex')
+        ->toContain('min-h-0 overflow-y-auto -mx-6 px-6 -mb-8 pb-8 flex')
         ->toContain('x-show="$wire.someFlag"')
         ->toContain("currentTab === 2 ? 'visible' : 'invisible pointer-events-none'");
 });


### PR DESCRIPTION
…put focus rings are not clipped