### PR TITLE
Deduplicate the component traits: shared base, one layout walker, one init skeleton

### DIFF
--- a/src/Support/LayoutFields.php
+++ b/src/Support/LayoutFields.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Noerd\Support;
+
+/**
+ * The single "recurse into type: block" walk over a YAML field layout. Every
+ * feature that derives something from the field list (writable keys,
+ * validation rules, picklist options, rendered relation forms) visits the
+ * fields through this walker instead of hand-rolling the recursion.
+ */
+final class LayoutFields
+{
+    /**
+     * Visit every non-block field, depth-first through nested `type: block`
+     * groups. The visitor may return `false` to stop the walk early.
+     *
+     * @param  array<int, array<string, mixed>>  $fields
+     * @param  callable(array<string, mixed>): (bool|null|void)  $visitor
+     * @return bool false when the visitor stopped the walk early
+     */
+    public static function walk(array $fields, callable $visitor): bool
+    {
+        foreach ($fields as $field) {
+            if (!is_array($field)) {
+                continue;
+            }
+
+            if (($field['type'] ?? null) === 'block') {
+                if (!self::walk($field['fields'] ?? [], $visitor)) {
+                    return false;
+                }
+
+                continue;
+            }
+
+            if ($visitor($field) === false) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Support/RelationFormSync.php
+++ b/src/Support/RelationFormSync.php
@@ -39,17 +39,11 @@ final class RelationFormSync
      */
     public static function rendered(array $layoutFields, string $formKey): bool
     {
-        foreach ($layoutFields as $field) {
-            if (($field['type'] ?? '') === 'block' && self::rendered($field['fields'] ?? [], $formKey)) {
-                return true;
-            }
-
-            if (str_starts_with($field['name'] ?? '', 'detailData.' . $formKey . '.')) {
-                return true;
-            }
-        }
-
-        return false;
+        // The walk stops (returns false) on the first matching field.
+        return !LayoutFields::walk(
+            $layoutFields,
+            fn(array $field): ?bool => str_starts_with($field['name'] ?? '', 'detailData.' . $formKey . '.') ? false : null,
+        );
     }
 
     /**

--- a/src/Traits/NoerdComponentShared.php
+++ b/src/Traits/NoerdComponentShared.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Noerd\Traits;
+
+/**
+ * The few members NoerdList and NoerdPage genuinely share. Both traits compose
+ * this one; PHP dedupes a method arriving through multiple use-paths of the
+ * SAME trait, so a component may use NoerdList and NoerdPage together without
+ * a collision — previously the byte-identical copies in each trait made that
+ * combination a fatal conflict.
+ */
+trait NoerdComponentShared
+{
+    public bool $disableModal = false;
+
+    /**
+     * Get the component name (alias for getName).
+     */
+    public function getComponentName(): string
+    {
+        return $this->getName();
+    }
+
+    public function refreshList(): void
+    {
+        $this->dispatch('$refresh');
+    }
+}

--- a/src/Traits/NoerdDetail.php
+++ b/src/Traits/NoerdDetail.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Str;
 use Livewire\Attributes\On;
 use Noerd\Helpers\StaticConfigHelper;
 use Noerd\Services\PicklistRegistry;
+use Noerd\Support\LayoutFields;
 use Noerd\Support\RelationFormSync;
 use ReflectionMethod;
 use ReflectionNamedType;
@@ -32,24 +33,16 @@ trait NoerdDetail
 
     public function initDetail(): void
     {
-        if ($this->prepareRoutedModal()) {
-            return;
-        }
-
-        // For detail components declaring $detailModel. Loads the pageLayout first
-        // so the YAML quick-create opt-in below can be read from it.
-        if (isset($this->detailModel)) {
-            if (!$this->canReadObject()) {
-                $this->objectReadBlocked = true;
-
-                return;
+        $this->initNoerdComponent(function (): void {
+            // For detail components declaring $detailModel. Loads the pageLayout
+            // first so the YAML quick-create opt-in below can be read from it.
+            if (isset($this->detailModel)) {
+                $modelClass = $this->detailModel;
+                $this->mountDetailComponent(new $modelClass(), $modelClass);
             }
 
-            $modelClass = $this->detailModel;
-            $this->mountDetailComponent(new $modelClass(), $modelClass);
-        }
-
-        $this->resolveQuickCreate();
+            $this->resolveQuickCreate();
+        });
     }
 
     public function store(): void
@@ -267,32 +260,26 @@ trait NoerdDetail
 
         $fields = StaticConfigHelper::getComponentFields($component, $modelClass)['fields'] ?? [];
 
-        $keys = [];
-        $this->collectWritableDetailDataKeys($fields, $keys);
-
-        return array_values(array_unique($keys));
+        return $this->writableKeysFromFields($fields);
     }
 
     /**
+     * Top-level detailData keys a field layout binds (recursing into blocks).
+     *
      * @param  array<int, array<string, mixed>>  $fields
-     * @param  array<int, string>  $keys
+     * @return array<int, string>
      */
-    protected function collectWritableDetailDataKeys(array $fields, array &$keys): void
+    protected function writableKeysFromFields(array $fields): array
     {
-        foreach ($fields as $field) {
-            if (($field['type'] ?? '') === 'block') {
-                $this->collectWritableDetailDataKeys($field['fields'] ?? [], $keys);
-
-                continue;
-            }
-
+        $keys = [];
+        LayoutFields::walk($fields, function (array $field) use (&$keys): void {
             $name = $field['name'] ?? null;
-            if (! is_string($name) || ! str_starts_with($name, 'detailData.')) {
-                continue;
+            if (is_string($name) && str_starts_with($name, 'detailData.')) {
+                $keys[] = Str::before(Str::after($name, 'detailData.'), '.');
             }
+        });
 
-            $keys[] = Str::before(Str::after($name, 'detailData.'), '.');
-        }
+        return array_values(array_unique($keys));
     }
 
     /**
@@ -390,31 +377,15 @@ trait NoerdDetail
     }
 
     /**
-     * Recursively extract validation rules from fields array.
+     * Extract validation rules from the field layout (recursing into blocks).
      */
     protected function extractRulesFromFields(array $fields, array &$rules): void
     {
-        foreach ($fields as $field) {
-            if (($field['type'] ?? '') === 'block') {
-                $this->extractRulesFromFields($field['fields'] ?? [], $rules);
-
-                continue;
+        LayoutFields::walk($fields, function (array $field) use (&$rules): void {
+            if (isset($field['name']) && ($field['required'] ?? false)) {
+                $rules[$field['name']] = ['required'];
             }
-
-            if (!isset($field['name'])) {
-                continue;
-            }
-
-            $fieldRules = [];
-
-            if ($field['required'] ?? false) {
-                $fieldRules[] = 'required';
-            }
-
-            if (!empty($fieldRules)) {
-                $rules[$field['name']] = $fieldRules;
-            }
-        }
+        });
     }
 
     /**

--- a/src/Traits/NoerdList.php
+++ b/src/Traits/NoerdList.php
@@ -24,6 +24,7 @@ use Noerd\Helpers\SetupCollectionHelper;
 use Noerd\Helpers\StaticConfigHelper;
 use Noerd\Services\ColumnFilterParser;
 use Noerd\Services\RelationTitleResolver;
+use Noerd\Support\LayoutFields;
 use Noerd\Support\SchemaColumnCache;
 use ReflectionClass;
 use ReflectionMethod;
@@ -33,6 +34,7 @@ use UnitEnum;
 
 trait NoerdList
 {
+    use NoerdComponentShared;
     use RoutedModal;
     use WithoutUrlPagination;
     use WithPagination;
@@ -106,8 +108,6 @@ trait NoerdList
     public array $listColumnFilters = [];
 
     public mixed $context = '';
-
-    public bool $disableModal = false;
 
     public bool $compact = false;
 
@@ -339,7 +339,7 @@ trait NoerdList
     #[Computed]
     public function availableListViews(): array
     {
-        return StaticConfigHelper::getListViews($this->getListComponent());
+        return StaticConfigHelper::getListViews($this->listConfigComponent());
     }
 
     /**
@@ -728,14 +728,6 @@ trait NoerdList
             ->all();
     }
 
-    /**
-     * Get the component name (alias for getName).
-     */
-    public function getComponentName(): string
-    {
-        return $this->getName();
-    }
-
     public function updateRow(): void {}
 
     #[Computed]
@@ -752,11 +744,6 @@ trait NoerdList
         }
 
         return $filters;
-    }
-
-    public function refreshList(): void
-    {
-        $this->dispatch('$refresh');
     }
 
     public function renderingNoerdList(): void
@@ -922,12 +909,13 @@ trait NoerdList
     }
 
     /**
-     * Get the detail component name.
-     * Uses DETAIL_COMPONENT constant if defined, otherwise derives from component name.
+     * The name this list's YAML config resolves under: a DETAIL_COMPONENT
+     * constant (legacy custom-config opt-in) or the component's own name.
+     * Renamed from getListComponent(), which meant the OPPOSITE of
+     * NoerdPage::getListComponent() and made composing the two traits a trap.
      */
-    protected function getListComponent(): string
+    protected function listConfigComponent(): string
     {
-
         if (defined('static::DETAIL_COMPONENT')) {
             return static::DETAIL_COMPONENT;
         }
@@ -1479,26 +1467,9 @@ trait NoerdList
 
         $fields = StaticConfigHelper::tryGetComponentFields($detailComponent)['fields'] ?? [];
         $map = [];
-        $this->collectSelectOptions($fields, $map);
-
-        return $this->picklistOptionCache[$detailComponent] = $map;
-    }
-
-    /**
-     * @param  array<int, array<string, mixed>>  $fields
-     * @param  array<string, array<int, array{value: mixed, label: string}>>  $map
-     */
-    protected function collectSelectOptions(array $fields, array &$map): void
-    {
-        foreach ($fields as $field) {
-            if (($field['type'] ?? null) === 'block') {
-                $this->collectSelectOptions($field['fields'] ?? [], $map);
-
-                continue;
-            }
-
+        LayoutFields::walk($fields, function (array $field) use (&$map): void {
             if (!isset($field['name'])) {
-                continue;
+                return;
             }
 
             // A value-storing collection select (valueField) resolves its badge
@@ -1518,16 +1489,17 @@ trait NoerdList
                     $map[Str::after($field['name'], 'detailData.')] = $options;
                 }
 
-                continue;
+                return;
             }
 
             if (($field['type'] ?? null) !== 'select' || empty($field['options'])) {
-                continue;
+                return;
             }
 
-            $key = Str::after($field['name'], 'detailData.');
-            $map[$key] = $field['options'];
-        }
+            $map[Str::after($field['name'], 'detailData.')] = $field['options'];
+        });
+
+        return $this->picklistOptionCache[$detailComponent] = $map;
     }
 
     /**
@@ -1580,7 +1552,7 @@ trait NoerdList
         if ($customName === null && $this->listActionMethod === 'selectAction' && $this->selectListConfig) {
             return StaticConfigHelper::getListConfig($this->selectListConfig, $this->listModel ?? null);
         }
-        $name = $customName ?? $this->getListComponent();
+        $name = $customName ?? $this->listConfigComponent();
 
         // An active alternate view only applies to this component's own config,
         // never to an explicitly requested custom config. A view from another
@@ -1665,11 +1637,18 @@ trait NoerdList
 
     /**
      * Get the event listeners for the component.
-     * Dynamically registers the refreshList listener based on detail component name.
+     * Dynamically registers the refreshList listener based on the config name.
+     *
+     * OVERRIDE CONTRACT: a component defining its own getListeners() replaces
+     * this set entirely and silently disconnects the framework events — always
+     * merge: `return parent-style via the trait alias + [...]` (see
+     * NoerdDetail's pageGetListeners alias for the pattern). #[On] attributes
+     * are no alternative here: the event names embed getName()/config-derived
+     * values, which attribute interpolation cannot express.
      */
     protected function getListeners(): array
     {
-        $name = $this->getListComponent();
+        $name = $this->listConfigComponent();
         $stripped = Str::afterLast($name, '.');
 
         $listeners = ['refreshList-' . $name => 'refreshList'];

--- a/src/Traits/NoerdPage.php
+++ b/src/Traits/NoerdPage.php
@@ -20,6 +20,7 @@ use RuntimeException;
  */
 trait NoerdPage
 {
+    use NoerdComponentShared;
     use RoutedModal;
 
     public bool $showSuccessIndicator = false;
@@ -30,8 +31,6 @@ trait NoerdPage
     public int $currentTab = 1;
 
     public array $pageLayout = [];
-
-    public bool $disableModal = false;
 
     /**
      * Set when the component is rendered inside a hosting page component (e.g.
@@ -56,14 +55,6 @@ trait NoerdPage
      * afterwards so the theme never outlives the render (see renderedNoerdPage).
      */
     protected ?string $themeContextBefore = null;
-
-    /**
-     * Get the component name (alias for getName).
-     */
-    public function getComponentName(): string
-    {
-        return $this->getName();
-    }
 
     /**
      * Livewire trait mount hook (runs for every page/detail). The active tab is
@@ -125,30 +116,44 @@ trait NoerdPage
 
     public function initPage(): void
     {
+        $this->initNoerdComponent(function (): void {
+            // Pages backed by a single Eloquent model declare $detailModel — the
+            // record is loaded into $detailData exactly like a detail would.
+            if (isset($this->detailModel)) {
+                $modelClass = $this->detailModel;
+                if (!$this->loadDetailModel(new $modelClass(), $modelClass)) {
+                    return;
+                }
+            }
+
+            // The page YAML (pages/{name}.yml) is OPTIONAL — hand-built pages keep
+            // defining their layout in the component itself.
+            $this->pageLayout = StaticConfigHelper::getPageFields($this->getName(), $this->detailModel ?? null);
+
+            $this->resolveQuickCreate();
+        });
+    }
+
+    /**
+     * Shared init skeleton of initPage()/initDetail()/initSettings(): routed-
+     * modal redirect, the object-read guard (canReadObject() is unrestricted
+     * for components without $detailModel and overridden by settings pages),
+     * then the component-specific loading. The three inits used to be three
+     * drifting copies of exactly this sequence.
+     */
+    protected function initNoerdComponent(callable $load): void
+    {
         if ($this->prepareRoutedModal()) {
             return;
         }
 
-        // Pages backed by a single Eloquent model declare $detailModel — the
-        // record is loaded into $detailData exactly like a detail would.
-        if (isset($this->detailModel)) {
-            if (!$this->canReadObject()) {
-                $this->objectReadBlocked = true;
+        if (!$this->canReadObject()) {
+            $this->objectReadBlocked = true;
 
-                return;
-            }
-
-            $modelClass = $this->detailModel;
-            if (!$this->loadDetailModel(new $modelClass(), $modelClass)) {
-                return;
-            }
+            return;
         }
 
-        // The page YAML (pages/{name}.yml) is OPTIONAL — hand-built pages keep
-        // defining their layout in the component itself.
-        $this->pageLayout = StaticConfigHelper::getPageFields($this->getName(), $this->detailModel ?? null);
-
-        $this->resolveQuickCreate();
+        $load();
     }
 
     public function closeModalProcess(?string $source = null): void
@@ -312,11 +317,6 @@ trait NoerdPage
     public function embeddedDetailDataUpdated(array $detailData): void
     {
         $this->detailData = array_merge($this->detailData, $detailData);
-    }
-
-    public function refreshList(): void
-    {
-        $this->dispatch('$refresh');
     }
 
     /**
@@ -505,6 +505,13 @@ trait NoerdPage
      * Get the event listeners for the component: the generic list refresh plus —
      * when the page YAML declares an embedded detail — the store roundtrip events
      * scoped by the detail's full component name.
+     *
+     * OVERRIDE CONTRACT: a component defining its own getListeners() replaces
+     * this set entirely and silently disconnects the framework events — always
+     * merge: `return parent-style via the trait alias + [...]` (see
+     * NoerdDetail's pageGetListeners alias for the pattern). #[On] attributes
+     * are no alternative here: the event names embed getName()/config-derived
+     * values, which attribute interpolation cannot express.
      */
     protected function getListeners(): array
     {

--- a/src/Traits/NoerdSettingsPage.php
+++ b/src/Traits/NoerdSettingsPage.php
@@ -5,6 +5,7 @@ namespace Noerd\Traits;
 use Illuminate\Support\Str;
 use Noerd\Helpers\StaticConfigHelper;
 use Noerd\Helpers\TenantHelper;
+use Noerd\Support\LayoutFields;
 use RuntimeException;
 
 /**
@@ -35,21 +36,19 @@ trait NoerdSettingsPage
 
     public function initSettings(): void
     {
-        if ($this->prepareRoutedModal()) {
-            return;
-        }
+        $this->initNoerdComponent(function (): void {
+            $tenantId = TenantHelper::getSelectedTenantId();
 
-        $tenantId = TenantHelper::getSelectedTenantId();
+            foreach ($this->settingsModelMap() as $property => $modelClass) {
+                $model = $modelClass::firstOrNew(['tenant_id' => $tenantId]);
 
-        foreach ($this->settingsModelMap() as $property => $modelClass) {
-            $model = $modelClass::firstOrNew(['tenant_id' => $tenantId]);
+                $this->{$property} = collect($model->toArray())
+                    ->except(['created_at', 'updated_at'])
+                    ->toArray();
+            }
 
-            $this->{$property} = collect($model->toArray())
-                ->except(['created_at', 'updated_at'])
-                ->toArray();
-        }
-
-        $this->pageLayout = StaticConfigHelper::getSettingsFields($this->getName());
+            $this->pageLayout = StaticConfigHelper::getSettingsFields($this->getName());
+        });
     }
 
     public function store(): void
@@ -94,32 +93,20 @@ trait NoerdSettingsPage
     protected function settingsWritableKeys(): array
     {
         $map = [];
-        $this->collectSettingsWritableKeys(StaticConfigHelper::getSettingsFields($this->getName())['fields'] ?? [], $map);
+        LayoutFields::walk(
+            StaticConfigHelper::getSettingsFields($this->getName())['fields'] ?? [],
+            function (array $field) use (&$map): void {
+                $name = $field['name'] ?? null;
+                if (! is_string($name) || ! str_contains($name, '.')) {
+                    return;
+                }
+
+                [$property, $rest] = explode('.', $name, 2);
+                $map[$property][] = Str::before($rest, '.');
+            },
+        );
 
         return $map;
-    }
-
-    /**
-     * @param  array<int, array<string, mixed>>  $fields
-     * @param  array<string, array<int, string>>  $map
-     */
-    protected function collectSettingsWritableKeys(array $fields, array &$map): void
-    {
-        foreach ($fields as $field) {
-            if (($field['type'] ?? '') === 'block') {
-                $this->collectSettingsWritableKeys($field['fields'] ?? [], $map);
-
-                continue;
-            }
-
-            $name = $field['name'] ?? null;
-            if (! is_string($name) || ! str_contains($name, '.')) {
-                continue;
-            }
-
-            [$property, $rest] = explode('.', $name, 2);
-            $map[$property][] = Str::before($rest, '.');
-        }
     }
 
     /**

--- a/tests/Feature/SecurityCriticalFixesTest.php
+++ b/tests/Feature/SecurityCriticalFixesTest.php
@@ -166,10 +166,7 @@ it('reduces a detail payload to declared layout keys and always drops identity/t
         /** @param array<int, array<string, mixed>> $fields */
         public function collectKeys(array $fields): array
         {
-            $keys = [];
-            $this->collectWritableDetailDataKeys($fields, $keys);
-
-            return array_values(array_unique($keys));
+            return $this->writableKeysFromFields($fields);
         }
 
         /**


### PR DESCRIPTION
Pre-release quality review, phase 6a of 7. Stacked on #47.

AGENTS.md says "never duplicate between NoerdPage and NoerdDetail" — the traits had drifted from that rule in four ways, each fixed here:

- **`NoerdComponentShared`**: `getComponentName()`, `refreshList()` and `$disableModal` were byte-identical in `NoerdList` and `NoerdPage`. Both now compose one shared trait — which also makes using `NoerdList` and `NoerdPage` together possible at all (identical copies in two traits are a fatal PHP collision).
- **`LayoutFields::walk()`**: five hand-rolled copies of the same "recurse into `type: block`" walk (`collectWritableDetailDataKeys`, `collectSettingsWritableKeys`, `collectSelectOptions`, `extractRulesFromFields`, `RelationFormSync::rendered`) collapse into one walker with early-exit support. The writable-key collection is exposed as a testable `writableKeysFromFields()`.
- **`initNoerdComponent()`**: `initPage()`, `initDetail()` and `initSettings()` were three drifting copies of the same skeleton (routed-modal redirect → object-read guard → load). They now share it — which also gives settings pages the read-guard sequence the other two had.
- **`NoerdList::getListComponent()` → `listConfigComponent()`**: the old name meant the OPPOSITE of `NoerdPage::getListComponent()` (this list's own config name vs. "derive the list for this detail") — a semantic collision between two traits designed to compose. No external caller used the list-side name (verified across all modules); the page-side contract is unchanged.
- The `getListeners()` override contract is now documented loudly on all three traits (a component defining its own silently disconnects the framework events). Migrating to `#[On]` attributes is deliberately NOT done: the event names embed `getName()`/config-derived values, which attribute interpolation cannot express.

Full package suite: 962 passed, 1 skipped; module suites (customer, accounting, crm) green against the refactor.