### PR TITLE
Fix pre-release blockers across packaging, install flow and list/relation components

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,25 @@
+# Keep dist installs (Packagist archives) lean: ship only what consumers need
+# at runtime. NOT excluded on purpose:
+# - demo/        -> read at runtime by noerd:demo (NoerdDemoCommand)
+# - dist/        -> the prebuilt frontend bundle published to public/vendor/noerd
+# - tests/TestCase.php, tests/helpers.php, tests/Traits/
+#                -> public test API for module developers
+#                   (`uses(Noerd\Tests\TestCase::class)` in every module test)
+/.github            export-ignore
+/docs               export-ignore
+/tests/Commands     export-ignore
+/tests/Components   export-ignore
+/tests/Feature      export-ignore
+/tests/Helpers      export-ignore
+/tests/Middleware   export-ignore
+/tests/Unit         export-ignore
+/tests/Pest.php     export-ignore
+/tests/CreateNewTenantTest.php export-ignore
+/tests/UserComponentTest.php   export-ignore
+/phpunit.xml        export-ignore
+/pint.json          export-ignore
+/vite.config.js     export-ignore
+/package.json       export-ignore
+/package-lock.json  export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,9 +47,12 @@ and are NOT repeated here. Read that guideline first; it applies to code in this
 - **Host run:** inside a host project `php artisan test --compact app-modules/noerd/tests/...`.
   The host's `tests/Pest.php` is loaded instead of ours, therefore **every test file binds the test
   case itself** with `uses(Noerd\Tests\TestCase::class);` — never move that into `tests/Pest.php`.
-- `tests/helpers.php` (autoloaded via composer `autoload.files`) holds the global test helpers
-  (`validDetailPayload()`, `requiredLayoutFields()`, `registerTestLivewireRoute()`, …). New global
-  helpers go there, guarded with `function_exists`.
+- `tests/helpers.php` holds the global test helpers (`validDetailPayload()`,
+  `requiredLayoutFields()`, `registerTestLivewireRoute()`, …). It is deliberately NOT in the
+  production composer autoload (test functions must never load in a consumer app's requests):
+  `Noerd\Tests\TestCase` requires it, so every suite extending it gets the helpers, and a host
+  project additionally requires it from its own `tests/Pest.php`. New global helpers go there,
+  guarded with `function_exists`.
 - **Tests prove mechanics, not configuration.** The YAML files under `app-configs/` are
   per-installation configuration: never assert their current content (titles, themes, field lists,
   route vs. component targets). Use synthetic layouts, fixture YAMLs written at runtime or the

--- a/composer.json
+++ b/composer.json
@@ -1,16 +1,33 @@
 {
     "name": "noerd/noerd",
-    "description": "",
+    "description": "YAML-driven Livewire framework for multi-tenant Laravel applications: generic list, detail and page components, modals, themes, tenant apps and install/update tooling.",
     "type": "library",
+    "keywords": [
+        "laravel",
+        "livewire",
+        "framework",
+        "multi-tenant",
+        "yaml",
+        "admin",
+        "crud"
+    ],
+    "homepage": "https://noerd.dev",
+    "authors": [
+        {
+            "name": "Johannes Brock"
+        }
+    ],
     "version": "v0.11.2",
     "license": "MIT",
     "require": {
         "php": "^8.3",
+        "ext-mbstring": "*",
         "laravel/framework": "^12.0 || ^13.0",
         "livewire/livewire": "^4.0",
         "noerd/modal": "^0.3.23",
-        "wireui/heroicons": "^2.9",
-        "symfony/yaml": "^7.1 || ^8.0"
+        "symfony/polyfill-mbstring": "^1.32",
+        "symfony/yaml": "^7.1 || ^8.0",
+        "wireui/heroicons": "^2.9"
     },
     "require-dev": {
         "orchestra/testbench": "^10.6 || ^11.1",
@@ -22,7 +39,9 @@
             "Noerd\\Tests\\": "tests/",
             "Noerd\\Database\\Factories\\": "database/factories/",
             "Noerd\\Database\\Seeders\\": "database/seeders/"
-        },
+        }
+    },
+    "autoload-dev": {
         "files": [
             "tests/helpers.php"
         ]

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -57,8 +57,10 @@ A test that asserts their current content is wrong by definition.
 
 ## Global helpers
 
-`tests/helpers.php` is autoloaded through composer (`autoload.files`), so the helpers are available
-in every host and module test. New global helpers go there, guarded with `function_exists`.
+`tests/helpers.php` is loaded by `Noerd\Tests\TestCase` (covering every suite that extends it) and
+by the host project's `tests/Pest.php`, so the helpers are available in every host and module test —
+without shipping test functions in the production composer autoload. New global helpers go there,
+guarded with `function_exists`.
 
 | Helper | Purpose |
 |--------|---------|

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -1054,8 +1054,8 @@ Detail components (`*-detail`) build their validation rules at runtime from the 
 test must never assume a specific field is — or is not — required.** Two global helpers support this:
 `validDetailPayload(Model::class, $overrides)` (a complete factory payload) and
 `requiredLayoutFields($component)` (the required field names from the live `pageLayout`). They live in
-the noerd package (`tests/helpers.php`) and are loaded globally via composer
-`autoload.files`, so they are available to every host and submodule test (not just the host `Feature`
+the noerd package (`tests/helpers.php`), loaded by `Noerd\Tests\TestCase` and the host's
+`tests/Pest.php`, so they are available to every host and submodule test (not just the host `Feature`
 suite). When adding a new global test helper, put it there (guarded with `function_exists`).
 
 **Store-SUCCESS tests** — submit a COMPLETE payload sourced from the model factory and override only

--- a/resources/views/components/table/table-cell.blade.php
+++ b/resources/views/components/table/table-cell.blade.php
@@ -6,14 +6,7 @@
 
 <td
     class="border-r border-b border-gray-300 py-1 first:pl-4 last:border-r-0 {{ $isTranslatableCell ? 'bg-sky-50 group-hover:bg-transparent' : '' }}"
-    @click="activeColumn = {{ $column }}, selectedRow = {{ $row }}"
     x-data="{ showDropdown: false }"
-    {{--
-    x-noerd::on:keydown.arrow-down.prevent="down()"
-    x-noerd::on:keydown.arrow-up.prevent="up()"
-    x-noerd::on:keydown.arrow-left.prevent="left()"
-    x-noerd::on:keydown.arrow-right.prevent="right()"
-    --}}
 >
     @if ($columnValue === 'action')
         <div class="mr-1 ml-auto flex" disabled wire:navigate>
@@ -108,7 +101,7 @@
     @elseif ($columnValue === 'selectAction')
         <a
             class="m-0.5 flex"
-            @click.stop="show = ! show"
+            @click.stop
             wire:navigate
             wire:click.stop.prevent="{{ $action }}('{{ $id }}')"
         >
@@ -117,7 +110,7 @@
     @elseif ($columnValue === 'deleteAction')
         <a
             class="m-0.5 flex"
-            wire:confirm="{{ __('Are you sure you want to delete your account?') }}"
+            wire:confirm="{{ __('Are you sure you want to delete this entry?') }}"
             wire:navigate
             wire:click.stop.prevent="{{ $action }}('{{ $id }}')"
         >

--- a/src/Commands/NoerdInstallCommand.php
+++ b/src/Commands/NoerdInstallCommand.php
@@ -4,7 +4,6 @@ namespace Noerd\Commands;
 
 use Exception;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Hash;
 
 use function Laravel\Prompts\callout;
 use function Laravel\Prompts\confirm;
@@ -20,7 +19,11 @@ use RecursiveIteratorIterator;
 
 class NoerdInstallCommand extends Command
 {
-    protected $signature = 'noerd:install {--force : Overwrite existing files without asking}';
+    protected $signature = 'noerd:install
+                            {--force : Overwrite existing files without asking}
+                            {--migrate : Run migrations without asking (required to migrate in non-interactive runs)}
+                            {--build : Run npm build without asking (required to build in non-interactive runs)}
+                            {--demo : Install the demo app without asking (required to install it in non-interactive runs)}';
 
     protected $description = 'Install noerd content to the local content directory';
 
@@ -64,6 +67,9 @@ class NoerdInstallCommand extends Command
             // Setup frontend assets and configuration
             $this->setupFrontendAssets();
 
+            // Publish fonts + built Vite assets to public/vendor/noerd
+            $this->publishNoerdAssets();
+
             // Run migrations and setup admin user
             $this->runMigrationsAndSetupAdmin();
 
@@ -83,17 +89,29 @@ class NoerdInstallCommand extends Command
     }
 
     /**
-     * Ask whether to install the demo app and run noerd:demo on confirmation
+     * Ask whether to install the demo app and run noerd:demo on confirmation.
+     * Non-interactive runs never install the demo implicitly — a CI/deploy
+     * invocation must opt in with --demo instead of inheriting the prompt default.
      */
     protected function installDemoApp(): void
     {
         $this->newLine();
 
-        $shouldInstallDemo = confirm(
-            label: 'Would you like to install the Demo App?',
-            default: true,
-            hint: 'DemoCustomer with lists & details',
-        );
+        $shouldInstallDemo = $this->boolOption('demo');
+
+        if (! $shouldInstallDemo && ! $this->input->isInteractive()) {
+            $this->line('<comment>Non-interactive run: skipping the demo app. Pass --demo to install it.</comment>');
+
+            return;
+        }
+
+        if (! $shouldInstallDemo) {
+            $shouldInstallDemo = confirm(
+                label: 'Would you like to install the Demo App?',
+                default: true,
+                hint: 'DemoCustomer with lists & details',
+            );
+        }
 
         if (! $shouldInstallDemo) {
             $this->line('<comment>Demo app will NOT be installed. You can run it later with: php artisan noerd:demo</comment>');
@@ -183,6 +201,29 @@ class NoerdInstallCommand extends Command
             $a[$key] = ($a[$key] ?? 0) + ($b[$key] ?? 0);
         }
         return $a;
+    }
+
+    /**
+     * Read a boolean option that may not exist on a subclass's redefined
+     * signature (NoerdUpdateCommand and test fixtures override $signature).
+     */
+    protected function boolOption(string $name): bool
+    {
+        return $this->input->hasOption($name) && (bool) $this->option($name);
+    }
+
+    /**
+     * Publish the package's public assets (fonts + built Vite bundle). Assets
+     * are published ONLY from console commands — a web request must never
+     * write to public/ (see NoerdServiceProvider).
+     */
+    protected function publishNoerdAssets(): void
+    {
+        $this->call('vendor:publish', [
+            '--tag' => 'noerd-assets',
+            '--force' => true,
+            '--no-interaction' => true,
+        ]);
     }
 
     /**
@@ -556,13 +597,20 @@ class NoerdInstallCommand extends Command
     }
 
     /**
-     * Setup an admin user - either create a new one or promote an existing user
+     * Setup an admin user - either create a new one or promote an existing user.
+     * Skipped in non-interactive runs: an admin needs prompted credentials, and
+     * `noerd:create-admin` accepts them as options for scripted setups.
      */
     protected function setupAdminUser(): void
     {
         $this->newLine();
         $this->info('Admin User Setup');
         $this->line('================');
+
+        if (! $this->input->isInteractive()) {
+            $this->line('<comment>Non-interactive run: skipping admin setup. Create one with: php artisan noerd:create-admin --name= --email= --password=</comment>');
+            return;
+        }
 
         $userCount = NoerdUser::count();
 
@@ -574,7 +622,9 @@ class NoerdInstallCommand extends Command
     }
 
     /**
-     * Create a new admin user when no users exist
+     * Create a new admin user when no users exist. Delegates to
+     * noerd:create-admin, which owns the prompts and their validation —
+     * the first user of an installation becomes super admin.
      */
     protected function setupNewAdminUser(): void
     {
@@ -585,58 +635,7 @@ class NoerdInstallCommand extends Command
             return;
         }
 
-        // Get name
-        $name = null;
-        while (empty($name)) {
-            $name = $this->ask('What is the admin user\'s name?');
-            if (empty($name)) {
-                $this->error('Name is required.');
-            }
-        }
-
-        // Get email
-        $email = null;
-        while (empty($email)) {
-            $email = $this->ask('What is the admin user\'s email?');
-            if (empty($email)) {
-                $this->error('Email is required.');
-            } elseif (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
-                $this->error('Please enter a valid email address.');
-                $email = null;
-            } elseif (NoerdUser::where('email', $email)->exists()) {
-                $this->error('A user with this email already exists.');
-                $email = null;
-            }
-        }
-
-        // Get password
-        $passwordValue = null;
-        while (empty($passwordValue)) {
-            $passwordValue = $this->secret('Enter a password for the admin user (minimum 8 characters)');
-            if (empty($passwordValue)) {
-                $this->error('Password is required.');
-            } elseif (mb_strlen($passwordValue) < 8) {
-                $this->error('Password must be at least 8 characters.');
-                $passwordValue = null;
-            }
-        }
-
-        // Create the user
-        $user = NoerdUser::create([
-            'name' => $name,
-            'email' => $email,
-            'password' => Hash::make($passwordValue),
-        ]);
-
-        // First user becomes Super Admin
-        $user->super_admin = true;
-        $user->save();
-
-        $this->newLine();
-        $this->info("User '{$user->name}' created successfully as Super Admin.");
-
-        // Make the user admin
-        $this->makeUserAdmin($user);
+        $this->call('noerd:create-admin', ['--super-admin' => true]);
     }
 
     /**
@@ -710,7 +709,8 @@ class NoerdInstallCommand extends Command
 
     /**
      * Run migrations and setup admin user
-     * Migrations must be run before creating an admin user
+     * Migrations must be run before creating an admin user.
+     * Non-interactive runs never migrate implicitly — opt in with --migrate.
      */
     protected function runMigrationsAndSetupAdmin(): void
     {
@@ -720,7 +720,14 @@ class NoerdInstallCommand extends Command
         $this->line('Running migrations is required before you can create an admin user.');
         $this->newLine();
 
-        if (!confirm('Would you like to run "php artisan migrate" now?', default: true)) {
+        $shouldMigrate = $this->boolOption('migrate');
+
+        if (! $shouldMigrate && ! $this->input->isInteractive()) {
+            $this->line('<comment>Non-interactive run: skipping migrations. Pass --migrate to run them.</comment>');
+            return;
+        }
+
+        if (! $shouldMigrate && !confirm('Would you like to run "php artisan migrate" now?', default: true)) {
             $this->line('<comment>Skipping migrations. You can run them manually later with: php artisan migrate</comment>');
             $this->line('<comment>Note: You will need to run migrations before creating an admin user.</comment>');
             return;
@@ -748,13 +755,21 @@ class NoerdInstallCommand extends Command
     }
 
     /**
-     * Ask to run npm build for frontend assets
+     * Ask to run npm build for frontend assets.
+     * Non-interactive runs never build implicitly — opt in with --build.
      */
     protected function runNpmBuild(): void
     {
         $this->newLine();
 
-        if (!confirm('Would you like to run "npm run build" to compile frontend assets?', default: true)) {
+        $shouldBuild = $this->boolOption('build');
+
+        if (! $shouldBuild && ! $this->input->isInteractive()) {
+            $this->line('<comment>Non-interactive run: skipping npm build. Pass --build to run it.</comment>');
+            return;
+        }
+
+        if (! $shouldBuild && !confirm('Would you like to run "npm run build" to compile frontend assets?', default: true)) {
             $this->line('<comment>Skipping npm build. You can run it manually later with: npm run build</comment>');
             return;
         }

--- a/src/Commands/NoerdUpdateCommand.php
+++ b/src/Commands/NoerdUpdateCommand.php
@@ -44,7 +44,10 @@ class NoerdUpdateCommand extends NoerdInstallCommand
             // 3. Setup frontend assets (creates what is missing, patches what exists)
             $this->setupFrontendAssets();
 
-            // 4. Optional: npm build (only if --build flag is set)
+            // 4. Refresh published fonts + built Vite assets
+            $this->publishNoerdAssets();
+
+            // 5. Optional: npm build (only if --build flag is set)
             if ($this->option('build')) {
                 $this->runNpmBuildWithoutPrompt();
             }

--- a/src/Helpers/StaticConfigHelper.php
+++ b/src/Helpers/StaticConfigHelper.php
@@ -867,7 +867,7 @@ class StaticConfigHelper
             return true;
         }
 
-        $routeName = ($nav['route'] ?? null) === 'collections' ? 'cms.collections' : ($nav['route'] ?? '');
+        $routeName = $nav['route'] ?? '';
 
         return $routeName !== '' && Route::has($routeName);
     }

--- a/src/Livewire/RelationFieldComponent.php
+++ b/src/Livewire/RelationFieldComponent.php
@@ -94,7 +94,9 @@ abstract class RelationFieldComponent extends Component
             return;
         }
 
-        if ($context && $context !== $this->fieldName) {
+        // Strict match: a picker opened without a context dispatches '' / null,
+        // which must not be adopted by every relation field on the page.
+        if ($context !== $this->fieldName) {
             return;
         }
 

--- a/src/Providers/NoerdServiceProvider.php
+++ b/src/Providers/NoerdServiceProvider.php
@@ -71,7 +71,6 @@ use Noerd\Support\DefaultCountries;
 use Noerd\Support\FieldTypeDefinition;
 use Noerd\Support\LockedPropertiesHook;
 use Noerd\Support\QuickCreateExitHook;
-use Noerd\Support\RelationFieldDefinition;
 use Noerd\Support\RelationFormPersistHook;
 use Noerd\Support\ThemeContext;
 use Noerd\Support\WriteGuardHook;
@@ -202,7 +201,6 @@ class NoerdServiceProvider extends ServiceProvider
         $themeRegistry->registerPath(__DIR__ . '/../../resources/views/themes', priority: 0);
 
         $fieldTypeRegistry = $this->app->make(FieldTypeRegistry::class);
-        $relationFieldRegistry = $this->app->make(RelationFieldRegistry::class);
         $fieldTypeRegistry->register('select', FieldTypeDefinition::include(
             'noerd::components.forms.input-select',
             resolver: function (array $field, mixed $component, mixed $detailData, mixed $modelId): array {
@@ -301,33 +299,28 @@ class NoerdServiceProvider extends ServiceProvider
             ],
         ));
 
-        // Some project-level app-configs reference legal-register even when the
-        // module is not installed. Register the type so YAML stays explicit.
-        $relationFieldRegistry->register('lawRelation', RelationFieldDefinition::model(
-            listComponent: 'laws-list',
-            detailComponent: 'law-detail',
-            modelClass: 'Noerd\\LegalRegister\\Models\\Law',
-            titleResolver: 'title',
-        ));
-
         View::composer('noerd::layouts.app', function ($view): void {
             $view->with('showSidebar', !session('hide_sidebar'));
         });
 
-        // Publish public assets (fonts + built Vite assets)
-        $this->publishes([
-            __DIR__ . '/../../public' => public_path('vendor/noerd'),
-            __DIR__ . '/../../dist/build' => public_path('vendor/noerd'),
-        ], 'noerd-assets');
-
-        // Auto-publish fonts if not exists (for development convenience)
-        $this->publishFontsIfNotExists();
-
-        // Auto-publish built assets if not exists
-        $this->publishBuiltAssetsIfNotExist();
-
-        // Register commands
+        // Publishing runs ONLY in console: a live web request must never write
+        // to public/ (concurrent requests race on the copy, and a production
+        // public/ is typically not writable by the PHP user). noerd:install and
+        // noerd:update publish the assets explicitly; the auto-refresh below
+        // keeps a dev checkout current on any artisan invocation.
         if ($this->app->runningInConsole()) {
+            // Publish public assets (fonts + built Vite assets)
+            $this->publishes([
+                __DIR__ . '/../../public' => public_path('vendor/noerd'),
+                __DIR__ . '/../../dist/build' => public_path('vendor/noerd'),
+            ], 'noerd-assets');
+
+            // Auto-publish fonts if not exists (for development convenience)
+            $this->publishFontsIfNotExists();
+
+            // Auto-publish built assets if missing or stale
+            $this->publishBuiltAssetsIfNotExist();
+
             $this->commands([
                 MakeUserAdmin::class,
                 NoerdInfoCommand::class,

--- a/src/Traits/NoerdList.php
+++ b/src/Traits/NoerdList.php
@@ -725,7 +725,13 @@ trait NoerdList
         return $this->getName();
     }
 
-    public function updateRow(): void {}
+    /**
+     * Inline cell editing (editable list columns dispatch
+     * `updateRow(id, column, value)` via wire:change). The base implementation
+     * is a deliberate no-op — a list opts into persistence by overriding this
+     * method with the same signature.
+     */
+    public function updateRow(int|string|null $id = null, ?string $column = null, mixed $value = null): void {}
 
     #[Computed]
     public function tableFilters(): array

--- a/src/Traits/NoerdSettingsPage.php
+++ b/src/Traits/NoerdSettingsPage.php
@@ -3,6 +3,7 @@
 namespace Noerd\Traits;
 
 use Illuminate\Support\Str;
+use Noerd\Helpers\AccessHelper;
 use Noerd\Helpers\StaticConfigHelper;
 use Noerd\Helpers\TenantHelper;
 use RuntimeException;
@@ -39,6 +40,12 @@ trait NoerdSettingsPage
             return;
         }
 
+        if (!$this->canReadObject()) {
+            $this->objectReadBlocked = true;
+
+            return;
+        }
+
         $tenantId = TenantHelper::getSelectedTenantId();
 
         foreach ($this->settingsModelMap() as $property => $modelClass) {
@@ -54,11 +61,44 @@ trait NoerdSettingsPage
 
     public function store(): void
     {
+        // Server-side guard, mirroring NoerdDetail::store(): the save button is
+        // hidden for write-denied users, but store() stays reachable directly.
+        if (!$this->canWriteObject()) {
+            return;
+        }
+
         $this->validateFromLayout();
 
         $this->persistSettings();
 
         $this->showSuccessIndicator = true;
+    }
+
+    /**
+     * Object permission checks for a settings page cover EVERY declared
+     * tenant-singleton model — NoerdPage's checks key off $detailModel, which a
+     * settings page does not declare, and would therefore never restrict.
+     */
+    public function canReadObject(): bool
+    {
+        foreach ($this->settingsModelMap() as $modelClass) {
+            if (!AccessHelper::canReadObject($modelClass)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function canWriteObject(): bool
+    {
+        foreach ($this->settingsModelMap() as $modelClass) {
+            if (!AccessHelper::canWriteObject($modelClass)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/tests/Commands/NoerdInstallDemoPromptTest.php
+++ b/tests/Commands/NoerdInstallDemoPromptTest.php
@@ -78,6 +78,11 @@ class InstallFlowOrderFixtureCommand extends NoerdInstallCommand
         static::$steps[] = 'setupFrontendAssets';
     }
 
+    protected function publishNoerdAssets(): void
+    {
+        static::$steps[] = 'publishNoerdAssets';
+    }
+
     protected function runMigrationsAndSetupAdmin(): void
     {
         static::$steps[] = 'runMigrationsAndSetupAdmin';

--- a/tests/Commands/NoerdInstallNonInteractiveTest.php
+++ b/tests/Commands/NoerdInstallNonInteractiveTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Noerd\Commands\NoerdInstallCommand;
+use Noerd\Models\Tenant;
+use Noerd\Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+/*
+ | noerd:install must be safe under --no-interaction: prompts default to "yes"
+ | interactively, but a scripted run (CI, deploy) must NEVER inherit those
+ | defaults — migrations, npm build, admin setup and the demo app all require
+ | an explicit opt-in flag. Admin credentials cannot be prompted at all, so
+ | that step is always skipped with a pointer to noerd:create-admin.
+ */
+
+/**
+ * Fixture exposing the opt-in installation steps in isolation. Sub-commands
+ * are recorded instead of executed, so no migration/demo actually runs.
+ */
+class InstallNonInteractiveFixtureCommand extends NoerdInstallCommand
+{
+    /** @var array<int, string> */
+    public static array $calledCommands = [];
+
+    protected $signature = 'test:install-non-interactive
+                            {--force : Overwrite existing files}
+                            {--migrate : Run migrations without asking}
+                            {--build : Run npm build without asking}
+                            {--demo : Install the demo app without asking}';
+
+    public function handle()
+    {
+        $this->runMigrationsAndSetupAdmin();
+        $this->installDemoApp();
+
+        return 0;
+    }
+
+    public function call($command, array $arguments = [])
+    {
+        static::$calledCommands[] = $command;
+
+        return 0;
+    }
+}
+
+beforeEach(function (): void {
+    InstallNonInteractiveFixtureCommand::$calledCommands = [];
+    $this->app[Kernel::class]->registerCommand(new InstallNonInteractiveFixtureCommand());
+});
+
+it('skips migrations, admin setup and the demo app in a non-interactive run without flags', function (): void {
+    $this->artisan('test:install-non-interactive', ['--no-interaction' => true])
+        ->expectsOutputToContain('Non-interactive run: skipping migrations. Pass --migrate to run them.')
+        ->expectsOutputToContain('Non-interactive run: skipping the demo app. Pass --demo to install it.')
+        ->assertExitCode(0);
+
+    expect(InstallNonInteractiveFixtureCommand::$calledCommands)->toBeEmpty();
+});
+
+it('runs migrations non-interactively when --migrate is passed and still skips the admin prompts', function (): void {
+    // An existing tenant keeps the flow off the tenant-creation branch — this
+    // test asserts the migrate opt-in and the admin skip, nothing else.
+    Tenant::factory()->create();
+
+    $this->artisan('test:install-non-interactive', ['--migrate' => true, '--no-interaction' => true])
+        ->expectsOutputToContain('Non-interactive run: skipping admin setup.')
+        ->expectsOutputToContain('Non-interactive run: skipping the demo app. Pass --demo to install it.')
+        ->assertExitCode(0);
+
+    expect(InstallNonInteractiveFixtureCommand::$calledCommands)->toContain('migrate')
+        ->not->toContain('noerd:demo');
+});
+
+it('installs the demo app non-interactively only with the --demo flag', function (): void {
+    $this->artisan('test:install-non-interactive', ['--demo' => true, '--no-interaction' => true])
+        ->assertExitCode(0);
+
+    expect(InstallNonInteractiveFixtureCommand::$calledCommands)->toContain('noerd:demo');
+});
+
+it('still asks the demo question in interactive runs', function (): void {
+    $this->artisan('test:install-non-interactive')
+        ->expectsConfirmation('Would you like to run "php artisan migrate" now?')
+        ->expectsConfirmation('Would you like to install the Demo App?', 'yes')
+        ->assertExitCode(0);
+
+    expect(InstallNonInteractiveFixtureCommand::$calledCommands)->toContain('noerd:demo');
+});

--- a/tests/Feature/RelationFieldSelectionContextTest.php
+++ b/tests/Feature/RelationFieldSelectionContextTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Noerd\Models\NoerdUser;
+use Noerd\Services\RelationFieldRegistry;
+use Noerd\Support\RelationFieldDefinition;
+use Noerd\Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+describe('Relation field selection context', function (): void {
+
+    beforeEach(function (): void {
+        $this->actingAs(NoerdUser::factory()->adminUser()->withSelectedApp('setup')->create());
+
+        app(RelationFieldRegistry::class)->register('contextGuardRelation', RelationFieldDefinition::model(
+            listComponent: 'context-guards-list',
+            detailComponent: 'context-guard-detail',
+            modelClass: null,
+            titleResolver: 'name',
+        ));
+    });
+
+    $props = [
+        'relationType' => 'contextGuardRelation',
+        'fieldName' => 'detailData.guard_id',
+        'label' => 'Guard',
+    ];
+
+    it('adopts a selection dispatched with its own field name as context', function () use ($props): void {
+        Livewire::test('noerd-relation-field', $props + ['value' => 7])
+            ->dispatch('noerdRelationSelected', value: 42, context: 'detailData.guard_id')
+            ->assertSet('value', 42);
+    });
+
+    it('ignores a selection dispatched with an empty context', function () use ($props): void {
+        // A picker opened without a context dispatches NoerdList::$context's
+        // default (''). That selection belongs to a custom listActionMethod
+        // flow — it must never be adopted by every relation field on the page.
+        Livewire::test('noerd-relation-field', $props + ['value' => 7])
+            ->dispatch('noerdRelationSelected', value: 42, context: '')
+            ->assertSet('value', 7);
+    });
+
+    it('ignores a selection dispatched with no context at all', function () use ($props): void {
+        Livewire::test('noerd-relation-field', $props + ['value' => 7])
+            ->dispatch('noerdRelationSelected', value: 42)
+            ->assertSet('value', 7);
+    });
+
+    it('ignores a selection dispatched for another field', function () use ($props): void {
+        Livewire::test('noerd-relation-field', $props + ['value' => 7])
+            ->dispatch('noerdRelationSelected', value: 42, context: 'detailData.other_id')
+            ->assertSet('value', 7);
+    });
+});

--- a/tests/Feature/SettingsPageTraitTest.php
+++ b/tests/Feature/SettingsPageTraitTest.php
@@ -184,3 +184,33 @@ it('throws a clear error when settingsModels is not declared', function (): void
     expect(fn() => Livewire::test('zz-settings-undeclared-page'))
         ->toThrow('must declare its tenant-singleton models');
 });
+
+it('blocks reading when the object-read gate denies a declared settings model', function (): void {
+    Illuminate\Support\Facades\Gate::define(
+        Noerd\Helpers\AccessHelper::OBJECT_READ_GATE,
+        fn(?Illuminate\Contracts\Auth\Authenticatable $user, string $modelClass): bool => $modelClass !== NoerdSettings::class,
+    );
+
+    NoerdSettings::create(['tenant_id' => TenantHelper::getSelectedTenantId(), 'currency' => 'EUR']);
+
+    Livewire::test('zz-settings-test-page')
+        ->assertSet('objectReadBlocked', true)
+        ->assertSet('detailData', []);
+});
+
+it('ignores store() when the object-write gate denies a declared settings model', function (): void {
+    Illuminate\Support\Facades\Gate::define(
+        Noerd\Helpers\AccessHelper::OBJECT_WRITE_GATE,
+        fn(?Illuminate\Contracts\Auth\Authenticatable $user, string $modelClass): bool => $modelClass !== Profile::class,
+    );
+
+    $tenantId = TenantHelper::getSelectedTenantId();
+
+    Livewire::test('zz-settings-test-page')
+        ->set('detailData.currency', 'USD')
+        ->call('store')
+        ->assertSet('showSuccessIndicator', false);
+
+    expect(NoerdSettings::where('tenant_id', $tenantId)->exists())->toBeFalse()
+        ->and(Profile::where('tenant_id', $tenantId)->exists())->toBeFalse();
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,13 @@ declare(strict_types=1);
 
 namespace Noerd\Tests;
 
+// The global test helpers ship with the package but are NOT in the production
+// autoload (a consumer app must never load test functions per request). Loading
+// them here covers every context that runs noerd-based tests: the package's own
+// suite, host-root runs and submodule testbench suites — they all extend this
+// TestCase. Each helper is function_exists-guarded, so double-loading is safe.
+require_once __DIR__ . '/helpers.php';
+
 use Illuminate\Foundation\Testing\RefreshDatabaseState;
 use Illuminate\Support\Facades\File;
 use Livewire\Livewire;


### PR DESCRIPTION
Pre-release quality review, phase 1 of 7 — the release blockers.

## Packaging
- `tests/helpers.php` is no longer in the production composer autoload (six global test functions loaded into every consumer request). It moves to `autoload-dev`; `Noerd\Tests\TestCase` and the host's `tests/Pest.php` now require it, so every suite keeps the helpers. AGENTS.md, the Boost guideline and docs/testing.md updated.
- `symfony/polyfill-mbstring: ^1.32` + `ext-mbstring` are now explicit requirements — the package uses the PHP 8.4 `mb_trim`/`mb_ltrim`/`mb_rtrim` (34 call sites) on a `php: ^8.3` constraint and only worked through a transitive, un-pinned polyfill.
- composer.json gets a description, keywords, homepage and authors; a new `.gitattributes` keeps dist archives lean (tests specs, docs, CI excluded — `demo/`, `dist/` and the public test API stay in).

## Service provider
- Asset publishing (`noerd-assets` + the auto-publish of fonts and the built bundle) now runs only in console. A live web request no longer stats or writes `public/` — `noerd:install`/`noerd:update` publish explicitly via a new `publishNoerdAssets()` step.
- The `lawRelation` registration (hard reference to the optional `Noerd\LegalRegister\Models\Law`) and the `route: collections` → `cms.collections` rewrite in `StaticConfigHelper` are removed — core no longer references optional modules.

## noerd:install non-interactive
- `--no-interaction` no longer hangs in the `while(empty) ask()` admin loops and no longer inherits every destructive prompt default: migrations, npm build and the demo app each require an explicit `--migrate` / `--build` / `--demo` opt-in; admin setup is skipped with a pointer to `noerd:create-admin`, which `setupNewAdminUser()` now delegates to instead of re-implementing its prompts.

## Bug fixes
- `RelationFieldComponent::relationSelected()` now requires a strict context match — a picker opened without a context (`''`) no longer writes its selection into every relation field on the page (the polymorphic field already did this correctly).
- `NoerdList::updateRow()` declares its real `(id, column, value)` signature, so inline cell edits reach overrides instead of being silently discarded.
- `table-cell.blade.php` no longer throws an Alpine `ReferenceError` on every cell click (`activeColumn`/`selectedRow`/`show` were undefined leftovers) and the generic `deleteAction` confirm no longer says "delete your account?".
- `NoerdSettingsPage` now enforces the `noerd.object-read`/`object-write` gates across all declared settings models — `initSettings()` and `store()` previously skipped the guards `NoerdDetail` has.

## Tests
- New: `RelationFieldSelectionContextTest`, `NoerdInstallNonInteractiveTest`, object-gate coverage in `SettingsPageTraitTest`.
- Full package suite: 969 passed, 1 skipped.