### PR TITLE
Cut avoidable queries from the list render path and the request lifecycle

### DIFF
--- a/resources/views/components/noerd-user-detail.blade.php
+++ b/resources/views/components/noerd-user-detail.blade.php
@@ -77,17 +77,24 @@ new class extends Component {
 
         $this->detailData = $user->toArray();
 
+        // One query for the edited user's tenant assignments instead of one
+        // per admin tenant. Mounts re-run on every modal-stack update, so this
+        // loop must stay cheap.
+        $profileByTenant = $user->exists
+            ? $user->tenants->mapWithKeys(fn($tenant) => [$tenant->id => $tenant->pivot->profile_id])->all()
+            : [];
+
         foreach (auth()->user()->adminTenants as $tenant) {
             $this->possibleTenants[$tenant->id] = $tenant->toArray();
-            $userProfile = $tenant->users()->where('user_id', $user->id)->first();
-            $profileId = $userProfile?->pivot->profile_id;
+            $profileId = $profileByTenant[$tenant->id] ?? null;
 
             $this->possibleTenants[$tenant->id]['selectedProfile'] = $profileId;
             $hasAccess = (bool) $profileId;
             $this->possibleTenants[$tenant->id]['hasAccess'] = $hasAccess;
 
             if (! $hasAccess) {
-                $this->possibleTenants[$tenant->id]['selectedProfile'] = $tenant->profiles->first()->id;
+                // A tenant without any profile row simply offers no preselect.
+                $this->possibleTenants[$tenant->id]['selectedProfile'] = $tenant->profiles->first()?->id;
             }
         }
     }

--- a/resources/views/components/table/list-controls.blade.php
+++ b/resources/views/components/table/list-controls.blade.php
@@ -43,7 +43,7 @@
                         @blur="searchFocused = false"
                         @keydown.escape="$refs.searchInput.blur()"
                         placeholder="{{ __('Search') }}"
-                        wire:model.live="search"
+                        wire:model.live.debounce.300ms="search"
                         type="text"
                         class="!mt-0 mb-3 h-8 min-w-[200px] pr-8 lg:mb-0"
                     />

--- a/resources/views/components/table/list-header.blade.php
+++ b/resources/views/components/table/list-header.blade.php
@@ -54,11 +54,11 @@
         </div>
 
         @php
-            $activeColumnFilterChips = $this->activeColumnFilterChips();
+            $activeColumnFilterChips = $this->activeColumnFilterChips;
         @endphp
-        @if ($this->tableFilters() || $activeColumnFilterChips !== [])
+        @if ($this->tableFilters || $activeColumnFilterChips !== [])
             <div class="ml-4 flex flex-wrap items-center gap-1">
-                @foreach ($this->tableFilters() as $tableFilter)
+                @foreach ($this->tableFilters as $tableFilter)
                     @if (in_array($tableFilter['type'] ?? 'Picklist', ['ShowFrom', 'ShowUntil']))
                         <x-noerd::filters.date-dropdown
                             :filter="$tableFilter"

--- a/resources/views/components/table/table-build.blade.php
+++ b/resources/views/components/table/table-build.blade.php
@@ -51,7 +51,7 @@
                         'relations' => $relations ?? [],
                         'action' => $action ?? $componentAction,
                         'states' => $this->states(),
-                        'tableFilters' => $this->tableFilters(),
+                        'tableFilters' => $this->tableFilters,
                     ])
             </div>
         @endif

--- a/src/Helpers/StaticConfigHelper.php
+++ b/src/Helpers/StaticConfigHelper.php
@@ -266,6 +266,24 @@ class StaticConfigHelper
             return null;
         }
 
+        // Memoized per request: the layout injects the navigation from several
+        // views (app bar, sidebar, top bar), and building it runs the dynamic
+        // providers (collection YAML globbing) plus a Route::has() per entry.
+        // Keyed by the runtime context — app, tenant and user all shape the
+        // filtered result.
+        $cacheKey = 'navigation.' . self::runtimeContextKey();
+        if (array_key_exists($cacheKey, self::$runtimeCache)) {
+            return self::$runtimeCache[$cacheKey];
+        }
+
+        return self::$runtimeCache[$cacheKey] = self::buildNavigationStructure($currentApp);
+    }
+
+    /**
+     * @see getNavigationStructure()
+     */
+    private static function buildNavigationStructure(string $currentApp): ?array
+    {
         $yamlPath = base_path("app-configs/{$currentApp}/navigation.yml");
 
         if (!file_exists($yamlPath)) {
@@ -454,17 +472,22 @@ class StaticConfigHelper
     /**
      * Parse a YAML file through the mtime-guarded cache: an edited file (dev,
      * test fixtures) is re-parsed, an unchanged one is parsed once per process.
+     * Public so other YAML readers (e.g. the collection definition repository)
+     * share the same cache instead of re-parsing per call.
      */
-    private static function parseYamlFile(string $path): array
+    public static function parseYamlFile(string $path): array
     {
-        $mtime = @filemtime($path) ?: 0;
+        // mtime alone misses a rewrite within the same second (runtime-written
+        // test fixtures above all) — the size catches practically all of those.
+        $stat = @stat($path);
+        $version = $stat ? $stat['mtime'] . ':' . $stat['size'] : '0';
         $entry = self::$yamlCache[$path] ?? null;
-        if ($entry !== null && $entry[0] === $mtime) {
+        if ($entry !== null && $entry[0] === $version) {
             return $entry[1];
         }
 
         $parsed = Yaml::parse(file_get_contents($path) ?: '') ?: [];
-        self::$yamlCache[$path] = [$mtime, $parsed];
+        self::$yamlCache[$path] = [$version, $parsed];
 
         return $parsed;
     }
@@ -496,11 +519,8 @@ class StaticConfigHelper
         return self::$runtimeCache[$cacheKey] ??= (function (): array {
             $labels = ['setup' => __('Setup')];
 
-            $tenant = TenantHelper::getSelectedTenant();
-            if ($tenant) {
-                foreach ($tenant->tenantApps()->pluck('title', 'name') as $name => $title) {
-                    $labels[mb_strtolower((string) $name)] = (string) $title;
-                }
+            foreach (self::tenantAppRows()->pluck('title', 'name') as $name => $title) {
+                $labels[mb_strtolower((string) $name)] = (string) $title;
             }
 
             return $labels;
@@ -658,24 +678,32 @@ class StaticConfigHelper
         $cacheKey = 'allowedFolders.' . (TenantHelper::getSelectedTenantId() ?? 0) . '.' . (NoerdAuth::id() ?? 0);
 
         return self::$runtimeCache[$cacheKey] ??= (function (): array {
-            $tenant = TenantHelper::getSelectedTenant();
-            if (!$tenant) {
-                return ['setup'];
-            }
-
-            $tenantAppNames = $tenant->tenantApps()->pluck('name')->toArray();
-
             // 'setup' is never filtered — its routes are admin-gated by the
             // setup middleware anyway.
             $allowedFolders = ['setup'];
-            foreach ($tenantAppNames as $appName) {
+            foreach (self::tenantAppRows()->pluck('name') as $appName) {
                 if (AccessHelper::canAccessApp($appName)) {
-                    $allowedFolders[] = mb_strtolower($appName);
+                    $allowedFolders[] = mb_strtolower((string) $appName);
                 }
             }
 
             return $allowedFolders;
         })();
+    }
+
+    /**
+     * The selected tenant's active app rows, fetched ONCE per request — the
+     * allowed folders and the app labels both derive from this collection
+     * instead of issuing their own tenantApps() queries.
+     *
+     * @return \Illuminate\Support\Collection<int, TenantApp>
+     */
+    private static function tenantAppRows(): \Illuminate\Support\Collection
+    {
+        $cacheKey = 'tenantAppRows.' . (TenantHelper::getSelectedTenantId() ?? 0);
+
+        return self::$runtimeCache[$cacheKey]
+            ??= TenantHelper::getSelectedTenant()?->tenantApps()->get() ?? collect();
     }
 
     /**

--- a/src/Helpers/TenantHelper.php
+++ b/src/Helpers/TenantHelper.php
@@ -8,6 +8,16 @@ use Noerd\Models\TenantApp;
 class TenantHelper
 {
     /**
+     * Request memo for getSelectedTenant(): the selected tenant is read from a
+     * dozen call sites per render (config discovery, middleware, blades) and
+     * Tenant::find() has no identity map. Flushed by the provider's booted()
+     * hook and whenever the selection changes.
+     *
+     * @var array<int, Tenant|null>
+     */
+    private static array $tenantMemo = [];
+
+    /**
      * The tenant the current request operates in — the SINGLE source both the
      * tenant scope and the tenant stamp read, so a record is never written with a
      * different tenant than the one it is later filtered by.
@@ -82,6 +92,7 @@ class TenantHelper
     public static function setSelectedTenantId(?int $tenantId): void
     {
         session(['noerd.selected_tenant_id' => $tenantId]);
+        self::clearCache();
 
         if (NoerdAuth::check()) {
             NoerdAuth::user()->setting->update(['selected_tenant_id' => $tenantId]);
@@ -89,14 +100,30 @@ class TenantHelper
     }
 
     /**
-     * Get the selected Tenant model.
+     * Get the selected Tenant model (memoized per request).
      * Works for both authenticated users and guests.
      */
     public static function getSelectedTenant(): ?Tenant
     {
         $tenantId = self::getSelectedTenantId();
 
-        return $tenantId ? Tenant::find($tenantId) : null;
+        if (!$tenantId) {
+            return null;
+        }
+
+        if (!array_key_exists($tenantId, self::$tenantMemo)) {
+            self::$tenantMemo[$tenantId] = Tenant::find($tenantId);
+        }
+
+        return self::$tenantMemo[$tenantId];
+    }
+
+    /**
+     * Drop the memoized tenant model (fresh app boot, changed selection).
+     */
+    public static function clearCache(): void
+    {
+        self::$tenantMemo = [];
     }
 
     /**

--- a/src/Middleware/SetUserLocale.php
+++ b/src/Middleware/SetUserLocale.php
@@ -12,8 +12,12 @@ class SetUserLocale
 {
     public function handle(Request $request, Closure $next): Response
     {
-        // This middleware runs in the global 'web' group, so it must resolve
-        // the noerd guard explicitly — never a host guard's user.
+        // This middleware runs in the global 'web' group DELIBERATELY: Livewire's
+        // update endpoint runs on 'web', and component updates render translated
+        // strings — scoping the locale to the noerd groups would drop it on every
+        // Livewire request. It must resolve the noerd guard explicitly (never a
+        // host guard's user), and the locale read is write-free (see
+        // NoerdUser::getLocaleAttribute), so a host route pays at most one read.
         $user = NoerdAuth::user();
 
         if ($user && $user->locale) {

--- a/src/Models/NoerdUser.php
+++ b/src/Models/NoerdUser.php
@@ -58,11 +58,13 @@ class NoerdUser extends Authenticatable implements HasLocalePreference
 
     public function adminTenants(): BelongsToMany
     {
-        $adminIds = Profile::where('key', 'ADMIN')->pluck('id');
-
+        // The admin-profile constraint is a subquery, NOT a query executed while
+        // the relation is being DEFINED — defining a relation must never hit the
+        // database (it runs on every with()/whereHas() constraint build).
         return $this->belongsToMany(Tenant::class, 'users_tenants', 'user_id')
             ->withPivot('profile_id')
-            ->wherePivotIn('profile_id', $adminIds)->with('profiles');
+            ->wherePivotIn('profile_id', Profile::query()->select('id')->where('key', 'ADMIN'))
+            ->with('profiles');
     }
 
     public function initials(): string
@@ -93,12 +95,11 @@ class NoerdUser extends Authenticatable implements HasLocalePreference
             return ['badge' => '', 'text' => ''];
         }
 
-        $profileName = '';
-        $tenant = $this->tenants->where('id', $selectedTenantId)->first();
-        if ($tenant && $tenant->pivot->profile_id) {
-            $profile = Profile::find($tenant->pivot->profile_id);
-            $profileName = $profile?->name ?? '';
-        }
+        // One joined query instead of loading the full tenants collection plus a
+        // separate Profile::find() — same tenant-profile semantics as currentProfile().
+        $profileName = (string) ($this->profiles()
+            ->where('noerd_profiles.tenant_id', $selectedTenantId)
+            ->value('name') ?? '');
 
         return ['badge' => $profileName, 'text' => ''];
     }
@@ -177,7 +178,14 @@ class NoerdUser extends Authenticatable implements HasLocalePreference
 
     public function getLocaleAttribute(): string
     {
-        return $this->setting->locale ?? 'en';
+        // Read-only: SetUserLocale reads this on EVERY web request — a missing
+        // settings row must not trigger the write path ($this->setting would
+        // firstOrCreate). Writers keep going through getSettingAttribute().
+        if (!$this->relationLoaded('userSetting')) {
+            $this->setRelation('userSetting', $this->userSetting()->first());
+        }
+
+        return $this->userSetting?->locale ?? 'en';
     }
 
     public function setLocaleAttribute(string $value): void
@@ -188,23 +196,6 @@ class NoerdUser extends Authenticatable implements HasLocalePreference
     public function preferredLocale(): string
     {
         return $this->locale;
-    }
-
-    public function toArray()
-    {
-        $tenants = $this->clients?->pluck('id') ?? [];
-        foreach ($tenants as $tenant) {
-            $array[$tenant] = true;
-        }
-
-        return [
-            'id' => $this->id,
-            'email' => $this->email,
-            'name' => $this->name,
-            'selectedTenants' => $array ?? [],
-            'tenants' => $this->tenants,
-            'is_owner' => $this->is_owner,
-        ];
     }
 
     protected static function newFactory(): NoerdUserFactory

--- a/src/Models/Tenant.php
+++ b/src/Models/Tenant.php
@@ -2,7 +2,6 @@
 
 namespace Noerd\Models;
 
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -14,10 +13,6 @@ class Tenant extends Authenticatable
 {
     use HasFactory;
     use Notifiable;
-
-    protected $appends = [
-        'frontendSession',
-    ];
 
     protected $guarded = ['id', 'created_at', 'updated_at'];
 
@@ -49,11 +44,6 @@ class Tenant extends Authenticatable
         // For backward compatibility, always use 'hash' column for existing databases
         // The accessor will still return it as 'uuid'
         $this->attributes['hash'] = $value;
-    }
-
-    public function getFrontendSessionAttribute(): int
-    {
-        return (int) Carbon::now()->addMinutes(60)->timestamp;
     }
 
     public function users(): BelongsToMany

--- a/src/Providers/NoerdServiceProvider.php
+++ b/src/Providers/NoerdServiceProvider.php
@@ -37,6 +37,7 @@ use Noerd\Contracts\SetupCollectionDefinitionRepositoryContract;
 use Noerd\Helpers\NoerdAuth;
 use Noerd\Helpers\SetupCollectionHelper;
 use Noerd\Helpers\StaticConfigHelper;
+use Noerd\Helpers\TenantHelper;
 use Noerd\Helpers\ThemeHelper;
 use Noerd\Listeners\InitializeTenantSession;
 use Noerd\Middleware\AppAccessMiddleware;
@@ -58,6 +59,7 @@ use Noerd\Services\DynamicNavigationRegistry;
 use Noerd\Services\FieldTypeRegistry;
 use Noerd\Services\HeaderActionsRegistry;
 use Noerd\Services\ListQueryContext;
+use Noerd\Services\NavigationService;
 use Noerd\Services\NoerdManager;
 use Noerd\Services\NullMediaResolver;
 use Noerd\Services\PicklistRegistry;
@@ -138,10 +140,16 @@ class NoerdServiceProvider extends ServiceProvider
         // boots (a per-request no-op under FPM, where statics die anyway).
         $this->app->booted(function (): void {
             StaticConfigHelper::flushRuntimeCaches();
+            TenantHelper::clearCache();
             ThemeHelper::clearCache();
             ThemeContext::clear();
             $this->app->make(ThemeRegistry::class)->clearCache();
         });
+
+        // The navigation is injected by several layout views per page — a
+        // singleton keeps it at one build per request (the structure itself is
+        // additionally memoized in StaticConfigHelper's runtime cache).
+        $this->app->singleton(NavigationService::class);
     }
 
     public function boot(): void

--- a/src/Repositories/YamlSetupCollectionDefinitionRepository.php
+++ b/src/Repositories/YamlSetupCollectionDefinitionRepository.php
@@ -4,9 +4,9 @@ namespace Noerd\Repositories;
 
 use Illuminate\Support\Collection;
 use Noerd\Contracts\SetupCollectionDefinitionRepositoryContract;
+use Noerd\Helpers\StaticConfigHelper;
 use Noerd\Support\SetupCollectionDefinitionData;
 use RuntimeException;
-use Symfony\Component\Yaml\Yaml;
 use Throwable;
 
 class YamlSetupCollectionDefinitionRepository implements SetupCollectionDefinitionRepositoryContract
@@ -59,18 +59,9 @@ class YamlSetupCollectionDefinitionRepository implements SetupCollectionDefiniti
             return null;
         }
 
-        $content = @file_get_contents($path);
-        if ($content === false) {
-            return null;
-        }
-
         try {
-            $fields = Yaml::parse($content) ?: [];
+            $fields = StaticConfigHelper::parseYamlFile($path);
         } catch (Throwable) {
-            return null;
-        }
-
-        if (! is_array($fields)) {
             return null;
         }
 
@@ -107,12 +98,14 @@ class YamlSetupCollectionDefinitionRepository implements SetupCollectionDefiniti
     private function loadFile(string $path): ?SetupCollectionDefinitionData
     {
         try {
-            $content = Yaml::parseFile($path);
+            // Shared mtime-guarded cache — the navigation build reads every
+            // collection YAML too, so each file parses once per process.
+            $content = StaticConfigHelper::parseYamlFile($path);
         } catch (Throwable) {
             return null;
         }
 
-        if (! is_array($content)) {
+        if ($content === []) {
             return null;
         }
 

--- a/src/Services/RelationTitleResolver.php
+++ b/src/Services/RelationTitleResolver.php
@@ -33,6 +33,66 @@ final class RelationTitleResolver
         return $this->titles[$key] ??= $this->resolve($fkColumn, $id);
     }
 
+    /**
+     * Prime the per-request memo for a whole page of ids in ONE query per source
+     * instead of one per row: a registered relation type loads via a single
+     * whereIn on its model (tenant scopes and the titleResolver apply exactly
+     * like the per-id path), remaining ids via a single whereIn on the
+     * convention table. Ids neither source resolves are memoized to the raw-id
+     * fallback, so title() never re-queries them one by one.
+     *
+     * @param  array<int, mixed>  $ids
+     */
+    public function prime(string $fkColumn, array $ids): void
+    {
+        if (! str_ends_with($fkColumn, '_id')) {
+            return;
+        }
+
+        $pending = [];
+        foreach ($ids as $id) {
+            if ($id === null || $id === '' || array_key_exists($fkColumn . '|' . $id, $this->titles)) {
+                continue;
+            }
+            $pending[(string) $id] = $id;
+        }
+
+        if ($pending === []) {
+            return;
+        }
+
+        $base = Str::beforeLast($fkColumn, '_id');
+        $resolved = [];
+
+        $definition = $this->registry->resolve(Str::camel($base) . 'Relation');
+        if ($definition?->modelClass !== null && class_exists($definition->modelClass)) {
+            foreach ($definition->modelClass::query()->findMany(array_values($pending)) as $model) {
+                $title = $definition->resolveTitle($model);
+                if ($title !== '') {
+                    $resolved[(string) $model->getKey()] = $title;
+                }
+            }
+        }
+
+        $remaining = array_diff_key($pending, $resolved);
+        if ($remaining !== []) {
+            $table = Str::plural($base);
+            $nameColumn = $this->nameColumn($table);
+            if ($nameColumn !== false) {
+                $names = DB::table($table)->whereIn('id', array_values($remaining))->pluck($nameColumn, 'id');
+                foreach ($names as $id => $name) {
+                    if (is_string($name) && mb_trim($name) !== '') {
+                        $resolved[(string) $id] = $name;
+                    }
+                }
+            }
+        }
+
+        foreach ($pending as $idKey => $id) {
+            $this->titles[$fkColumn . '|' . $id] = $resolved[$idKey] ?? (string) $id;
+        }
+    }
+
     private function resolve(string $fkColumn, mixed $id): string
     {
         $base = Str::beforeLast($fkColumn, '_id');

--- a/src/Traits/NoerdList.php
+++ b/src/Traits/NoerdList.php
@@ -25,6 +25,7 @@ use Noerd\Scopes\SearchScope;
 use Noerd\Scopes\SortScope;
 use Noerd\Services\ColumnFilterParser;
 use Noerd\Services\ListQueryContext;
+use Noerd\Services\RelationTitleResolver;
 use ReflectionClass;
 use ReflectionMethod;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -193,6 +194,16 @@ trait NoerdList
     /** @var array<string, mixed>|null Last buildList() result, memoized per request. */
     protected ?array $builtListConfigCache = null;
 
+    /** @var array<string, bool>|null Request cache for isJsonColumnPath(), keyed by column field. */
+    protected ?array $jsonColumnPathCache = null;
+
+    /** @var array<string, array<string, mixed>> Request memo for getListConfig() (incl. layout overrides). */
+    protected array $listConfigMemo = [];
+
+    /** One reusable instance of the resolved model, for table/cast introspection. */
+    private ?Model $resolvedModelInstanceMemo = null;
+
+    /** @var array<string, array<string, array<string, mixed>>> Schema columns per table, keyed by column name. */
     private static array $schemaColumnCache = [];
 
     /**
@@ -398,6 +409,9 @@ trait NoerdList
 
     public function updatedSearch(): void
     {
+        // A new search shrinks the result set — staying on page 3 would show an
+        // empty table even though there are matches on page 1.
+        $this->resetPage();
         $this->syncListQueryContext();
     }
 
@@ -448,6 +462,7 @@ trait NoerdList
     public function storeActiveListFilters(): void
     {
         session(['listFilters' => $this->listFilters]);
+        $this->resetPage();
     }
 
     public function clearAllListFilters(): void
@@ -492,6 +507,7 @@ trait NoerdList
      *
      * @return array<int, array{field: string, label: string, value: string}>
      */
+    #[Computed]
     public function activeColumnFilterChips(): array
     {
         $active = array_filter(
@@ -507,8 +523,9 @@ trait NoerdList
             ->filter(fn($column): bool => isset($column['field']))
             ->keyBy('field');
         $picklistOptions = $this->picklistOptionsFromDetail();
-        $schemaTypes = $this->resolvedModelClass !== null
-            ? $this->schemaColumnTypeMap((new $this->resolvedModelClass())->getTable())
+        $model = $this->resolvedModelInstance();
+        $schemaTypes = $model !== null
+            ? $this->schemaColumnTypeMap($model->getTable())
             : [];
 
         $chips = [];
@@ -693,6 +710,9 @@ trait NoerdList
         }
 
         $this->selectedRecordIds = [];
+        // The guard checks above resolved (and memoized) the pre-delete list —
+        // drop it so the re-render queries the surviving rows.
+        $this->builtListConfigCache = null;
         $this->resetPage();
     }
 
@@ -852,6 +872,14 @@ trait NoerdList
      */
     protected function resolvedListConfig(): array
     {
+        // Memoized per request: actions like toggleSelectAllVisible() resolve the
+        // list before the render does — without the memo each resolution runs the
+        // full paginated query again. Mutating actions (deleteSelected) clear the
+        // cache so their re-render queries fresh rows.
+        if ($this->builtListConfigCache !== null) {
+            return $this->builtListConfigCache;
+        }
+
         if (property_exists($this, 'listModel') && $this->listModel) {
             return $this->listData();
         }
@@ -892,7 +920,7 @@ trait NoerdList
         }
 
         $allowed = $this->getAllowedListFilterColumns();
-        $filterTypes = collect($this->tableFilters())->pluck('type', 'column')->toArray();
+        $filterTypes = collect($this->tableFilters)->pluck('type', 'column')->toArray();
 
         foreach ($this->listFilters as $key => $value) {
             if (!in_array($key, $allowed) || !$value) {
@@ -998,10 +1026,14 @@ trait NoerdList
      */
     protected function listQuery(string $modelClass, ?string $configName = null): Builder
     {
+        if ($this->resolvedModelClass !== $modelClass || $this->listQueryConfigName !== $configName) {
+            $this->filterableColumnCache = null;
+            $this->relationColumnPathCache = null;
+            $this->jsonColumnPathCache = null;
+            $this->resolvedModelInstanceMemo = null;
+        }
         $this->resolvedModelClass = $modelClass;
         $this->listQueryConfigName = $configName;
-        $this->filterableColumnCache = null;
-        $this->relationColumnPathCache = null;
 
         $query = $modelClass::query()
             ->withoutGlobalScope(SearchScope::class)
@@ -1014,17 +1046,19 @@ trait NoerdList
         }
 
         $listConfig = $this->getListConfig($configName);
+        $table = $this->resolvedModelInstance()->getTable();
 
         if (!empty($this->search)) {
             $searchableFields = !empty($listConfig['searchableColumns'])
                 ? $listConfig['searchableColumns']
                 : collect($listConfig['columns'] ?? [])->pluck('field')->filter()->toArray();
 
-            $table = (new $modelClass())->getTable();
-            $validFields = array_filter($searchableFields, fn($f) => Schema::hasColumn($table, $f));
+            $validFields = array_filter($searchableFields, fn($f) => is_string($f) && self::tableHasColumn($table, $f));
 
             if (!empty($validFields)) {
-                $search = $this->search;
+                // Escape LIKE wildcards so a literal % or _ in the search input
+                // matches literally — same rule as ColumnFilterParser.
+                $search = addcslashes($this->search, '\\%_');
                 $query->where(function (Builder $q) use ($validFields, $search): void {
                     foreach (array_values($validFields) as $index => $field) {
                         $index === 0
@@ -1038,8 +1072,7 @@ trait NoerdList
         $this->applyColumnFilters($query, $modelClass);
         $this->eagerLoadRelationColumns($query);
 
-        $table = (new $modelClass())->getTable();
-        $sortField = Schema::hasColumn($table, $this->sortField) ? $this->sortField : 'id';
+        $sortField = self::tableHasColumn($table, $this->sortField) ? $this->sortField : 'id';
         $query->orderBy($sortField, $this->sortAsc ? 'asc' : 'desc');
 
         return $query;
@@ -1092,7 +1125,7 @@ trait NoerdList
             return $this->filterableColumnCache;
         }
 
-        $table = (new $this->resolvedModelClass())->getTable();
+        $table = $this->resolvedModelInstance()->getTable();
 
         return $this->filterableColumnCache = collect($this->getListConfig($this->listQueryConfigName)['columns'] ?? [])
             ->pluck('field')
@@ -1100,7 +1133,7 @@ trait NoerdList
                 && $field !== 'action'
                 && (self::isDottedField($field)
                     ? ($this->isJsonColumnPath($field) || $this->relationColumnPath($field) !== null)
-                    : Schema::hasColumn($table, $field)))
+                    : self::tableHasColumn($table, $field)))
             ->values()
             ->all();
     }
@@ -1118,10 +1151,16 @@ trait NoerdList
             return false;
         }
 
-        $model = new $this->resolvedModelClass();
+        $this->jsonColumnPathCache ??= [];
+
+        if (array_key_exists($field, $this->jsonColumnPathCache)) {
+            return $this->jsonColumnPathCache[$field];
+        }
+
+        $model = $this->resolvedModelInstance();
         $base = Str::before($field, '.');
 
-        return Schema::hasColumn($model->getTable(), $base)
+        return $this->jsonColumnPathCache[$field] = self::tableHasColumn($model->getTable(), $base)
             && $model->hasCast($base, ['array', 'json', 'object', 'collection']);
     }
 
@@ -1167,7 +1206,7 @@ trait NoerdList
             return;
         }
 
-        $table = (new $modelClass())->getTable();
+        $table = $this->resolvedModelInstance()->getTable();
         $schemaTypes = $this->schemaColumnTypeMap($table);
         $yamlTypes = collect($this->getListConfig($this->listQueryConfigName)['columns'] ?? [])
             ->filter(fn($column): bool => isset($column['field'], $column['type']))
@@ -1224,8 +1263,7 @@ trait NoerdList
         // With zero rows (e.g. a column filter matching nothing) no model instance can
         // be pulled from the result set — fall back to the class listQuery() resolved,
         // so bool/date columns keep their type and the filter popover keeps its UI.
-        $model = $this->resolveModelFromRows($rows)
-            ?? ($this->resolvedModelClass !== null ? new $this->resolvedModelClass() : null);
+        $model = $this->resolveModelFromRows($rows) ?? $this->resolvedModelInstance();
         if (!$model) {
             return $listSettings;
         }
@@ -1264,18 +1302,51 @@ trait NoerdList
      */
     protected function schemaColumnTypeMap(string $table): array
     {
-        $schemaColumns = self::$schemaColumnCache[$table]
-            ??= Schema::getColumns($table);
-
         $columnTypeMap = [];
-        foreach ($schemaColumns as $col) {
+        foreach (self::tableColumns($table) as $name => $col) {
             $normalized = mb_strtolower(preg_replace('/\(.*\)/', '', $col['type_name']));
             if (isset(self::COLUMN_TYPE_MAP[$normalized])) {
-                $columnTypeMap[$col['name']] = self::COLUMN_TYPE_MAP[$normalized];
+                $columnTypeMap[$name] = self::COLUMN_TYPE_MAP[$normalized];
             }
         }
 
         return $columnTypeMap;
+    }
+
+    /**
+     * The table's schema columns keyed by column name, introspected at most once
+     * per table and process. Backs every column-existence check in the trait:
+     * Schema::hasColumn() is NOT cached by Laravel and issues one
+     * information-schema query per call — on an 8-column list that used to mean
+     * a two-digit number of metadata queries per render.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    protected static function tableColumns(string $table): array
+    {
+        return self::$schemaColumnCache[$table]
+            ??= collect(Schema::getColumns($table))->keyBy('name')->all();
+    }
+
+    /**
+     * Cached replacement for Schema::hasColumn() (see tableColumns()).
+     */
+    protected static function tableHasColumn(string $table, string $column): bool
+    {
+        return array_key_exists($column, self::tableColumns($table));
+    }
+
+    /**
+     * One shared instance of the resolved model class for table-name and cast
+     * introspection — the render path asks for it many times per request.
+     */
+    protected function resolvedModelInstance(): ?Model
+    {
+        if ($this->resolvedModelClass === null) {
+            return null;
+        }
+
+        return $this->resolvedModelInstanceMemo ??= new $this->resolvedModelClass();
     }
 
     protected function resolveModelFromRows(mixed $rows): ?Model
@@ -1307,6 +1378,7 @@ trait NoerdList
 
         $listSettings = $this->applyAutoColumnTypes($listSettings, $rows);
         $listSettings = $this->applyPicklistBadges($listSettings);
+        $this->primeRelationBadgeTitles($listSettings, $rows);
 
         // Object permissions: strip the affordances the current user may not use.
         // In-memory lists (no model class) stay unrestricted.
@@ -1386,6 +1458,43 @@ trait NoerdList
         }
 
         return $listSettings;
+    }
+
+    /**
+     * Resolve the titles of every `relationBadge` column for the current page in
+     * one query per column instead of one per cell: the resolver's per-id memo is
+     * primed with a whereIn batch, so the table cells only read memoized values.
+     */
+    protected function primeRelationBadgeTitles(array $listSettings, mixed $rows): void
+    {
+        $badgeFields = [];
+        foreach ($listSettings['columns'] ?? [] as $column) {
+            if (($column['type'] ?? null) === 'relationBadge' && isset($column['field'])) {
+                $badgeFields[] = $column['field'];
+            }
+        }
+        if ($badgeFields === []) {
+            return;
+        }
+
+        if ($rows instanceof LengthAwarePaginator || $rows instanceof Paginator) {
+            $collection = $rows->getCollection();
+        } elseif ($rows instanceof Collection) {
+            $collection = $rows;
+        } elseif (is_array($rows)) {
+            $collection = collect($rows);
+        } else {
+            return;
+        }
+
+        if ($collection->isEmpty()) {
+            return;
+        }
+
+        $resolver = app(RelationTitleResolver::class);
+        foreach ($badgeFields as $field) {
+            $resolver->prime($field, $collection->map(fn($row) => data_get($row, $field))->all());
+        }
     }
 
     /**
@@ -1482,6 +1591,28 @@ trait NoerdList
      * In select mode, uses selectListConfig if set.
      */
     protected function getListConfig(?string $customName = null): array
+    {
+        // Memoized per request: the render path resolves the config from several
+        // places (query, filters, chips, bulk-action guard), and every raw
+        // resolution re-runs the layout-override hook — DB-backed in noerd-pro.
+        $memoKey = implode('|', [
+            $customName ?? '',
+            $this->listView ?? '',
+            $this->listViewApp ?? '',
+            $this->listActionMethod,
+            $this->selectListConfig ?? '',
+        ]);
+        if (array_key_exists($memoKey, $this->listConfigMemo)) {
+            return $this->listConfigMemo[$memoKey];
+        }
+
+        return $this->listConfigMemo[$memoKey] = $this->resolveListConfig($customName);
+    }
+
+    /**
+     * @see getListConfig()
+     */
+    private function resolveListConfig(?string $customName): array
     {
         if ($customName === null && $this->listActionMethod === 'selectAction' && $this->selectListConfig) {
             return StaticConfigHelper::getListConfig($this->selectListConfig, $this->listModel ?? null);
@@ -1609,7 +1740,7 @@ trait NoerdList
         }
 
         $table = $model->getTable();
-        if (!Schema::hasTable($table) || !Schema::hasColumn($table, $column)) {
+        if (!Schema::hasTable($table) || !self::tableHasColumn($table, $column)) {
             return null;
         }
 

--- a/tests/Components/ListControlsInjectionTest.php
+++ b/tests/Components/ListControlsInjectionTest.php
@@ -24,7 +24,7 @@ it('injects search and the YAML actions into a custom header of a list host', fu
     $html = Livewire::test(CustomHeaderListComponent::class)->assertOk()->html();
 
     expect($html)->toContain('Custom Header')
-        ->toContain('wire:model.live="search"')
+        ->toContain('wire:model.live.debounce.300ms="search"')
         ->toContain('$wire.listAction(null, [])')
         ->toContain('New Thing');
 });
@@ -32,7 +32,7 @@ it('injects search and the YAML actions into a custom header of a list host', fu
 it('renders the controls exactly once for a standard list', function (): void {
     $html = Livewire::test(StandardHeaderListComponent::class)->assertOk()->html();
 
-    expect(mb_substr_count($html, 'wire:model.live="search"'))->toBe(1)
+    expect(mb_substr_count($html, 'wire:model.live.debounce.300ms="search"'))->toBe(1)
         ->and(mb_substr_count($html, '$wire.listAction(null, [])'))->toBe(1);
 });
 
@@ -42,7 +42,7 @@ it('suppresses the injection with listControls=false', function (): void {
         ->html();
 
     expect($html)->toContain('Custom Header')
-        ->not->toContain('wire:model.live="search"')
+        ->not->toContain('wire:model.live.debounce.300ms="search"')
         ->not->toContain('New Thing');
 });
 
@@ -51,7 +51,7 @@ it('keeps the search but hides the actions in picker mode', function (): void {
         ->assertOk()
         ->html();
 
-    expect($html)->toContain('wire:model.live="search"')
+    expect($html)->toContain('wire:model.live.debounce.300ms="search"')
         ->not->toContain('New Thing');
 });
 
@@ -69,7 +69,7 @@ it('wraps the injected controls in the listControlsShow expression', function ()
         ->html();
 
     expect($html)->toContain('x-show="currentTab === 2"')
-        ->toContain('wire:model.live="search"');
+        ->toContain('wire:model.live.debounce.300ms="search"');
 });
 
 /**

--- a/tests/Feature/RelationTitleResolverTest.php
+++ b/tests/Feature/RelationTitleResolverTest.php
@@ -86,3 +86,34 @@ it('prefers a registered relation type over the table convention', function (): 
 
     expect(app(RelationTitleResolver::class)->title('fixture_widget_id', $widget->id))->toBe('WIDGET:Erika Musterfrau');
 });
+
+it('primes a whole page of convention-table ids with a single query', function (): void {
+    $ids = [];
+    foreach (['Alpha', 'Beta', 'Gamma'] as $name) {
+        $ids[] = DB::table('gadgets')->insertGetId(['name' => $name]);
+    }
+
+    $this->resolver->prime('gadget_id', $ids);
+
+    DB::enableQueryLog();
+    expect($this->resolver->title('gadget_id', $ids[0]))->toBe('Alpha')
+        ->and($this->resolver->title('gadget_id', $ids[1]))->toBe('Beta')
+        ->and($this->resolver->title('gadget_id', $ids[2]))->toBe('Gamma')
+        ->and(DB::getQueryLog())->toBeEmpty();
+    DB::disableQueryLog();
+});
+
+it('primes through a registered relation type and falls back per id', function (): void {
+    $widget = RelationTitleFixtureWidget::create(['name' => 'Erika Musterfrau']);
+
+    app(RelationFieldRegistry::class)->register('fixtureWidgetRelation', RelationFieldDefinition::model(
+        'fixture-widgets-list',
+        null,
+        RelationTitleFixtureWidget::class,
+    ));
+
+    $this->resolver->prime('fixture_widget_id', [$widget->id, 999999, null, '']);
+
+    expect($this->resolver->title('fixture_widget_id', $widget->id))->toBe('Erika Musterfrau')
+        ->and($this->resolver->title('fixture_widget_id', 999999))->toBe('999999');
+});

--- a/tests/Traits/NoerdListColumnFilterTest.php
+++ b/tests/Traits/NoerdListColumnFilterTest.php
@@ -755,3 +755,14 @@ class TestableColumnFilterChipListComponent extends TestableColumnFilterListComp
         ];
     }
 }
+
+it('resets pagination when the search changes', function (): void {
+    NoerdUser::factory()->count(3)->create();
+
+    $component = Livewire::test(TestableColumnFilterListComponent::class)
+        ->set('perPage', 1)
+        ->call('setPage', 2)
+        ->set('search', 'a');
+
+    expect($component->instance()->paginators['page'] ?? 1)->toBe(1);
+});


### PR DESCRIPTION
Pre-release quality review, phase 3 of 7 — performance. A typical 8-column, 50-row list paid on the order of 60–100 avoidable queries per render, and roughly ten times that while someone typed in the search box. All of the following are memoization/batching changes with no behavioral change unless noted.

## NoerdList render path
- **Schema introspection is now cached per table.** `Schema::hasColumn()` is not cached by Laravel — every call is an information-schema query, and the trait issued one per searchable column, per configured column, per dotted field, plus one for the sort field, per render. All checks now go through the static per-table column listing that `schemaColumnTypeMap()` already maintained (`tableColumns()` / `tableHasColumn()`).
- **`#[Computed] tableFilters` was bypassed everywhere** — the Blades and the trait called it as a method, re-running every `get*ListFilter()` (including the tenant filter's relation load) three times per render. All call sites use the cached property form now; `activeColumnFilterChips()` is `#[Computed]` too.
- **`resolvedListConfig()` is memoized**, so `toggleSelectAllVisible()` no longer runs the full paginated query twice per checkbox click; `deleteSelected()` explicitly drops the memo after deleting so its re-render queries fresh rows.
- **`getListConfig()` is memoized per request** — it was resolved 6–8× per render, and each raw resolution re-runs the layout-override hook (DB-backed in noerd-pro). `isJsonColumnPath()` gets the same per-field cache its siblings already had; model instantiation for table/cast introspection now reuses one instance.
- **`relationBadge` columns no longer N+1.** `buildList()` primes the `RelationTitleResolver` for the whole page in one `whereIn` per column (registered relation types resolve through their model incl. tenant scopes; convention tables through one query). 50 rows previously meant 50 queries.
- **Search**: `wire:model.live` gets a 300ms debounce (one query per keystroke before); `updatedSearch()` and `storeActiveListFilters()` reset pagination (searching from page 3 used to show an empty table); LIKE wildcards (`%`, `_`) are escaped like the column filters already did.

## Request lifecycle
- `NavigationService` is a singleton and the navigation structure is memoized per request — it was rebuilt three times per page (app bar, sidebar, top bar), each build globbing and parsing every collection YAML plus one `Route::has()` per entry. The collection-definition repository now parses through the shared mtime+size-guarded YAML cache.
- `TenantHelper::getSelectedTenant()` is memoized (12 identical `Tenant::find()` per render across middleware, config discovery and blades); flushed on selection change and app boot.
- `getAllowedAppFolders()` and `appLabels()` derive from ONE shared `tenantApps()` query instead of two.
- `NoerdUser::getLocaleAttribute()` no longer runs `firstOrCreate` — `SetUserLocale` sits on the global `web` group (deliberately: Livewire's update endpoint runs on `web`, and dropping the middleware there would lose the locale on every component update — documented in the middleware), so this was a potential DB write on every request of the host app.

## Models
- `NoerdUser::toArray()` override removed — it referenced a non-existent `clients` relation (always null), bypassed `$hidden` handling, and eagerly serialized the `tenants` relation on every `toArray()`/`toJson()`.
- `NoerdUser::adminTenants()` no longer executes a query while the relation is being *defined* (breaks eager loading semantics) — the admin-profile filter is a subquery now. `getProfileForTenantAttribute()` resolves via one joined query instead of loading the full tenants collection plus a `Profile::find()`.
- `Tenant::$appends['frontendSession']` removed (a `now()+60min` timestamp appended to every `toArray()` made every serialization non-deterministic and defeated Livewire's dirty-diffing; nothing consumed it).
- `noerd-user-detail`'s mount loop loads the edited user's tenant assignments once instead of one query per admin tenant, and no longer crashes on a tenant without profiles.

## Tests
- New: batch-priming tests for `RelationTitleResolver` (including a query-log assertion), pagination-reset-on-search regression test.
- Full package suite: 962 passed, 1 skipped. The three `wire:model.live="search"` assertions in crm/noerd-plus tests need the debounce suffix (updated in those repos alongside this release).