### PR TITLE
Make request-scoped state Octane-safe and lock mount-established component identity

### DIFF
--- a/resources/views/components/detail/block.blade.php
+++ b/resources/views/components/detail/block.blade.php
@@ -37,6 +37,10 @@
 
     $theme = \Noerd\Helpers\ThemeHelper::fromLayout(['theme' => $theme ?? null]);
     $themeDefinition = $themeRegistry->get($theme);
+    // Save/restore the theme context around this block (mirrors NoerdPage's
+    // rendering hooks): two sibling blocks with different `theme:` keys must
+    // not leak the first block's theme into chrome rendered after it.
+    $themeContextBefore = \Noerd\Support\ThemeContext::current();
     \Noerd\Support\ThemeContext::set($theme);
     $numberedRowIndex = 0;
 
@@ -142,6 +146,9 @@
                 </div>
             @endif
         @endforeach
-        @php \Noerd\Support\FieldContext::clear(); @endphp
+        @php
+            \Noerd\Support\FieldContext::clear();
+            \Noerd\Support\ThemeContext::set($themeContextBefore);
+        @endphp
     </div>
 </div>

--- a/src/Livewire/PolymorphicRelationFieldComponent.php
+++ b/src/Livewire/PolymorphicRelationFieldComponent.php
@@ -17,10 +17,17 @@ use Noerd\Support\RelationFieldDefinition;
  */
 abstract class PolymorphicRelationFieldComponent extends Component
 {
+    // Mount-established identity/config is #[Locked] — a crafted update must
+    // never repoint the field at another form key or widen the type whitelist.
+    // $value, $currentType, $selectedRelationType and $displayTitle stay
+    // mutable: they carry the user's selection.
+    #[Locked]
     public string $fieldName = '';
 
+    #[Locked]
     public string $typeField = '';
 
+    #[Locked]
     public string $label = '';
 
     public mixed $value = null;
@@ -28,22 +35,28 @@ abstract class PolymorphicRelationFieldComponent extends Component
     public ?string $currentType = null;
 
     /** @var array<int, string> */
+    #[Locked]
     public array $allowedTypes = [];
 
+    #[Locked]
     public bool $required = false;
 
     #[Locked]
     public bool $readonly = false;
 
     /** Optional YAML `helpText`, rendered as a tooltip next to the label. */
+    #[Locked]
     public string $helpText = '';
 
+    #[Locked]
     public mixed $modelId = null;
 
     /** Row number supplied by the detail block in themes that number their rows. */
+    #[Locked]
     public ?int $number = null;
 
     /** Theme the owning detail block renders in — selects the element template. */
+    #[Locked]
     public string $theme = 'default';
 
     public string $selectedRelationType = '';

--- a/src/Livewire/RelationFieldComponent.php
+++ b/src/Livewire/RelationFieldComponent.php
@@ -16,38 +16,53 @@ use RuntimeException;
  */
 abstract class RelationFieldComponent extends Component
 {
+    // Everything below except $value/$displayTitle is mount-established
+    // identity/config — #[Locked], so a crafted update can never repoint the
+    // field at another form key, list, detail target or event.
+    #[Locked]
     public string $relationType = '';
 
+    #[Locked]
     public string $fieldName = '';
 
+    #[Locked]
     public string $label = '';
 
     public mixed $value = null;
 
+    #[Locked]
     public bool $required = false;
 
     #[Locked]
     public bool $readonly = false;
 
     /** Optional YAML `helpText`, rendered as a tooltip next to the label. */
+    #[Locked]
     public string $helpText = '';
 
+    #[Locked]
     public mixed $modelId = null;
 
     /** Row number supplied by the detail block in themes that number their rows. */
+    #[Locked]
     public ?int $number = null;
 
     /** Theme the owning detail block renders in — selects the element template. */
+    #[Locked]
     public string $theme = 'default';
 
     public string $displayTitle = '';
 
+    #[Locked]
     public string $listComponent = '';
 
+    #[Locked]
     public ?string $detailComponent = null;
 
+    #[Locked]
     public ?string $detailRoute = null;
 
+    #[Locked]
     public ?string $legacySelectEvent = null;
 
     public function mount(

--- a/src/Mail/EmailPreviewTestMail.php
+++ b/src/Mail/EmailPreviewTestMail.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Noerd\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * The "send test email" preview of HasEmailPreview. Queued so the Livewire
+ * response never blocks on SMTP; on the default sync queue driver the send
+ * still happens inline.
+ */
+class EmailPreviewTestMail extends Mailable implements ShouldQueue
+{
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(
+        private readonly string $htmlContent,
+        private readonly string $subjectLine,
+    ) {}
+
+    public function build(): self
+    {
+        return $this->subject($this->subjectLine)->html($this->htmlContent);
+    }
+}

--- a/src/Providers/NoerdServiceProvider.php
+++ b/src/Providers/NoerdServiceProvider.php
@@ -34,6 +34,7 @@ use Noerd\Commands\NoerdUpdateCommand;
 use Noerd\Commands\PublishHomeCommand;
 use Noerd\Contracts\MediaResolverContract;
 use Noerd\Contracts\SetupCollectionDefinitionRepositoryContract;
+use Noerd\Helpers\CurrencyHelper;
 use Noerd\Helpers\NoerdAuth;
 use Noerd\Helpers\SetupCollectionHelper;
 use Noerd\Helpers\StaticConfigHelper;
@@ -71,9 +72,11 @@ use Noerd\Support\ComponentAccessHook;
 use Noerd\Support\DefaultCountries;
 use Noerd\Support\FieldTypeDefinition;
 use Noerd\Support\LockedPropertiesHook;
+use Noerd\Support\FieldContext;
 use Noerd\Support\QuickCreateExitHook;
 use Noerd\Support\RelationFieldDefinition;
 use Noerd\Support\RelationFormPersistHook;
+use Noerd\Support\SchemaColumnCache;
 use Noerd\Support\ThemeContext;
 use Noerd\Support\WriteGuardHook;
 use Noerd\View\Components\AppLayout;
@@ -137,17 +140,56 @@ class NoerdServiceProvider extends ServiceProvider
         // instance inside one Pest process — flush them whenever a fresh app
         // boots (a per-request no-op under FPM, where statics die anyway).
         $this->app->booted(function (): void {
-            StaticConfigHelper::flushRuntimeCaches();
-            TenantHelper::clearCache();
-            ThemeHelper::clearCache();
-            ThemeContext::clear();
-            $this->app->make(ThemeRegistry::class)->clearCache();
+            $this->flushRequestState();
+            // The schema cache survives ordinary boots (it describes database
+            // structure, not request state) — but a fresh app in a test process
+            // may point at a DIFFERENT database (testbench sqlite vs. host
+            // MySQL) whose tables share names, so it must reset here too.
+            SchemaColumnCache::clear();
         });
+
+        // Migrations change what the schema cache describes — never keep
+        // serving the pre-migration column listing.
+        Event::listen(\Illuminate\Database\Events\MigrationsEnded::class, fn() => SchemaColumnCache::clear());
+
+        // Under Octane booted() fires once per WORKER, not per request — the
+        // same flush must run before every request, or one user's memoized
+        // tenant/config/theme state leaks into the next request the worker
+        // serves. Guarded by class_exists so the listener only registers when
+        // Octane is installed. The schema cache deliberately survives requests.
+        if (class_exists(\Laravel\Octane\Events\RequestReceived::class)) {
+            Event::listen(\Laravel\Octane\Events\RequestReceived::class, function (): void {
+                $this->flushRequestState();
+                // Stateful singletons are rebuilt per request: the title
+                // resolver memoizes tenant-scoped DB values.
+                $this->app->forgetInstance(RelationTitleResolver::class);
+            });
+        }
 
         // The navigation is injected by several layout views per page — a
         // singleton keeps it at one build per request (the structure itself is
         // additionally memoized in StaticConfigHelper's runtime cache).
         $this->app->singleton(NavigationService::class);
+    }
+
+    /**
+     * Drop every request-scoped PHP static the package maintains. Runs on app
+     * boot (fresh per test in one Pest process, per-request no-op under FPM)
+     * and — via the Octane RequestReceived listener — before every Octane
+     * request. The schema column listing is deliberately not part of this
+     * flush: it describes the database structure, not request state (see the
+     * boot hook and the MigrationsEnded listener).
+     */
+    private function flushRequestState(): void
+    {
+        StaticConfigHelper::flushRuntimeCaches();
+        TenantHelper::clearCache();
+        ThemeHelper::clearCache();
+        ThemeContext::clear();
+        FieldContext::clear();
+        CurrencyHelper::clearCache();
+        DatabaseSetupCollectionDefinitionRepository::resetCache();
+        $this->app->make(ThemeRegistry::class)->clearCache();
     }
 
     public function boot(): void

--- a/src/Services/RelationTitleResolver.php
+++ b/src/Services/RelationTitleResolver.php
@@ -5,6 +5,7 @@ namespace Noerd\Services;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
+use Noerd\Helpers\TenantHelper;
 
 /**
  * Resolves the display title for a foreign-key list cell (`relationBadge`): a
@@ -28,9 +29,20 @@ final class RelationTitleResolver
             return null;
         }
 
-        $key = $fkColumn . '|' . $id;
+        $key = $this->memoKey($fkColumn, $id);
 
         return $this->titles[$key] ??= $this->resolve($fkColumn, $id);
+    }
+
+    /**
+     * Memo key including the current tenant: the convention lookup is a raw
+     * unscoped DB read, so a memoized title must never be served to another
+     * tenant a long-lived worker later handles (defense in depth on top of the
+     * per-request reset in the provider's Octane listener).
+     */
+    private function memoKey(string $fkColumn, mixed $id): string
+    {
+        return (TenantHelper::currentTenantId() ?? 0) . '|' . $fkColumn . '|' . $id;
     }
 
     /**
@@ -51,7 +63,7 @@ final class RelationTitleResolver
 
         $pending = [];
         foreach ($ids as $id) {
-            if ($id === null || $id === '' || array_key_exists($fkColumn . '|' . $id, $this->titles)) {
+            if ($id === null || $id === '' || array_key_exists($this->memoKey($fkColumn, $id), $this->titles)) {
                 continue;
             }
             $pending[(string) $id] = $id;
@@ -89,7 +101,7 @@ final class RelationTitleResolver
         }
 
         foreach ($pending as $idKey => $id) {
-            $this->titles[$fkColumn . '|' . $id] = $resolved[$idKey] ?? (string) $id;
+            $this->titles[$this->memoKey($fkColumn, $id)] = $resolved[$idKey] ?? (string) $id;
         }
     }
 

--- a/src/Support/SchemaColumnCache.php
+++ b/src/Support/SchemaColumnCache.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Noerd\Support;
+
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Process-wide cache of a table's schema columns, keyed by column name. Backs
+ * every column-existence/type check in the list render path —
+ * Schema::hasColumn() is NOT cached by Laravel and issues one
+ * information-schema query per call.
+ *
+ * A single shared class instead of a trait static on purpose: a static
+ * property declared in a trait is duplicated into every composing class, which
+ * would both fragment the cache per list component and make it impossible to
+ * flush centrally (fresh app boots in tests, Octane workers after migrations).
+ */
+final class SchemaColumnCache
+{
+    /** @var array<string, array<string, array<string, mixed>>> */
+    private static array $columnsByTable = [];
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public static function columns(string $table): array
+    {
+        return self::$columnsByTable[$table]
+            ??= collect(Schema::getColumns($table))->keyBy('name')->all();
+    }
+
+    public static function hasColumn(string $table, string $column): bool
+    {
+        return array_key_exists($column, self::columns($table));
+    }
+
+    public static function clear(): void
+    {
+        self::$columnsByTable = [];
+    }
+}

--- a/src/Traits/HasEmailPreview.php
+++ b/src/Traits/HasEmailPreview.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\HtmlString;
 use Noerd\Helpers\NoerdAuth;
+use Noerd\Mail\EmailPreviewTestMail;
 
 trait HasEmailPreview
 {
@@ -79,9 +80,9 @@ trait HasEmailPreview
             $data['email_subject'] ?? 'Test Email',
         );
 
-        Mail::html($html, function ($message) use ($email, $subject): void {
-            $message->to($email)->subject($subject);
-        });
+        // Queued: a synchronous SMTP send would block the Livewire response.
+        // On the default sync queue driver the behavior is unchanged.
+        Mail::to($email)->queue(new EmailPreviewTestMail($html, $subject));
 
         $cooldown = 60;
         Cache::put($this->getTestEmailCacheKey(), now()->timestamp + $cooldown, $cooldown);

--- a/src/Traits/NoerdList.php
+++ b/src/Traits/NoerdList.php
@@ -24,6 +24,7 @@ use Noerd\Helpers\SetupCollectionHelper;
 use Noerd\Helpers\StaticConfigHelper;
 use Noerd\Services\ColumnFilterParser;
 use Noerd\Services\RelationTitleResolver;
+use Noerd\Support\SchemaColumnCache;
 use ReflectionClass;
 use ReflectionMethod;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -196,9 +197,6 @@ trait NoerdList
     /** One reusable instance of the resolved model, for table/cast introspection. */
     private ?Model $resolvedModelInstanceMemo = null;
 
-    /** @var array<string, array<string, array<string, mixed>>> Schema columns per table, keyed by column name. */
-    private static array $schemaColumnCache = [];
-
     /**
      * Whether a column field addresses a nested path rather than a real DB column — e.g. a custom
      * attribute (`custom_attributes.sap_number`) or a relation (`customer.name`). Such fields resolve at
@@ -247,7 +245,7 @@ trait NoerdList
             return;
         }
 
-        $this->perPage = session('listPerPage', 50);
+        $this->perPage = session("listPerPage.{$this->componentName()}", 50);
         $this->loadListFilters();
 
         // Column filters: a ?cf[...] URL param (shared link) wins over the session
@@ -316,6 +314,18 @@ trait NoerdList
         }
 
         $this->syncListViewParam();
+
+        // Deep-link support: ?{entity}Id=5 opens the record's modal over the
+        // list, ?create=1 the create modal. Mount-only BY DESIGN — Livewire
+        // updates POST to /livewire/update and carry no page query, and the
+        // former `rendering()` hook was both accidental-initial-load-only and
+        // silently disabled by any component defining its own rendering().
+        $deepLinkId = (int) request()->query($this->getDeepLinkParam());
+        if ($deepLinkId) {
+            $this->listAction($deepLinkId);
+        } elseif (request()->query('create')) {
+            $this->listAction();
+        }
     }
 
     /**
@@ -362,19 +372,6 @@ trait NoerdList
         return $this->buildList($rows);
     }
 
-    public function rendering(): void
-    {
-        $deepLinkId = request()->query($this->getDeepLinkParam());
-
-        if ((int) $deepLinkId) {
-            $this->listAction((int) $deepLinkId);
-        }
-
-        if (request()->create) {
-            $this->listAction();
-        }
-    }
-
     /**
      * Switch the active list view and remember it per component in the session.
      * Unknown keys are ignored (e.g. a stale dropdown after a view YAML was removed).
@@ -395,7 +392,7 @@ trait NoerdList
     public function updatedPerPage(): void
     {
         $this->perPage = $this->clampPerPage($this->perPage);
-        session(['listPerPage' => $this->perPage]);
+        session(["listPerPage.{$this->componentName()}" => $this->perPage]);
         $this->resetPage();
     }
 
@@ -443,6 +440,12 @@ trait NoerdList
         $this->persistListSort();
     }
 
+    /**
+     * The header filters live in ONE session bucket shared across lists ON
+     * PURPOSE: NoerdPage::setPreselect() seeds it from detail pages so a
+     * related list opens pre-filtered, and preselect() reads it back. Only
+     * columns whitelisted per list (getAllowedListFilterColumns) ever apply.
+     */
     public function loadListFilters(): void
     {
         $this->listFilters = session('listFilters', []);
@@ -1277,17 +1280,15 @@ trait NoerdList
 
     /**
      * The table's schema columns keyed by column name, introspected at most once
-     * per table and process. Backs every column-existence check in the trait:
-     * Schema::hasColumn() is NOT cached by Laravel and issues one
-     * information-schema query per call — on an 8-column list that used to mean
-     * a two-digit number of metadata queries per render.
+     * per table and process (see SchemaColumnCache) — on an 8-column list the
+     * uncached Schema::hasColumn() calls used to mean a two-digit number of
+     * metadata queries per render.
      *
      * @return array<string, array<string, mixed>>
      */
     protected static function tableColumns(string $table): array
     {
-        return self::$schemaColumnCache[$table]
-            ??= collect(Schema::getColumns($table))->keyBy('name')->all();
+        return SchemaColumnCache::columns($table);
     }
 
     /**
@@ -1295,7 +1296,7 @@ trait NoerdList
      */
     protected static function tableHasColumn(string $table, string $column): bool
     {
-        return array_key_exists($column, self::tableColumns($table));
+        return SchemaColumnCache::hasColumn($table, $column);
     }
 
     /**

--- a/src/Traits/TenantFilterTrait.php
+++ b/src/Traits/TenantFilterTrait.php
@@ -13,7 +13,9 @@ trait TenantFilterTrait
         $filter['type'] = 'Picklist';
         $filter['options'] = [];
 
-        $tenants = NoerdAuth::user()->adminTenants;
+        // Guest-safe: a list rendered without an authenticated noerd user
+        // simply offers an empty tenant picklist instead of fataling.
+        $tenants = NoerdAuth::user()?->adminTenants ?? collect();
 
         foreach ($tenants as $tenant) {
             $filter['options'][$tenant->id] = $tenant->name;

--- a/tests/Feature/RelationFieldReadonlyGuardTest.php
+++ b/tests/Feature/RelationFieldReadonlyGuardTest.php
@@ -71,3 +71,17 @@ describe('Relation field readonly server guards', function (): void {
             ->assertNotDispatched('setFieldValue');
     });
 });
+
+it('rejects client writes to the mount-established field identity', function (): void {
+    $props = [
+        'relationType' => 'readonlyGuardRelation',
+        'fieldName' => 'detailData.guard_id',
+        'label' => 'Guard',
+    ];
+
+    expect(fn() => Livewire::test('noerd-relation-field', $props)->set('fieldName', 'detailData.other_id'))
+        ->toThrow(Exception::class);
+
+    expect(fn() => Livewire::test('noerd-relation-field', $props)->set('detailRoute', 'evil.route'))
+        ->toThrow(Exception::class);
+});


### PR DESCRIPTION
Pre-release quality review, phase 5 of 7. Stacked on #46 (retargets once that merges).

## Octane / long-lived worker safety
- The provider's `booted()` flush is explicitly a per-worker (not per-request) hook under Octane. A new `flushRequestState()` covers EVERY request-scoped static the package maintains — `StaticConfigHelper`, `TenantHelper`, `ThemeHelper`, `ThemeContext`, `FieldContext` (was never flushed anywhere), `CurrencyHelper` (same), the database collection-definition repository cache (same) and the `ThemeRegistry` — and runs both on app boot and, via a `class_exists`-guarded `Octane\RequestReceived` listener, before every Octane request. The `RelationTitleResolver` singleton is forgotten per request there too.
- The schema-column cache moves from a trait static into a shared `SchemaColumnCache` support class. A static declared in a trait is duplicated into every composing class — fragmenting the cache per list component and making it impossible to flush. It now resets on `MigrationsEnded` (a worker must not keep serving the pre-migration column listing) and on fresh app boots in test processes (testbench sqlite vs. host MySQL share table names).
- `RelationTitleResolver` memo keys now include the current tenant — the convention lookup is a raw unscoped DB read, and a memoized title must never be served to another tenant a long-lived worker later handles (defense in depth on top of the per-request reset).
- `detail/block.blade.php` now saves/restores the `ThemeContext` around each block (mirroring `NoerdPage`'s rendering hooks) — two sibling blocks with different `theme:` keys no longer leak the first block's theme into chrome rendered after them, and an exception mid-block no longer leaves a stale `FieldContext` for the process (covered by the request-state flush).

## State hygiene
- `listPerPage` is stored per component (`listPerPage.{component}`) — changing the page size of one list no longer changes it for every list. The shared `listFilters` bucket is deliberate (NoerdPage's preselect mechanism seeds it) and now documented as such at the read site.
- All mount-established identity/config properties of the two relation-field components are `#[Locked]` (`fieldName`, `relationType`, `listComponent`, `detailComponent`, `detailRoute`, `typeField`, `allowedTypes`, …) — a crafted update can no longer repoint a field at another form key, list, detail target or widen the polymorphic type whitelist. With a regression test.
- The list deep-link handling moves from the trait's un-namespaced `rendering()` hook into `mountList()`: the old hook was initial-load-only by accident (`request()` is the Livewire POST on updates), used the fragile `request()->create` magic property, and was silently disabled by any component defining its own `rendering()`. Existing deep-link tests pass unchanged.
- `HasEmailPreview` sends its test mail through a queued mailable instead of blocking the Livewire response on SMTP; `TenantFilterTrait` no longer fatals for a guest.

Full package suite: 961 passed, 1 skipped.