### PR TITLE
Add fieldComponent to RelationFieldDefinition for custom relation field renderers

### DIFF
--- a/docs/relation-field-types.md
+++ b/docs/relation-field-types.md
@@ -46,6 +46,7 @@ $relationFieldRegistry->register('customerRelation', RelationFieldDefinition::mo
 | `titleResolver` | Model attribute name or callback that returns the display title (default `'name'`) |
 | `selectEvent` | Custom selection event name; defaults to the `{entity}Selected` convention derived from the list component |
 | `detailRoute` | Named `Route::livewire()` route opened as a modal for existing values — preferred over `detailComponent` when the record is addressable (see [Modals](modal.md#route-modals)); `detailComponent` stays as the fallback when the route is not registered |
+| `fieldComponent` | Livewire component rendering the field in the detail form; `null` (default) uses the generic `noerd-relation-field` input. See [Custom Renderer Component](#custom-renderer-component) |
 
 ## Custom Title Resolver
 
@@ -57,6 +58,46 @@ $relationFieldRegistry->register('quoteRelation', RelationFieldDefinition::model
     titleResolver: fn (Quote $quote): string => $quote->number . ' (' . \Number::currency($quote->total_net, in: 'EUR', locale: 'de') . ')',
 ));
 ```
+
+## Custom Renderer Component
+
+By default every relation type renders as the generic readonly input with a clear button and a
+magnifier (`noerd-relation-field`). A module can replace that markup for a single relation type —
+e.g. render an address as a clickable card — by passing its own Livewire component as
+`fieldComponent`:
+
+```php
+$relationFieldRegistry->register('customerAddressCardRelation', RelationFieldDefinition::model(
+    listComponent: 'customer::customer-addresses-list',
+    detailComponent: 'customer::customer-address-detail',
+    detailRoute: 'customer.address.detail',
+    modelClass: CustomerAddress::class,
+    titleResolver: fn (CustomerAddress $address): string => $address->label ?? '',
+    fieldComponent: 'customer::customer-address-card-field',
+));
+```
+
+The component MUST extend `Noerd\Livewire\RelationFieldComponent` — it then inherits the complete
+behaviour (mount hydration, the `noerdRelationSelected` round trip, `clear()`, `openDetail()`,
+`setFieldValue` sync to the parent detail) and receives exactly the same props as the generic
+renderer (`relationType`, `fieldName`, `label`, `value`, `modelId`, `theme`, …). Only the Blade
+markup differs. The single-file component is two lines plus markup:
+
+```blade
+<?php
+
+new class extends \Noerd\Livewire\RelationFieldComponent {}; ?>
+
+<div>
+    {{-- custom markup; open the picker exactly like the generic template: --}}
+    {{-- @click="$modal('{{ $listComponent }}', {id: {{ $modelId ?: 'null' }}, context: '{{ $fieldName }}', listActionMethod: 'selectAction'})" --}}
+</div>
+```
+
+For markup that shows more than the title, the base class exposes the related Eloquent record via
+`$this->relatedModel()` (resolved through the definition's `modelClass`; `null` while the field is
+empty). Non-default themes resolve a `{component}-{theme}` sibling when it exists and fall back to
+the component itself (see [Themes](themes.md)).
 
 ## Polymorphic Relation Fields
 
@@ -87,7 +128,8 @@ Polymorphic fields render through the shared Livewire component
 ## Runtime Behaviour
 
 - All registered relation types render through the shared Livewire component `noerd-relation-field`
-  (polymorphic types through `noerd-polymorphic-relation-field`)
+  (polymorphic types through `noerd-polymorphic-relation-field`), unless the definition names a
+  custom `fieldComponent`
 - Selection uses the generic event `noerdRelationSelected`; the `{entity}Selected` event (or the
   definition's `selectEvent`) is dispatched as well, so detail components can listen with
   `#[On('customerSelected')]`

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -314,6 +314,28 @@ public function customerSelected($customerId): void
 
 **Reference:** `docs/relation-field-types.md`
 
+### Custom Field Types (FieldTypeRegistry)
+The YAML `type:` of a detail field is resolved through the `Noerd\Services\FieldTypeRegistry`
+singleton — nothing is hardcoded. A module registers additional field types in its ServiceProvider
+`boot()` and any detail YAML may then use them:
+
+- `FieldTypeDefinition::include('module::components.forms.my-type', resolver: ...)` for Blade
+  partials, `FieldTypeDefinition::livewire('module::my-field', resolver: ..., keyResolver: ...)`
+  for dedicated Livewire field components. The optional `resolver` computes the props per render
+  from `(array $field, $component, $detailData, $modelId)`.
+- Relation types are registered via `RelationFieldRegistry::register('{x}Relation', RelationFieldDefinition::model(...))`
+  — this auto-registers the matching field type; never register both by hand. The generic renderer
+  is `noerd-relation-field` (readonly input + magnifier). To restyle ONE relation type (e.g. an
+  address card), pass a custom Livewire component as `fieldComponent:` in the definition; that
+  component MUST extend `Noerd\Livewire\RelationFieldComponent` (inherits the full picker/select/
+  clear/openDetail behaviour and the same props) and may read the related record via
+  `$this->relatedModel()`. Never fork the selection round trip in custom markup — reuse
+  `$modal('{{ $listComponent }}', {id: ..., context: '{{ $fieldName }}', listActionMethod: 'selectAction'})`.
+- Unknown types fall back to the plain input (`text`, `number`, `date`, … need no registration);
+  unregistered `*Relation` types throw during rendering.
+- Reference: `docs/field-types.md` ("Custom Field Types"), `docs/relation-field-types.md`
+  ("Custom Renderer Component"), `docs/extension-registries.md`.
+
 ### Actions in List Components
 List components support multiple action buttons via the `actions` array in the YAML configuration.
 

--- a/src/Livewire/RelationFieldComponent.php
+++ b/src/Livewire/RelationFieldComponent.php
@@ -143,6 +143,25 @@ abstract class RelationFieldComponent extends Component
         ];
     }
 
+    /**
+     * The related Eloquent model behind the current value — for custom renderer
+     * components (fieldComponent) that display more than the title.
+     */
+    public function relatedModel(): mixed
+    {
+        if (!$this->value) {
+            return null;
+        }
+
+        $definition = app(RelationFieldRegistry::class)->resolve($this->relationType);
+
+        if (!$definition?->modelClass || !class_exists($definition->modelClass)) {
+            return null;
+        }
+
+        return $definition->modelClass::query()->find($this->value);
+    }
+
     private function resolveDisplayTitle(): void
     {
         $definition = app(RelationFieldRegistry::class)->resolve($this->relationType);

--- a/src/Services/RelationFieldRegistry.php
+++ b/src/Services/RelationFieldRegistry.php
@@ -20,7 +20,7 @@ class RelationFieldRegistry
         $this->definitions[$type] = $definition;
 
         $this->fieldTypeRegistry->register($type, FieldTypeDefinition::livewire(
-            'noerd-relation-field',
+            $definition->fieldComponent ?? 'noerd-relation-field',
             resolver: function (array $field, mixed $component, mixed $detailData, mixed $modelId) use ($type): array {
                 $fieldName = $field['name'] ?? '';
 

--- a/src/Support/RelationFieldDefinition.php
+++ b/src/Support/RelationFieldDefinition.php
@@ -12,6 +12,10 @@ class RelationFieldDefinition
      *                                relation detail opens via Noerd::modalRoute()
      *                                (URL rewrite) and $detailComponent is not used
      * @param  callable|null  $titleResolver
+     * @param  ?string  $fieldComponent  Livewire component rendering the field in the
+     *                                   detail form; null uses the generic
+     *                                   'noerd-relation-field'. A custom component must
+     *                                   extend Noerd\Livewire\RelationFieldComponent
      */
     public function __construct(
         public string $listComponent,
@@ -20,6 +24,7 @@ class RelationFieldDefinition
         public ?string $modelClass = null,
         public $titleResolver = null,
         public ?string $selectEvent = null,
+        public ?string $fieldComponent = null,
     ) {}
 
     /**
@@ -32,6 +37,7 @@ class RelationFieldDefinition
         callable|string|null $titleResolver = 'name',
         ?string $selectEvent = null,
         ?string $detailRoute = null,
+        ?string $fieldComponent = null,
     ): self {
         return new self(
             listComponent: $listComponent,
@@ -42,6 +48,7 @@ class RelationFieldDefinition
                 ? static fn(mixed $model): mixed => data_get($model, $titleResolver)
                 : $titleResolver,
             selectEvent: $selectEvent,
+            fieldComponent: $fieldComponent,
         );
     }
 

--- a/tests/Unit/RelationFieldRegistryTest.php
+++ b/tests/Unit/RelationFieldRegistryTest.php
@@ -41,6 +41,31 @@ it('registers a relation type and exposes it via field type registry', function 
     ]);
 });
 
+it('renders a relation type through its custom field component when one is registered', function (): void {
+    $fieldTypeRegistry = new FieldTypeRegistry();
+    $relationFieldRegistry = new RelationFieldRegistry($fieldTypeRegistry);
+
+    $relationFieldRegistry->register('customerAddressCardRelation', RelationFieldDefinition::model(
+        listComponent: 'customer-addresses-list',
+        detailComponent: 'customer-address-detail',
+        modelClass: null,
+        titleResolver: 'label',
+        fieldComponent: 'customer::customer-address-card-field',
+    ));
+
+    $fieldTypeDefinition = $fieldTypeRegistry->resolve('customerAddressCardRelation');
+
+    expect($fieldTypeDefinition?->kind)->toBe('livewire');
+    expect($fieldTypeDefinition?->target)->toBe('customer::customer-address-card-field');
+    // The custom component receives the identical props as the generic renderer.
+    expect($fieldTypeDefinition?->resolveProps([
+        'name' => 'detailData.default_invoice_address_id',
+        'label' => 'Default Invoice Address',
+    ], new class {
+        public array $detailData = ['default_invoice_address_id' => 7];
+    }, null, 3)['value'])->toBe(7);
+});
+
 it('passes the row number on only when the theme numbered the field', function (): void {
     $fieldTypeRegistry = new FieldTypeRegistry();
     $relationFieldRegistry = new RelationFieldRegistry($fieldTypeRegistry);


### PR DESCRIPTION
## Summary

- `RelationFieldDefinition` gets an optional `fieldComponent` parameter: a Livewire component that renders the relation field in the detail form instead of the generic `noerd-relation-field` input.
- `RelationFieldRegistry::register()` uses the definition's `fieldComponent` as the auto-registered field type's livewire target (falling back to `noerd-relation-field`); resolver and keyResolver are unchanged, so a custom renderer receives exactly the same props.
- `RelationFieldComponent::relatedModel()` exposes the related Eloquent record (via the definition's `modelClass`) so custom markup can display more than the title.
- Docs: new "Custom Renderer Component" section in `docs/relation-field-types.md`; new "Custom Field Types (FieldTypeRegistry)" section in the Boost guideline.
- Test: `RelationFieldRegistryTest` covers the custom target and identical props.

A custom renderer must extend `Noerd\Livewire\RelationFieldComponent` and inherits the full behaviour (picker round trip, `clear()`, `openDetail()`, `setFieldValue` sync). First consumer: the customer module's `customerAddressCardRelation`, which renders the default invoice/delivery address as a clickable address card.

## Test plan

- `vendor/bin/pest tests/Unit/RelationFieldRegistryTest.php`
- `tests/Feature/BoostGuidelineTest.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)