### PR TITLE
Guard the position of the demo prompt in noerd:install and forbid moving published tags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,13 @@ and are NOT repeated here. Read that guideline first; it applies to code in this
 - **Release:** tagging a version requires the `composer.json` `"version"` field to equal the tag in
   the tagged commit (`Bump version to vX.Y.Z`). That bump may be committed to `main` as part of the
   tag flow.
+- **A pushed tag is immutable — never move it.** Packagist indexes a version once and keeps the
+  commit it saw first, so re-pointing an existing tag keeps shipping the old code while the
+  repository looks correct. Consumers see no reason to update, because the version number did not
+  change. Anything that has to reach users goes into the next patch release instead. This is not
+  hypothetical: `v0.11.0` was moved to a later commit after it had been published, Packagist kept
+  serving the commit from five days earlier, and the released `v0.11.0` was therefore older than
+  `v0.10.13` — `^0.11.0` resolved to less code than `^0.10`.
 - Commit messages: one concise sentence describing the change. No generated-by footers, no
   co-author lines.
 - Do not change dependencies (`composer.json` `require`) without explicit agreement.

--- a/tests/Commands/NoerdInstallDemoPromptTest.php
+++ b/tests/Commands/NoerdInstallDemoPromptTest.php
@@ -14,10 +14,9 @@ uses(TestCase::class);
  */
 class InstallDemoPromptFixtureCommand extends NoerdInstallCommand
 {
-    protected $signature = 'test:install-demo-prompt {--force : Overwrite existing files without asking}';
-
     /** @var array<int, array{command: string, arguments: array<string, mixed>}> */
     public static array $calledCommands = [];
+    protected $signature = 'test:install-demo-prompt {--force : Overwrite existing files}';
 
     public function handle()
     {
@@ -34,9 +33,78 @@ class InstallDemoPromptFixtureCommand extends NoerdInstallCommand
     }
 }
 
+/**
+ * Fixture recording the ORDER of the installation steps. Every side-effecting
+ * step is neutralised and only reports its name, so the flow can be asserted
+ * without touching the filesystem, the database or npm.
+ */
+class InstallFlowOrderFixtureCommand extends NoerdInstallCommand
+{
+    /** @var array<int, string> */
+    public static array $steps = [];
+    protected $signature = 'test:install-flow-order';
+
+    protected function copyDirectoryContents(string $sourceDir, string $targetDir): array
+    {
+        static::$steps[] = 'copyDirectoryContents';
+
+        return [
+            'created_dirs' => 0,
+            'copied_files' => 0,
+            'skipped_files' => 0,
+            'overwritten_files' => 0,
+        ];
+    }
+
+    protected function displaySummary(array $results): void {}
+
+    protected function ensureAppModulesDirectory(): void
+    {
+        static::$steps[] = 'ensureAppModulesDirectory';
+    }
+
+    protected function updatePhpunitXml(): void
+    {
+        static::$steps[] = 'updatePhpunitXml';
+    }
+
+    protected function publishNoerdConfig(): void
+    {
+        static::$steps[] = 'publishNoerdConfig';
+    }
+
+    protected function setupFrontendAssets(): void
+    {
+        static::$steps[] = 'setupFrontendAssets';
+    }
+
+    protected function runMigrationsAndSetupAdmin(): void
+    {
+        static::$steps[] = 'runMigrationsAndSetupAdmin';
+    }
+
+    protected function runNpmBuild(): void
+    {
+        static::$steps[] = 'runNpmBuild';
+    }
+
+    protected function installDemoApp(): void
+    {
+        static::$steps[] = 'installDemoApp';
+    }
+
+    protected function displayApplicationReady(): void
+    {
+        static::$steps[] = 'displayApplicationReady';
+    }
+}
+
 beforeEach(function (): void {
     InstallDemoPromptFixtureCommand::$calledCommands = [];
+    InstallFlowOrderFixtureCommand::$steps = [];
+
     $this->app[Kernel::class]->registerCommand(new InstallDemoPromptFixtureCommand());
+    $this->app[Kernel::class]->registerCommand(new InstallFlowOrderFixtureCommand());
 });
 
 it('runs noerd:demo when the demo app prompt is confirmed', function (): void {
@@ -57,4 +125,24 @@ it('skips noerd:demo when the demo app prompt is declined', function (): void {
         ->assertExitCode(0);
 
     expect(InstallDemoPromptFixtureCommand::$calledCommands)->toBeEmpty();
+});
+
+it('offers the demo app as the last installation step', function (): void {
+    $this->artisan('test:install-flow-order')->assertExitCode(0);
+
+    $steps = InstallFlowOrderFixtureCommand::$steps;
+
+    expect($steps)->toContain('installDemoApp');
+
+    // The demo question used to be the very first prompt of noerd:install, which
+    // made users decide before seeing anything. It must stay at the end of the
+    // flow — behind every other step that asks something.
+    $demoStep = array_search('installDemoApp', $steps, true);
+
+    foreach (['publishNoerdConfig', 'setupFrontendAssets', 'runMigrationsAndSetupAdmin', 'runNpmBuild'] as $earlierStep) {
+        $earlierStepIndex = array_search($earlierStep, $steps, true);
+
+        expect($earlierStepIndex)->not->toBeFalse("Step {$earlierStep} did not run")
+            ->and($demoStep)->toBeGreaterThan($earlierStepIndex, "The demo prompt must come after {$earlierStep}");
+    }
 });


### PR DESCRIPTION
## Why

`noerd:install` asked *"Would you like to install the Demo App?"* as its very first prompt in versions published before v0.10.11. `bb15203` moved that question to the end of the flow, but nothing prevents it from drifting back — the existing test only asserted that a confirmation runs `noerd:demo`, not *where* in the flow it is asked.

The same release also surfaced a process problem: the `v0.11.0` tag was moved to a later commit after publication. Packagist keeps the commit it indexed first, so the released `v0.11.0` stayed at the commit from five days earlier and was in fact older than `v0.10.13` — `^0.11.0` resolved to *less* code than `^0.10`. Fixed by releasing v0.11.1.

## What

- **`tests/Commands/NoerdInstallDemoPromptTest.php`** — new fixture `InstallFlowOrderFixtureCommand` neutralises every side-effecting install step so it only records its name. The new test asserts the demo prompt runs after `publishNoerdConfig`, `setupFrontendAssets`, `runMigrationsAndSetupAdmin` and `runNpmBuild`. Verified against a mutation: moving `installDemoApp()` back to the top of `handle()` fails the test with *"The demo prompt must come after publishNoerdConfig"*.
- **`AGENTS.md`** — new workflow rule: a pushed tag is immutable, anything that has to reach users goes into the next patch release, with the `v0.11.0` incident as the concrete example.

No production code changed.

## Tests

`php artisan test app-modules/noerd/tests/Commands/` → 121 passed (487 assertions)