### PR TITLE
End noerd:install with an "Application ready" callout

### DIFF
--- a/src/Commands/NoerdInstallCommand.php
+++ b/src/Commands/NoerdInstallCommand.php
@@ -5,7 +5,10 @@ namespace Noerd\Commands;
 use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Hash;
+use Laravel\Prompts\Elements\Link;
+use Laravel\Prompts\Elements\NumberedList;
 
+use function Laravel\Prompts\callout;
 use function Laravel\Prompts\confirm;
 
 use Noerd\Models\NoerdUser;
@@ -70,7 +73,7 @@ class NoerdInstallCommand extends Command
             // Offer the demo app as the last installation step.
             $this->installDemoApp();
 
-            $this->info('Noerd content successfully installed!');
+            $this->displayApplicationReady();
 
             return 0;
         } catch (Exception $e) {
@@ -803,5 +806,32 @@ class NoerdInstallCommand extends Command
         $allAppIds = TenantApp::where('is_active', true)->pluck('id')->toArray();
         $tenant->tenantApps()->sync($allAppIds);
         $this->info("All apps auto-assigned to tenant '{$tenant->name}'.");
+    }
+
+    /**
+     * Display the closing "Application ready" callout with the next steps.
+     */
+    protected function displayApplicationReady(): void
+    {
+        $url = rtrim((string) config('app.url'), '/');
+
+        if (!function_exists('\Laravel\Prompts\callout')) {
+            $this->newLine();
+            $this->info('Application ready!');
+            $this->line("Open: {$url}/noerd-apps and log in with your admin user.");
+            $this->line('New to noerd? Check out the documentation: https://noerd.dev');
+
+            return;
+        }
+
+        callout('Application ready', [
+            'You can start your local development using:',
+            new NumberedList([
+                'Run: composer run dev',
+                'Open: ' . new Link($url . '/noerd-apps') . ' and log in with your admin user',
+            ]),
+            'New to noerd? Check out the ' . new Link('https://noerd.dev', 'documentation') . '.',
+            'Build something amazing!',
+        ]);
     }
 }

--- a/tests/Commands/NoerdInstallReadyCalloutTest.php
+++ b/tests/Commands/NoerdInstallReadyCalloutTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Support\Facades\Artisan;
+use Noerd\Commands\NoerdInstallCommand;
+use Noerd\Tests\TestCase;
+
+uses(TestCase::class);
+
+/**
+ * Fixture exposing the closing "Application ready" callout in isolation.
+ */
+class InstallReadyCalloutFixtureCommand extends NoerdInstallCommand
+{
+    protected $signature = 'test:install-ready-callout';
+
+    public function handle()
+    {
+        $this->displayApplicationReady();
+
+        return 0;
+    }
+}
+
+beforeEach(function (): void {
+    $this->app[Kernel::class]->registerCommand(new InstallReadyCalloutFixtureCommand());
+});
+
+it('displays the application ready callout with the next steps', function (): void {
+    config(['app.url' => 'https://example.test']);
+
+    Artisan::call('test:install-ready-callout');
+    $output = Artisan::output();
+
+    expect($output)
+        ->toContain('Application ready')
+        ->toContain('https://example.test/noerd-apps')
+        ->toContain('documentation')
+        ->toContain('Build something amazing!');
+});


### PR DESCRIPTION
## Summary
- `noerd:install` now closes with the same boxed "Application ready" callout the Laravel installer shows, rendered via `Laravel\Prompts\callout()` with `NumberedList` and `Link` elements: run `composer run dev`, open `{app.url}/noerd-apps`, log in with the created admin user, plus a link to the noerd.dev documentation.
- Replaces the plain "Noerd content successfully installed!" line; a plain-text fallback covers `laravel/prompts` versions without `callout()`.

## Tests
- New `tests/Commands/NoerdInstallReadyCalloutTest.php` (fixture-command pattern); full Commands suite green (120 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)