### PR TITLE
Make tests independent of the host application's locale

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -104,6 +104,14 @@ abstract class TestCase extends BaseTestCase
         $app['config']->set('queue.default', 'sync');
         $app['config']->set('mail.default', 'array');
 
+        // Translated output must not depend on the host application's
+        // APP_LOCALE — a real project (and this repo's .env.testing) runs
+        // German, which would break every assertion on an English source
+        // string. Tests that exercise translation set their own locale
+        // explicitly, e.g. FieldHelpTextTest.
+        $app['config']->set('app.locale', 'en');
+        $app['config']->set('app.fallback_locale', 'en');
+
         // Defaults to testbench's built-in sqlite :memory: connection. A
         // dedicated variable (not DB_CONNECTION) selects another database, so
         // a host application's CI environment never leaks into these tests.


### PR DESCRIPTION
## Problem

Every noerd test that asserts on a string rendered through `__()` silently depended on the **host application's** `APP_LOCALE`. In a German project this breaks: `liefertool`'s `.env.testing` sets `APP_LOCALE=de`, so `TranslatableFieldMarkerTest` counted the English source string `'This field is translatable.'` while the rendered HTML carried the German translation from `resources/lang/de.json:386`.

Result there: 3 failures (`default`, `compact`, `numbered` data sets) that had nothing to do with the module itself and could not be reproduced by running the suite standalone.

## Change

`defineEnvironment()` in `tests/TestCase.php` now pins the locale:

```php
$app['config']->set('app.locale', 'en');
$app['config']->set('app.fallback_locale', 'en');
```

This follows the pattern the same method already uses for the database — a host application's environment must never leak into these tests. The locale was the last piece that still did.

Tests that exercise translation *as behaviour* keep working unchanged, because `app()->setLocale()` overrides the pinned default — see `FieldHelpTextTest::it('translates the help text')`.

## Verification

The full module suite, run under three different host locales:

| `APP_LOCALE` | Result |
| --- | --- |
| `de` | 824 tests, 823 passed, 1 skipped |
| `en` | 824 tests, 823 passed, 1 skipped |
| `fr` | 824 tests, 823 passed, 1 skipped |

Before this change the suite passed under `en` and failed with 3 failures under `de`.

## Notes

- `CreateNewTenantTest.php:25` asserts on `'Neuen Mandanten erstellen'` and looks locale-dependent, but is not: `create-new-tenant.blade.php:73` passes that German literal as the *source* string to `__()`, and no translation key matches it, so it returns unchanged in any locale. Worth cleaning up separately for consistency — it is the only German source string in the views.
- `SetupCollectionsListFilterTest.php:88` (`app()->setLocale('en')`) is now redundant. Left in place: harmless, and it documents the test's intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)