### PR TITLE
Tenants list in setup, slim tenant detail, no NOERD_MULTI_TENANT env write on install

### DIFF
--- a/app-configs/setup/details/tenant-detail.yml
+++ b/app-configs/setup/details/tenant-detail.yml
@@ -5,27 +5,7 @@ fields:
     label: Name
     type: text
     colspan: 6
-  - name: detailData.email
-    label: Email
-    type: email
-    colspan: 6
     required: true
-  - name: detailData.contact_name
-    label: Contact Person
-    type: text
-    colspan: 6
-  - name: detailData.address
-    label: Address
-    type: text
-    colspan: 6
-  - name: detailData.zipcode
-    label: ZIP Code
-    type: text
-    colspan: 6
-  - name: detailData.city
-    label: City
-    type: text
-    colspan: 6
   - name: logo
     label: Logo
     type: image

--- a/app-configs/setup/lists/tenants-list.yml
+++ b/app-configs/setup/lists/tenants-list.yml
@@ -1,0 +1,4 @@
+title: Tenants
+columns:
+  - field: name
+    label: Name

--- a/app-configs/setup/navigation.yml
+++ b/app-configs/setup/navigation.yml
@@ -5,8 +5,8 @@
   block_menus:
     - title: Administration
       navigations:
-        - title: Tenant
-          route: tenant
+        - title: Tenants
+          route: tenants
           heroicon: building-office
         - title: Apps
           route: tenant-apps

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -98,7 +98,9 @@ npm run build     # or: npm run dev
 
 `noerd:install` publishes `config/noerd.php`. Notable flags:
 
-- `features.multi_tenant` (`NOERD_MULTI_TENANT`) — tenant switcher and multi-tenant UI
+- `features.multi_tenant` (`NOERD_MULTI_TENANT`) — tenant switcher and multi-tenant UI. Enabled
+  by default; `noerd:install` does not write this flag to `.env` — set `NOERD_MULTI_TENANT=false`
+  yourself to disable it
 - `features.currency` (`NOERD_CURRENCY_ENABLED`) — set to `false` to hide currency-related UI on
   installations that don't need it
 - `auth.guard` (`NOERD_AUTH_GUARD`) / `auth.set_as_default` (`NOERD_AUTH_DEFAULT`) — noerd's

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -217,6 +217,7 @@
     "New Parameter": "Neuer Parameter",
     "New Storage Location": "Neue Lagerstelle",
     "Tenant": "Mandant",
+    "Tenants": "Mandanten",
     "Login as user": "Als Benutzer anmelden",
     "Do you really want to log in as this user?": "Möchtest Du Dich wirklich als dieser Benutzer anmelden?",
     "Projects": "Projekte",

--- a/resources/views/components/tenant-detail.blade.php
+++ b/resources/views/components/tenant-detail.blade.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Auth;
 use Livewire\Component;
 use Livewire\WithFileUploads;
 use Noerd\Models\Tenant;
@@ -18,31 +19,31 @@ new class extends Component {
 
     public function mount(): void
     {
+        if (! $this->modelId) {
+            $this->modelId = (string) Auth::user()->selected_tenant_id;
+        }
+
+        $user = Auth::user();
+        abort_unless(
+            $user->isSuperAdmin() || $user->adminTenants()->whereKey($this->modelId)->exists(),
+            403,
+        );
+
         $this->initDetail();
-
-        $tenant = Tenant::find(auth()->user()->selected_tenant_id);
-
-        $this->detailData = $tenant->toArray();
     }
 
     public function store(): void
     {
         $this->validate([
             'detailData.name' => ['required', 'string', 'max:255', 'min:3'],
-            'detailData.email' => ['required', 'email', 'max:255'],
         ]);
 
-        $tenant = Tenant::find(auth()->user()->selected_tenant_id);
+        $tenant = Tenant::findOrFail($this->modelId);
         $tenant->name = $this->detailData['name'];
-        $tenant->email = $this->detailData['email'];
-        $tenant->contact_name = $this->detailData['contact_name'] ?? null;
-        $tenant->address = $this->detailData['address'] ?? null;
-        $tenant->zipcode = $this->detailData['zipcode'] ?? null;
-        $tenant->city = $this->detailData['city'] ?? null;
         $tenant->logo = $this->detailData['logo'] ?? null;
         $tenant->save();
 
-        $this->showSuccessIndicator = true;
+        $this->storeProcess($tenant);
     }
 
     public function delete(): void

--- a/resources/views/components/tenants-list.blade.php
+++ b/resources/views/components/tenants-list.blade.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Support\Facades\Auth;
+use Livewire\Component;
+use Noerd\Models\Tenant;
+use Noerd\Traits\NoerdList;
+
+new class extends Component {
+    use NoerdList;
+
+    public $listModel = Tenant::class;
+
+    public ?string $detailRoute = 'tenant.detail';
+
+    public $detailComponent = 'noerd::tenant-detail';
+
+    public function mount(): void
+    {
+        $this->mountList();
+        $this->setDefaultSort('name', true);
+    }
+
+    public function listData(): array
+    {
+        $query = $this->listQuery($this->listModel);
+
+        if (! Auth::user()->isSuperAdmin()) {
+            $query->whereIn('id', Auth::user()->adminTenants()->pluck('tenants.id'));
+        }
+
+        $rows = $query->paginate($this->perPage);
+
+        return $this->buildList($rows);
+    }
+}; ?>
+
+<x-noerd::page>
+
+    <x-noerd::list />
+
+</x-noerd::page>

--- a/routes/noerd-routes.php
+++ b/routes/noerd-routes.php
@@ -12,7 +12,8 @@ Route::group(['prefix' => 'setup', 'middleware' => ['noerd', 'setup']], function
     Route::livewire('tenant-apps', 'noerd::tenant-apps-list')->name('tenant-apps');
     Route::livewire('users', 'noerd::noerd-users-list')->name('users');
     Route::livewire('noerd-user/{modelId}', 'noerd::noerd-user-detail')->name('noerd-user.detail');
-    Route::livewire('tenant', 'noerd::tenant-detail')->name('tenant');
+    Route::livewire('tenants', 'noerd::tenants-list')->name('tenants');
+    Route::livewire('tenant/{modelId}', 'noerd::tenant-detail')->name('tenant.detail');
     Route::livewire('create-tenant', 'noerd::create-tenant')->name('create-tenant');
     Route::livewire('collections', 'noerd::setup-collections-list')->name('setup-collections');
     Route::livewire('collection/{modelId}', 'noerd::setup-collection-detail')->name('setup-collection.detail');

--- a/src/Commands/NoerdInstallCommand.php
+++ b/src/Commands/NoerdInstallCommand.php
@@ -732,15 +732,8 @@ class NoerdInstallCommand extends Command
 
         // Create default tenant if none exist
         if (Tenant::count() === 0) {
-            $multiTenant = confirm('Do you want to enable multi-tenant mode?', default: false);
-            $this->setEnvValue('NOERD_MULTI_TENANT', $multiTenant ? 'true' : 'false');
-
-            if ($multiTenant) {
-                $this->call('noerd:create-tenant');
-            } else {
-                $this->call('noerd:create-tenant', ['--default' => true]);
-                $this->autoAssignAllApps();
-            }
+            $this->call('noerd:create-tenant');
+            $this->autoAssignAllApps();
         } else {
             $this->line('<comment>Tenant(s) already exist, skipping.</comment>');
         }
@@ -810,22 +803,5 @@ class NoerdInstallCommand extends Command
         $allAppIds = TenantApp::where('is_active', true)->pluck('id')->toArray();
         $tenant->tenantApps()->sync($allAppIds);
         $this->info("All apps auto-assigned to tenant '{$tenant->name}'.");
-    }
-
-    /**
-     * Set or update a value in the .env file.
-     */
-    private function setEnvValue(string $key, string $value): void
-    {
-        $envPath = base_path('.env');
-        $envContent = file_get_contents($envPath);
-
-        if (preg_match("/^{$key}=/m", $envContent)) {
-            $envContent = preg_replace("/^{$key}=.*/m", "{$key}={$value}", $envContent);
-        } else {
-            $envContent .= "\n{$key}={$value}\n";
-        }
-
-        file_put_contents($envPath, $envContent);
     }
 }

--- a/tests/Feature/TenantsListTest.php
+++ b/tests/Feature/TenantsListTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Noerd\Helpers\TenantHelper;
+use Noerd\Models\NoerdUser;
+use Noerd\Models\Profile;
+use Noerd\Models\Tenant;
+use Noerd\Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->tenant = Tenant::factory()->create(['name' => 'My Tenant']);
+    $this->adminProfile = Profile::factory()->create([
+        'tenant_id' => $this->tenant->id,
+        'key' => 'ADMIN',
+        'name' => 'Admin',
+    ]);
+
+    $this->admin = NoerdUser::factory()->create(['selected_tenant_id' => $this->tenant->id]);
+    $this->admin->tenants()->attach($this->tenant->id, ['profile_id' => $this->adminProfile->id]);
+
+    TenantHelper::setSelectedTenantId($this->tenant->id);
+    TenantHelper::setSelectedApp('SETUP');
+});
+
+it('renders the tenants list page', function (): void {
+    $this->actingAs($this->admin);
+
+    $this->get('/setup/tenants')
+        ->assertSuccessful()
+        ->assertSeeLivewire('noerd::tenants-list');
+});
+
+it('lists only tenants the user administers', function (): void {
+    $foreignTenant = Tenant::factory()->create(['name' => 'Foreign Tenant']);
+
+    $this->actingAs($this->admin);
+
+    Livewire::test('noerd::tenants-list')
+        ->assertSee('My Tenant')
+        ->assertDontSee($foreignTenant->name);
+});
+
+it('lists all tenants for super admins', function (): void {
+    $otherTenant = Tenant::factory()->create(['name' => 'Other Tenant']);
+    $superAdmin = NoerdUser::factory()->create([
+        'super_admin' => true,
+        'selected_tenant_id' => $this->tenant->id,
+    ]);
+    $superAdmin->tenants()->attach($this->tenant->id, ['profile_id' => $this->adminProfile->id]);
+
+    $this->actingAs($superAdmin);
+
+    Livewire::test('noerd::tenants-list')
+        ->assertSee('My Tenant')
+        ->assertSee('Other Tenant');
+});
+
+it('updates the tenant name through the detail', function (): void {
+    $this->actingAs($this->admin);
+
+    Livewire::test('noerd::tenant-detail', ['modelId' => (string) $this->tenant->id])
+        ->set('detailData.name', 'Renamed Tenant')
+        ->call('store')
+        ->assertHasNoErrors();
+
+    expect($this->tenant->fresh()->name)->toBe('Renamed Tenant');
+});
+
+it('rejects a too short tenant name', function (): void {
+    $this->actingAs($this->admin);
+
+    Livewire::test('noerd::tenant-detail', ['modelId' => (string) $this->tenant->id])
+        ->set('detailData.name', 'ab')
+        ->call('store')
+        ->assertHasErrors(['detailData.name']);
+});
+
+it('denies the detail for a tenant the user does not administer', function (): void {
+    $foreignTenant = Tenant::factory()->create();
+
+    $this->actingAs($this->admin);
+
+    Livewire::test('noerd::tenant-detail', ['modelId' => (string) $foreignTenant->id])
+        ->assertForbidden();
+});
+
+it('falls back to the selected tenant when no model id is given', function (): void {
+    $this->actingAs($this->admin);
+
+    Livewire::test('noerd::tenant-detail')
+        ->assertSet('detailData.name', 'My Tenant');
+});


### PR DESCRIPTION
## Summary
- The setup navigation entry "Tenant" becomes "Tenants" and opens a new `noerd::tenants-list` under `/setup/tenants`; the tenant name is edited in the detail opened from a row (route modal `tenant.detail`, `/setup/tenant/{modelId}`).
- `tenant-detail` is reduced to the fields a fresh installation actually has (`name`, `logo`) — email/contact/address/zip/city referenced columns that do not exist in the shipped `tenants` migration.
- Access follows the users list: super admins see all tenants, admins only the tenants they administer (403 on foreign tenants; fallback to the selected tenant without a model id).
- `noerd:install` no longer prompts for multi-tenant mode and no longer writes `NOERD_MULTI_TENANT` to `.env` — the config default is already enabled; the first tenant is created and gets all apps assigned.

## Tests
- New `tests/Feature/TenantsListTest.php` (7 tests); full package suite green (912 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)