### PR TITLE
Namespace all core route names under noerd.

### DIFF
--- a/app-configs/setup/lists/noerd-users-list.yml
+++ b/app-configs/setup/lists/noerd-users-list.yml
@@ -4,7 +4,7 @@ searchableColumns:
   - email
 actions:
   - label: New User
-    route: noerd-user.detail
+    route: noerd.user.detail
 disableSearch: false
 description: ''
 columns:

--- a/app-configs/setup/lists/setup-languages-list.yml
+++ b/app-configs/setup/lists/setup-languages-list.yml
@@ -1,7 +1,7 @@
 title: Languages
 actions:
   - label: New Language
-    route: setup-language.detail
+    route: noerd.setup-language.detail
 disableSearch: false
 columns:
   - field: code
@@ -20,4 +20,4 @@ columns:
     actions:
       - label: Edit
         heroicon: pencil-square
-        route: setup-language.detail
+        route: noerd.setup-language.detail

--- a/app-configs/setup/navigation.yml
+++ b/app-configs/setup/navigation.yml
@@ -1,28 +1,28 @@
 - title: Setup
   name: setup
   hidden: true
-  route: setup
+  route: noerd.setup
   block_menus:
     - title: Administration
       navigations:
         - title: Tenants
-          route: tenants
+          route: noerd.tenants
           heroicon: building-office
         - title: Apps
-          route: tenant-apps
+          route: noerd.tenant-apps
           heroicon: squares-2x2
           superAdmin: true
         - title: Users
-          route: users
+          route: noerd.users
           heroicon: users
         - title: Languages
-          route: setup-languages
+          route: noerd.setup-languages
           heroicon: language
         - title: System Settings
-          route: system-settings
+          route: noerd.system-settings
           heroicon: cog-6-tooth
         - title: Collection Definitions
-          route: setup-collection-definitions
+          route: noerd.setup-collection-definitions
           heroicon: rectangle-stack
           config: noerd.collections.show_definitions_ui
     - title: Data Management

--- a/database/migrations/2026_08_28_000000_rename_core_route_names_in_tenant_apps.php
+++ b/database/migrations/2026_08_28_000000_rename_core_route_names_in_tenant_apps.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * The core route names moved into the `noerd.` namespace (users → noerd.users,
+ * setup → noerd.setup, …) so the package no longer claims generic global names
+ * a host application may own. `tenant_apps.route` stores route names, so any
+ * row still pointing at an old core name is mapped to its namespaced successor.
+ */
+return new class extends Migration
+{
+    /** @var array<string, string> */
+    private array $renames = [
+        'setup' => 'noerd.setup',
+        'tenant-apps' => 'noerd.tenant-apps',
+        'users' => 'noerd.users',
+        'noerd-user.detail' => 'noerd.user.detail',
+        'tenants' => 'noerd.tenants',
+        'tenant.detail' => 'noerd.tenant.detail',
+        'create-tenant' => 'noerd.create-tenant',
+        'setup-collections' => 'noerd.setup-collections',
+        'setup-collection.detail' => 'noerd.setup-collection.detail',
+        'setup-collection-definitions' => 'noerd.setup-collection-definitions',
+        'setup-collection-definition.detail' => 'noerd.setup-collection-definition.detail',
+        'setup-languages' => 'noerd.setup-languages',
+        'setup-language.detail' => 'noerd.setup-language.detail',
+        'system-settings' => 'noerd.system-settings',
+        'noerd-apps' => 'noerd.apps',
+        'component-page' => 'noerd.component-page',
+        'no-tenant' => 'noerd.no-tenant',
+        'noerd-user' => 'noerd.profile',
+    ];
+
+    public function up(): void
+    {
+        if (! Schema::hasTable('tenant_apps')) {
+            return;
+        }
+
+        foreach ($this->renames as $old => $new) {
+            DB::table('tenant_apps')->where('route', $old)->update(['route' => $new]);
+        }
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('tenant_apps')) {
+            return;
+        }
+
+        foreach ($this->renames as $old => $new) {
+            DB::table('tenant_apps')->where('route', $new)->update(['route' => $old]);
+        }
+    }
+};

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -39,7 +39,7 @@ another user model), define the key in your `config/auth.php` and noerd will use
 
 noerd's core screens live under a configurable URL prefix (default `noerd`, set via
 `config('noerd.routes.prefix')` / `NOERD_ROUTE_PREFIX`): `/noerd/login`, `/noerd/forgot-password`,
-`/noerd/reset-password/{token}`, `/noerd/user` (route name `noerd-user`), `/noerd/no-tenant`,
+`/noerd/reset-password/{token}`, `/noerd/user` (route name `noerd.profile`), `/noerd/no-tenant`,
 `/noerd/component-page/{componentName}`. Only the URLs carry the prefix — the route names are
 stable and unaffected by a prefix change. The `/setup` area keeps its own prefix, and the apps
 dashboard stays at `/noerd-apps` (already namespaced, and the address the installer prints).
@@ -68,7 +68,7 @@ generates routes with the `noerd` group.
 
 `Noerd\Middleware\NoerdAuthenticate` extends Laravel's `Authenticate` and pins the guest redirect
 to `route('noerd.login')`; `Noerd\Middleware\NoerdRedirectIfAuthenticated` extends
-`RedirectIfAuthenticated` and pins the authenticated redirect to `route('noerd-apps')`. Neither the
+`RedirectIfAuthenticated` and pins the authenticated redirect to `route('noerd.apps')`. Neither the
 host's `auth`/`guest` middleware aliases nor globally registered `redirectUsing()` callbacks (e.g.
 from a starter kit's `bootstrap/app.php`) apply to noerd routes — the two stacks never redirect
 into each other.

--- a/resources/views/components/auth/login.blade.php
+++ b/resources/views/components/auth/login.blade.php
@@ -42,7 +42,7 @@ new #[Layout('noerd::layouts.auth')] class extends Component {
 
         NoerdAuth::user()->update(['last_login_at' => now()]);
 
-        $this->redirect(session()->pull('url.intended', route('noerd-apps', absolute: false)), navigate: false);
+        $this->redirect(session()->pull('url.intended', route('noerd.apps', absolute: false)), navigate: false);
     }
 
     /**

--- a/resources/views/components/layout/sidebar-navigation-button.blade.php
+++ b/resources/views/components/layout/sidebar-navigation-button.blade.php
@@ -7,7 +7,7 @@ new class extends Component {
 } ?>
 
 @php
-    $routeName = ($navi['route'] ?? null) === 'collections' ? 'cms.collections' : ($navi['route'] ?? '');
+    $routeName = $navi['route'] ?? '';
     $isActive = isset($navi['link'])
         ? request()->is(ltrim($navi['link'], '/'))
         : request()->routeIs($routeName);

--- a/resources/views/components/layout/sidebar-navigation-element.blade.php
+++ b/resources/views/components/layout/sidebar-navigation-element.blade.php
@@ -19,7 +19,7 @@ new class extends Component {
     // The primary `route:` may belong to an optional module. A stale navigation
     // entry must never take the whole page down, so a route-only entry whose
     // route is not registered is skipped entirely.
-    $routeName = ($navi['route'] ?? null) === 'collections' ? 'cms.collections' : ($navi['route'] ?? '');
+    $routeName = $navi['route'] ?? '';
     $routeExists = $routeName !== '' && \Illuminate\Support\Facades\Route::has($routeName);
     $hasTarget = isset($navi['link']) || $opensAsModal || $routeExists;
 @endphp

--- a/resources/views/components/layout/sidebar.blade.php
+++ b/resources/views/components/layout/sidebar.blade.php
@@ -7,7 +7,7 @@ new class extends Component {
     public function openHome(): void
     {
         TenantHelper::setSelectedApp('noerd-apps');
-        $this->redirect(route('noerd-apps'), navigate: true);
+        $this->redirect(route('noerd.apps'), navigate: true);
     }
 
     public function openSidebar(): void

--- a/resources/views/components/layout/tenant-switcher.blade.php
+++ b/resources/views/components/layout/tenant-switcher.blade.php
@@ -93,7 +93,7 @@ new class extends Component {
 
         @if($canCreateTenant)
             <div class="my-1 border-t border-gray-100"></div>
-            <a wire:navigate href="{{ route('create-tenant') }}"
+            <a wire:navigate href="{{ route('noerd.create-tenant') }}"
                class="flex items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
                role="menuitem">
                 <svg class="h-4 w-4 shrink-0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">

--- a/resources/views/components/layout/top-bar.blade.php
+++ b/resources/views/components/layout/top-bar.blade.php
@@ -92,7 +92,7 @@ new class extends Component {
                     @endforeach
 
                     @if(auth()->user()->isAdmin())
-                        <a class="shrink-0" wire:navigate href="{{route('setup')}}">
+                        <a class="shrink-0" wire:navigate href="{{route('noerd.setup')}}">
                             <x-noerd::button variant="icon" icon="cog-6-tooth" type="button">
                                 <span class="sr-only">View setup</span>
                             </x-noerd::button>
@@ -117,7 +117,7 @@ new class extends Component {
                              class="absolute right-0 z-90 mt-2 w-48 origin-top-right rounded-md bg-white py-1 shadow-lg ring-1 ring-black/5 focus:outline-hidden"
                              role="menu" aria-orientation="vertical" aria-labelledby="user-menu-button"
                              tabindex="-1">
-                            <a wire:navigate href="{{route('noerd-user')}}" class="block px-4 py-2 text-sm text-gray-700"
+                            <a wire:navigate href="{{route('noerd.profile')}}" class="block px-4 py-2 text-sm text-gray-700"
                                role="menuitem"
                                tabindex="-1" id="user-menu-item-0">{{__('Profile')}}</a>
 

--- a/resources/views/components/noerd-users-list.blade.php
+++ b/resources/views/components/noerd-users-list.blade.php
@@ -15,7 +15,7 @@ new class () extends Component {
     public const DETAIL_COMPONENT = 'noerd::noerd-users-list';
 
     public $listModel = NoerdUser::class;
-    public ?string $detailRoute = 'noerd-user.detail';
+    public ?string $detailRoute = 'noerd.user.detail';
 
     public function mount(): void
     {

--- a/resources/views/components/profile/update-profile-information-form.blade.php
+++ b/resources/views/components/profile/update-profile-information-form.blade.php
@@ -48,7 +48,7 @@ new class extends Component {
         $user = Auth::user();
 
         if ($user->hasVerifiedEmail()) {
-            $path = session('url.intended', route('noerd-apps'));
+            $path = session('url.intended', route('noerd.apps'));
 
             $this->redirect($path);
 

--- a/resources/views/components/setup-collection-definitions-list.blade.php
+++ b/resources/views/components/setup-collection-definitions-list.blade.php
@@ -12,7 +12,7 @@ new class extends Component
 {
     use NoerdList;
 
-    public ?string $detailRoute = 'setup-collection-definition.detail';
+    public ?string $detailRoute = 'noerd.setup-collection-definition.detail';
 
 
     public function mount(): void

--- a/resources/views/components/setup-collections-list.blade.php
+++ b/resources/views/components/setup-collections-list.blade.php
@@ -16,7 +16,7 @@ new class extends Component
     use SetupLanguageFilterTrait;
 
     public $listModel = SetupCollectionEntry::class;
-    public ?string $detailRoute = 'setup-collection.detail';
+    public ?string $detailRoute = 'noerd.setup-collection.detail';
 
     public string|int|null $collectionKey = null;
 
@@ -62,7 +62,7 @@ new class extends Component
 
     public function listAction(mixed $modelId = null, array $relations = []): void
     {
-        Noerd::modalFor('setup-collection.detail', 'noerd::setup-collection-detail', ['modelId' => $modelId, 'collectionKey' => $this->collectionKey, 'relations' => $relations]);
+        Noerd::modalFor('noerd.setup-collection.detail', 'noerd::setup-collection-detail', ['modelId' => $modelId, 'collectionKey' => $this->collectionKey, 'relations' => $relations]);
     }
 
     public function listData(): array

--- a/resources/views/components/setup-languages-list.blade.php
+++ b/resources/views/components/setup-languages-list.blade.php
@@ -9,7 +9,7 @@ new class extends Component
     use NoerdList;
 
     public $listModel = SetupLanguage::class;
-    public ?string $detailRoute = 'setup-language.detail';
+    public ?string $detailRoute = 'noerd.setup-language.detail';
 
     public function mount(): void
     {

--- a/resources/views/components/tabs.blade.php
+++ b/resources/views/components/tabs.blade.php
@@ -96,7 +96,7 @@
                             @php
                                 $tabArguments = isset($tab['arguments']) ? $resolveArguments($tab['arguments']) : [];
                                 $isRoutable = ! empty($tab['routable']);
-                                $tabRoute = $isRoutable ? 'component-page' : null;
+                                $tabRoute = $isRoutable ? 'noerd.component-page' : null;
                                 $tabRouteParameters = $isRoutable
                                     ? array_merge(['componentName' => $tab['component']], $tabArguments)
                                     : [];

--- a/resources/views/components/tenants-list.blade.php
+++ b/resources/views/components/tenants-list.blade.php
@@ -10,7 +10,7 @@ new class extends Component {
 
     public $listModel = Tenant::class;
 
-    public ?string $detailRoute = 'tenant.detail';
+    public ?string $detailRoute = 'noerd.tenant.detail';
 
     public $detailComponent = 'noerd::tenant-detail';
 

--- a/routes/noerd-routes.php
+++ b/routes/noerd-routes.php
@@ -3,48 +3,50 @@
 use Illuminate\Support\Facades\Route;
 
 // Every setup page lives under /setup. Route NAMES are the public contract
-// (navigation.yml `route:` keys, tenant_apps.route, route() calls) and stay
-// unprefixed — only the URLs carry the prefix, so the redundant `setup-` in
-// paths like `setup-collections` is dropped in favour of the group prefix.
+// (navigation.yml `route:` keys, tenant_apps.route, route() calls) and are all
+// namespaced under `noerd.` — a host application or another package may own
+// generic names like `users` or `tenants`, and a collision would silently
+// corrupt route:cache (last registration wins). URLs drop the redundant
+// `setup-` in favour of the group prefix.
 Route::group(['prefix' => 'setup', 'middleware' => ['noerd', 'setup']], function (): void {
-    Route::livewire('/', 'noerd::noerd-users-list')->name('setup');
-    Route::livewire('tenant-apps', 'noerd::tenant-apps-list')->name('tenant-apps');
-    Route::livewire('users', 'noerd::noerd-users-list')->name('users');
-    Route::livewire('noerd-user/{modelId}', 'noerd::noerd-user-detail')->name('noerd-user.detail');
-    Route::livewire('tenants', 'noerd::tenants-list')->name('tenants');
-    Route::livewire('tenant/{modelId}', 'noerd::tenant-detail')->name('tenant.detail');
-    Route::livewire('create-tenant', 'noerd::create-tenant')->name('create-tenant');
-    Route::livewire('collections', 'noerd::setup-collections-list')->name('setup-collections');
-    Route::livewire('collection/{modelId}', 'noerd::setup-collection-detail')->name('setup-collection.detail');
+    Route::livewire('/', 'noerd::noerd-users-list')->name('noerd.setup');
+    Route::livewire('tenant-apps', 'noerd::tenant-apps-list')->name('noerd.tenant-apps');
+    Route::livewire('users', 'noerd::noerd-users-list')->name('noerd.users');
+    Route::livewire('noerd-user/{modelId}', 'noerd::noerd-user-detail')->name('noerd.user.detail');
+    Route::livewire('tenants', 'noerd::tenants-list')->name('noerd.tenants');
+    Route::livewire('tenant/{modelId}', 'noerd::tenant-detail')->name('noerd.tenant.detail');
+    Route::livewire('create-tenant', 'noerd::create-tenant')->name('noerd.create-tenant');
+    Route::livewire('collections', 'noerd::setup-collections-list')->name('noerd.setup-collections');
+    Route::livewire('collection/{modelId}', 'noerd::setup-collection-detail')->name('noerd.setup-collection.detail');
     Route::livewire('collection-definitions', 'noerd::setup-collection-definitions-list')
         ->middleware('setup.collections.ui')
-        ->name('setup-collection-definitions');
+        ->name('noerd.setup-collection-definitions');
     Route::livewire('collection-definition/{modelId}', 'noerd::setup-collection-definition-detail')
         ->middleware('setup.collections.ui')
-        ->name('setup-collection-definition.detail');
-    Route::livewire('languages', 'noerd::setup-languages-list')->name('setup-languages');
-    Route::livewire('language/{modelId}', 'noerd::setup-language-detail')->name('setup-language.detail');
-    Route::livewire('system-settings', 'noerd::system-settings-page')->name('system-settings');
+        ->name('noerd.setup-collection-definition.detail');
+    Route::livewire('languages', 'noerd::setup-languages-list')->name('noerd.setup-languages');
+    Route::livewire('language/{modelId}', 'noerd::setup-language-detail')->name('noerd.setup-language.detail');
+    Route::livewire('system-settings', 'noerd::system-settings-page')->name('noerd.system-settings');
 });
 
 // Every other core screen lives under the configurable URL prefix (default
 // /noerd) so a host application — e.g. one generated from a Laravel starter
-// kit — keeps its own /login, /dashboard etc. Route names stay stable; the
-// auth routes are namespaced (noerd.login, noerd.password.*) so the package
-// never claims the starter-kit route names (they would break route:cache).
+// kit — keeps its own /login, /dashboard etc. Route names are namespaced
+// (noerd.*) so the package never claims host route names (they would break
+// route:cache).
 $prefix = config('noerd.routes.prefix', 'noerd');
 
 // The apps dashboard deliberately stays at its unprefixed URL — /noerd-apps
 // is already namespaced and is the address users know from the installer.
 Route::group(['middleware' => ['noerd']], function (): void {
-    Route::livewire('noerd-apps', 'noerd::noerd-apps')->name('noerd-apps');
+    Route::livewire('noerd-apps', 'noerd::noerd-apps')->name('noerd.apps');
 });
 
 Route::group(['prefix' => $prefix, 'middleware' => ['noerd']], function (): void {
-    Route::livewire('component-page/{componentName}', 'noerd::generic-component-page')->name('component-page');
+    Route::livewire('component-page/{componentName}', 'noerd::generic-component-page')->name('noerd.component-page');
     Route::redirect('home', '/noerd-apps');
-    Route::livewire('no-tenant', 'noerd::no-tenant')->name('no-tenant');
-    Route::view('user', 'noerd::profile')->name('noerd-user');
+    Route::livewire('no-tenant', 'noerd::no-tenant')->name('noerd.no-tenant');
+    Route::view('user', 'noerd::profile')->name('noerd.profile');
 });
 
 Route::group(['prefix' => $prefix, 'middleware' => ['noerd-guest']], function (): void {

--- a/src/Middleware/NoerdRedirectIfAuthenticated.php
+++ b/src/Middleware/NoerdRedirectIfAuthenticated.php
@@ -15,6 +15,6 @@ class NoerdRedirectIfAuthenticated extends RedirectIfAuthenticated
 {
     protected function redirectTo(Request $request): ?string
     {
-        return route('noerd-apps');
+        return route('noerd.apps');
     }
 }

--- a/src/Middleware/SetupMiddleware.php
+++ b/src/Middleware/SetupMiddleware.php
@@ -22,7 +22,7 @@ class SetupMiddleware
             $firstTenantId = $user->tenants->first()?->id;
 
             if (! $firstTenantId) {
-                return redirect()->route('no-tenant');
+                return redirect()->route('noerd.no-tenant');
             }
 
             TenantHelper::setSelectedTenantId($firstTenantId);

--- a/src/Navigation/SetupCollectionsNavigationProvider.php
+++ b/src/Navigation/SetupCollectionsNavigationProvider.php
@@ -29,7 +29,7 @@ class SetupCollectionsNavigationProvider implements DynamicNavigationProviderCon
         return $this->repository->all()
             ->map(fn(SetupCollectionDefinitionData $d) => [
                 'title' => $d->titleList,
-                'link' => route('setup-collections', ['key' => $d->filename], absolute: false),
+                'link' => route('noerd.setup-collections', ['key' => $d->filename], absolute: false),
                 'heroicon' => 'archive-box',
             ])
             ->values()

--- a/tests/Feature/DirectDetailRoutesTest.php
+++ b/tests/Feature/DirectDetailRoutesTest.php
@@ -8,13 +8,13 @@ use Noerd\Tests\TestCase;
 uses(TestCase::class);
 
 it('has direct route for noerd-user-detail', function (): void {
-    expect(Route::has('noerd-user.detail'))->toBeTrue();
+    expect(Route::has('noerd.user.detail'))->toBeTrue();
 });
 
 it('has direct route for setup-collection-detail', function (): void {
-    expect(Route::has('setup-collection.detail'))->toBeTrue();
+    expect(Route::has('noerd.setup-collection.detail'))->toBeTrue();
 });
 
 it('has direct route for setup-language-detail', function (): void {
-    expect(Route::has('setup-language.detail'))->toBeTrue();
+    expect(Route::has('noerd.setup-language.detail'))->toBeTrue();
 });

--- a/tests/Feature/GenericComponentPageTest.php
+++ b/tests/Feature/GenericComponentPageTest.php
@@ -10,18 +10,18 @@ use Noerd\Tests\TestCase;
 uses(TestCase::class, RefreshDatabase::class);
 
 it('registers the generic component-page route', function (): void {
-    expect(Route::has('component-page'))->toBeTrue();
+    expect(Route::has('noerd.component-page'))->toBeTrue();
 });
 
 it('aborts with 404 when the component name has no module namespace', function (): void {
     $user = NoerdUser::factory()->withExampleTenant()->create();
 
     $this->actingAs($user)
-        ->get(route('component-page', ['componentName' => 'some-local-component']))
+        ->get(route('noerd.component-page', ['componentName' => 'some-local-component']))
         ->assertNotFound();
 });
 
 it('requires authentication', function (): void {
-    $this->get(route('component-page', ['componentName' => 'noerd::dashboard']))
+    $this->get(route('noerd.component-page', ['componentName' => 'noerd::dashboard']))
         ->assertRedirect(route('noerd.login'));
 });

--- a/tests/Feature/NoerdGuardTest.php
+++ b/tests/Feature/NoerdGuardTest.php
@@ -106,7 +106,7 @@ describe('login flow', function (): void {
         $user = NoerdUser::factory()->create();
         $this->actingAs($user, 'noerd');
 
-        $this->get(route('noerd.login'))->assertRedirect(route('noerd-apps'));
+        $this->get(route('noerd.login'))->assertRedirect(route('noerd.apps'));
     });
 });
 

--- a/tests/Feature/RoutePrefixCustomTest.php
+++ b/tests/Feature/RoutePrefixCustomTest.php
@@ -22,7 +22,7 @@ uses(RoutePrefixCustomTestCase::class);
 
 it('applies a custom prefix from the config to the core routes', function (): void {
     expect(route('noerd.login', absolute: false))->toBe('/backend/login')
-        ->and(route('noerd-user', absolute: false))->toBe('/backend/user');
+        ->and(route('noerd.profile', absolute: false))->toBe('/backend/user');
 });
 
 it('points the /login alias at the custom prefix', function (): void {
@@ -30,6 +30,6 @@ it('points the /login alias at the custom prefix', function (): void {
 });
 
 it('keeps the setup area and the apps dashboard outside the custom prefix', function (): void {
-    expect(route('setup', absolute: false))->toBe('/setup')
-        ->and(route('noerd-apps', absolute: false))->toBe('/noerd-apps');
+    expect(route('noerd.setup', absolute: false))->toBe('/setup')
+        ->and(route('noerd.apps', absolute: false))->toBe('/noerd-apps');
 });

--- a/tests/Feature/RoutePrefixTest.php
+++ b/tests/Feature/RoutePrefixTest.php
@@ -20,14 +20,14 @@ describe('core route URL prefix', function (): void {
         ['noerd.login', '/noerd/login'],
         ['noerd.password.request', '/noerd/forgot-password'],
         ['noerd.password.reset', '/noerd/reset-password'],
-        ['noerd-user', '/noerd/user'],
-        ['no-tenant', '/noerd/no-tenant'],
-        ['component-page', '/noerd/component-page'],
+        ['noerd.profile', '/noerd/user'],
+        ['noerd.no-tenant', '/noerd/no-tenant'],
+        ['noerd.component-page', '/noerd/component-page'],
     ]);
 
     it('keeps the setup area and the apps dashboard outside the prefix', function (): void {
-        expect(route('setup', absolute: false))->toBe('/setup')
-            ->and(route('noerd-apps', absolute: false))->toBe('/noerd-apps');
+        expect(route('noerd.setup', absolute: false))->toBe('/setup')
+            ->and(route('noerd.apps', absolute: false))->toBe('/noerd-apps');
     });
 
     it('redirects the /login alias to the prefixed login route', function (): void {
@@ -42,6 +42,12 @@ describe('starter-kit coexistence contract', function (): void {
         expect(Route::has($name))->toBeFalse();
     })->with(['login', 'dashboard', 'profile', 'password.request', 'password.reset', 'home']);
 
+    // The same applies to generic host names the core used to claim before its
+    // routes were namespaced under `noerd.` — they must stay free for hosts.
+    it('does not register generic global route names', function (string $name): void {
+        expect(Route::has($name))->toBeFalse();
+    })->with(['users', 'tenants', 'setup', 'tenant-apps', 'system-settings', 'no-tenant', 'component-page', 'create-tenant']);
+
     it('does not claim the /dashboard and /profile URIs', function (): void {
         $routes = collect(Route::getRoutes()->get('GET'));
 
@@ -53,13 +59,13 @@ describe('starter-kit coexistence contract', function (): void {
 
 describe('auth redirects', function (): void {
     it('sends guests on noerd routes to the noerd login', function (): void {
-        $this->get(route('noerd-apps'))->assertRedirect(route('noerd.login'));
+        $this->get(route('noerd.apps'))->assertRedirect(route('noerd.login'));
     });
 
     it('sends authenticated users on guest routes to the apps dashboard', function (): void {
         $this->actingAs(NoerdUser::factory()->create(), 'noerd');
 
-        $this->get(route('noerd.login'))->assertRedirect(route('noerd-apps'));
+        $this->get(route('noerd.login'))->assertRedirect(route('noerd.apps'));
     });
 });
 

--- a/tests/Feature/SetupCollectionDefinitionTest.php
+++ b/tests/Feature/SetupCollectionDefinitionTest.php
@@ -60,7 +60,7 @@ it('dispatches modal when listAction is called', function (): void {
         ->call('listAction', 'expense_categories')
         ->assertDispatched(
             'noerdModal',
-            fn(string $event, array $params): bool => ($params['route'] ?? null) === 'setup-collection-definition.detail'
+            fn(string $event, array $params): bool => ($params['route'] ?? null) === 'noerd.setup-collection-definition.detail'
                 && ($params['arguments']['modelId'] ?? null) === 'expense_categories',
         );
 });

--- a/tests/Feature/SidebarUnregisteredRouteTest.php
+++ b/tests/Feature/SidebarUnregisteredRouteTest.php
@@ -35,14 +35,14 @@ it('renders the page and hides entries whose route is not registered', function 
   title: Setup
   name: setup
   hidden: true
-  route: setup
+  route: noerd.setup
   block_menus:
     -
       title: Administration
       navigations:
         -
           title: 'Zz Valid Entry'
-          route: users
+          route: noerd.users
           heroicon: users
         -
           title: 'Zz Stale Entry'

--- a/tests/Feature/TopBarSidebarToggleTest.php
+++ b/tests/Feature/TopBarSidebarToggleTest.php
@@ -62,7 +62,7 @@ it('shows the app bar again without touching the navigation', function (): void 
 it('opens home via the sidebar home shortcut', function (): void {
     Livewire::test('noerd::layout.sidebar')
         ->call('openHome')
-        ->assertRedirect(route('noerd-apps'));
+        ->assertRedirect(route('noerd.apps'));
 
     expect(session('noerd.selected_app'))->toBe('noerd-apps');
 });

--- a/tests/Helpers/StaticConfigHelperTest.php
+++ b/tests/Helpers/StaticConfigHelperTest.php
@@ -100,10 +100,10 @@ it('hides feature-gated navigation items when the config value is false', functi
       navigations:
         -
           title: 'Zz Ungated Entry'
-          route: setup
+          route: noerd.setup
         -
           title: 'Zz Gated Entry'
-          route: setup
+          route: noerd.setup
           config: noerd.testing.synthetic_gate
 YAML);
 


### PR DESCRIPTION
Pre-release quality review, phase 2 of 7.

Route NAMES are the public contract (navigation.yml `route:` keys, `tenant_apps.route`, `route()` calls), and the core claimed generic global names — `users`, `tenants`, `setup`, `system-settings`, `component-page`, … A host application or third-party package owning any of those names collides silently: `route:cache` keeps whichever registration wins last. The auth routes were already namespaced (`noerd.login`, `noerd.password.*`) for exactly this reason; this PR applies the same rule to every remaining core route before the public release makes the names a compatibility promise.

- All core routes now live under `noerd.` (`noerd.users`, `noerd.tenants`, `noerd.setup`, `noerd.user.detail`, `noerd.apps`, `noerd.profile`, …). **URLs are unchanged** — `/setup/...`, `/noerd-apps` and the `/noerd` prefix stay as they were.
- Every `route()` call site, `$detailRoute` declaration, and the setup navigation/list YAMLs are updated; `docs/auth.md` follows.
- A new migration maps existing `tenant_apps.route` values from the old names to their namespaced successors (and back in `down()`).
- The starter-kit coexistence test now also proves the generic names (`users`, `tenants`, `setup`, …) stay free for hosts.
- The two remaining copies of the dead `route: collections` → `cms.collections` rewrite in the sidebar blades are removed (same root as the `StaticConfigHelper` cleanup in #43; nothing references `route: collections` anymore).

Host projects consuming this version need `noerd:update` (refreshes the published setup YAMLs) and `php artisan migrate` (maps `tenant_apps.route`); their own `route('...')` calls to old core names must be updated.

Full package suite: 967 passed, 1 skipped.