### PR TITLE
Deduplicate the install/update command layer and make config publishing non-destructive

### DIFF
--- a/resources/views/components/setup-collection-definition-detail.blade.php
+++ b/resources/views/components/setup-collection-definition-detail.blade.php
@@ -331,14 +331,9 @@ new class extends Component
                             <td class="py-1 border-gray-300 border-r border-b">
                                 <select wire:model="fields.{{ $index }}.type"
                                         class="border-transparent! ring-0! border-1! focus:ring-0! focus:border-1! p-0 bg-transparent w-full text-sm py-0.5 px-1.5">
-                                    <option value="text">Text</option>
-                                    <option value="translatableText">Translatable Text</option>
-                                    <option value="translatableTextarea">Translatable Textarea</option>
-                                    <option value="translatableRichText">Translatable RichText</option>
-                                    <option value="image">Image</option>
-                                    <option value="email">E-Mail</option>
-                                    <option value="tel">Tel</option>
-                                    <option value="checkbox">Checkbox</option>
+                                    @foreach (\Noerd\Helpers\SetupCollectionHelper::FIELD_TYPES as $typeValue => $typeLabel)
+                                        <option value="{{ $typeValue }}">{{ $typeLabel }}</option>
+                                    @endforeach
                                 </select>
                             </td>
                             <td class="py-1 border-gray-300 border-r border-b">

--- a/src/Commands/Concerns/PublishesConfigDirectory.php
+++ b/src/Commands/Concerns/PublishesConfigDirectory.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Noerd\Commands\Concerns;
+
+use Exception;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+/**
+ * The single recursive config-publishing implementation shared by
+ * noerd:install/noerd:update and the module install commands — previously two
+ * divergent ~65-line copies. Existing files prompt skip/overwrite/overwrite-all
+ * (or are overwritten under --force), and every overwrite first writes a
+ * one-generation `.bak` next to the file, so an update can never destroy a
+ * host customization irrecoverably.
+ */
+trait PublishesConfigDirectory
+{
+    /**
+     * @param  string|null  $displayBase  base path stripped from printed paths;
+     *                                    defaults to the source directory
+     * @return array{created_dirs: int, copied_files: int, skipped_files: int, overwritten_files: int}
+     */
+    protected function publishConfigDirectory(string $sourceDir, string $targetDir, ?string $displayBase = null): array
+    {
+        $results = [
+            'created_dirs' => 0,
+            'copied_files' => 0,
+            'skipped_files' => 0,
+            'overwritten_files' => 0,
+        ];
+
+        $display = function (string $path) use ($sourceDir, $targetDir, $displayBase): string {
+            if ($displayBase !== null) {
+                return str_replace($displayBase . DIRECTORY_SEPARATOR, '', $path);
+            }
+
+            return mb_substr($path, mb_strlen($targetDir) + 1) ?: $path;
+        };
+
+        if (!is_dir($targetDir)) {
+            if (!mkdir($targetDir, 0755, true)) {
+                throw new Exception("Failed to create directory: {$targetDir}");
+            }
+            $this->line('<info>Created directory:</info> ' . $display($targetDir));
+            $results['created_dirs']++;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($sourceDir, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::SELF_FIRST,
+        );
+
+        foreach ($iterator as $item) {
+            $sourcePath = $item->getPathname();
+            $relativePath = mb_substr($sourcePath, mb_strlen($sourceDir) + 1);
+            $targetPath = $targetDir . DIRECTORY_SEPARATOR . $relativePath;
+            $displayPath = $display($targetPath);
+
+            if ($item->isDir()) {
+                if (!is_dir($targetPath)) {
+                    if (!mkdir($targetPath, 0755, true)) {
+                        throw new Exception("Failed to create directory: {$targetPath}");
+                    }
+                    $this->line("<info>Created directory:</info> {$displayPath}");
+                    $results['created_dirs']++;
+                }
+
+                continue;
+            }
+
+            if (file_exists($targetPath)) {
+                if (!$this->option('force')) {
+                    $choice = $this->choice(
+                        "File already exists: {$displayPath}. What do you want to do?",
+                        ['skip', 'overwrite', 'overwrite-all'],
+                        'skip',
+                    );
+
+                    if ($choice === 'skip') {
+                        $this->line("<comment>Skipped:</comment> {$displayPath}");
+                        $results['skipped_files']++;
+
+                        continue;
+                    }
+                    if ($choice === 'overwrite-all') {
+                        // Set force option for remaining files
+                        $this->input->setOption('force', true);
+                    }
+                }
+
+                // One-generation backup so --force can always be undone.
+                @copy($targetPath, $targetPath . '.bak');
+
+                $this->line("<comment>Overwriting:</comment> {$displayPath}");
+                $results['overwritten_files']++;
+            } else {
+                $this->line("<info>Copying:</info> {$displayPath}");
+                $results['copied_files']++;
+            }
+
+            if (!copy($sourcePath, $targetPath)) {
+                throw new Exception("Failed to copy file: {$sourcePath} to {$targetPath}");
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * @param  array{created_dirs: int, copied_files: int, skipped_files: int, overwritten_files: int}  $results
+     */
+    protected function displayPublishSummary(array $results): void
+    {
+        $this->line('');
+        $this->info('Installation Summary:');
+        $this->table(
+            ['Operation', 'Count'],
+            [
+                ['Directories created', $results['created_dirs']],
+                ['Files copied', $results['copied_files']],
+                ['Files overwritten', $results['overwritten_files']],
+                ['Files skipped', $results['skipped_files']],
+            ],
+        );
+    }
+}

--- a/src/Commands/Concerns/RunsNpmBuild.php
+++ b/src/Commands/Concerns/RunsNpmBuild.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Noerd\Commands\Concerns;
+
+/**
+ * Run `npm run build` in the project root, streaming output to the terminal.
+ * Shared by noerd:install, noerd:update and the module install commands —
+ * previously three byte-identical proc_open blocks.
+ */
+trait RunsNpmBuild
+{
+    protected function executeNpmBuild(): void
+    {
+        $this->line('Running npm run build...');
+        $this->newLine();
+
+        $process = proc_open(
+            'npm run build',
+            [
+                0 => STDIN,
+                1 => STDOUT,
+                2 => STDERR,
+            ],
+            $pipes,
+            base_path(),
+        );
+
+        if (!is_resource($process)) {
+            $this->warn('Could not execute npm run build. Please run it manually.');
+
+            return;
+        }
+
+        $exitCode = proc_close($process);
+
+        $this->newLine();
+        if ($exitCode === 0) {
+            $this->info('Frontend assets compiled successfully!');
+        } else {
+            $this->warn('npm run build finished with errors. You may need to run it manually.');
+        }
+    }
+}

--- a/src/Commands/MakeCollectionCommand.php
+++ b/src/Commands/MakeCollectionCommand.php
@@ -16,18 +16,7 @@ class MakeCollectionCommand extends Command
 
     protected $description = 'Create a new collection YML file interactively';
 
-    private array $fieldTypes = [
-        'translatableText' => 'Translatable Text',
-        'translatableTextarea' => 'Translatable Textarea',
-        'text' => 'Text',
-        'textarea' => 'Textarea',
-        'checkbox' => 'Checkbox',
-        'select' => 'Select',
-        'image' => 'Image',
-        'date' => 'Date',
-        'datetime' => 'DateTime',
-        'number' => 'Number',
-    ];
+    private array $fieldTypes = \Noerd\Helpers\SetupCollectionHelper::FIELD_TYPES;
 
     public function handle(): int
     {

--- a/src/Commands/NoerdInstallCommand.php
+++ b/src/Commands/NoerdInstallCommand.php
@@ -15,11 +15,12 @@ use Noerd\Models\NoerdUser;
 use Noerd\Models\Tenant;
 use Noerd\Models\TenantApp;
 use Noerd\Services\FrontendScaffolder;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
 
 class NoerdInstallCommand extends Command
 {
+    use \Noerd\Commands\Concerns\PublishesConfigDirectory;
+    use \Noerd\Commands\Concerns\RunsNpmBuild;
+
     protected $signature = 'noerd:install {--force : Overwrite existing files without asking}';
 
     protected $description = 'Install noerd content to the local content directory';
@@ -105,76 +106,11 @@ class NoerdInstallCommand extends Command
     }
 
     /**
-     * Copy directory contents recursively
+     * Copy directory contents recursively (see PublishesConfigDirectory).
      */
     protected function copyDirectoryContents(string $sourceDir, string $targetDir): array
     {
-        $results = [
-            'created_dirs' => 0,
-            'copied_files' => 0,
-            'skipped_files' => 0,
-            'overwritten_files' => 0,
-        ];
-
-        $iterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($sourceDir, RecursiveDirectoryIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::SELF_FIRST,
-        );
-
-        foreach ($iterator as $item) {
-            $sourcePath = $item->getPathname();
-            $relativePath = mb_substr($sourcePath, mb_strlen($sourceDir) + 1);
-            $targetPath = $targetDir . DIRECTORY_SEPARATOR . $relativePath;
-
-            if ($item->isDir()) {
-                // Create directory if it doesn't exist
-                if (!is_dir($targetPath)) {
-
-                    if (!mkdir($targetPath, 0755, true)) {
-                        throw new Exception("Failed to create directory: {$targetPath}");
-                    }
-
-                    $this->line("<info>Created directory:</info> {$relativePath}");
-                    $results['created_dirs']++;
-                }
-            } else {
-                // Check if file already exists
-                if (file_exists($targetPath)) {
-                    if (!$this->option('force')) {
-
-
-                        $choice = $this->choice(
-                            "File already exists: {$relativePath}. What do you want to do?",
-                            ['skip', 'overwrite', 'overwrite-all'],
-                            'skip',
-                        );
-
-                        if ($choice === 'skip') {
-                            $this->line("<comment>Skipped:</comment> {$relativePath}");
-                            $results['skipped_files']++;
-                            continue;
-                        }
-                        if ($choice === 'overwrite-all') {
-                            // Set force option for remaining files
-                            $this->input->setOption('force', true);
-                        }
-                    }
-
-                    $this->line("<comment>Overwriting:</comment> {$relativePath}");
-                    $results['overwritten_files']++;
-                } else {
-                    $this->line("<info>Copying:</info> {$relativePath}");
-                    $results['copied_files']++;
-                }
-
-                if (!copy($sourcePath, $targetPath)) {
-                    throw new Exception("Failed to copy file: {$sourcePath} to {$targetPath}");
-                }
-
-            }
-        }
-
-        return $results;
+        return $this->publishConfigDirectory($sourceDir, $targetDir);
     }
 
     /**
@@ -204,7 +140,10 @@ class NoerdInstallCommand extends Command
 
             $this->line('<info>Frontend assets setup completed successfully.</info>');
         } catch (Exception $e) {
-            $this->warn('Frontend assets setup failed: ' . $e->getMessage());
+            // Surface the failure loudly — a broken frontend scaffold must not
+            // end in a green "Application ready!" message.
+            $this->error('Frontend assets setup failed: ' . $e->getMessage());
+            $this->error('Fix the issue and re-run: php artisan noerd:update');
         }
     }
 
@@ -249,11 +188,17 @@ class NoerdInstallCommand extends Command
 
         $this->line('<comment>Installing npm packages...</comment>');
 
-        $command = 'cd ' . base_path() . ' && npm install ' . implode(' ', $packages) . ' --save-dev';
-        exec($command, $output, $returnCode);
+        // Process handles the working directory and argument escaping — the
+        // previous string-built `cd <path> && npm install ...` broke on paths
+        // with spaces and discarded npm's diagnostics on failure.
+        $result = \Illuminate\Support\Facades\Process::path(base_path())
+            ->timeout(300)
+            ->run(array_merge(['npm', 'install'], $packages, ['--save-dev']));
 
-        if ($returnCode !== 0) {
-            $this->warn('Failed to install npm packages. You may need to run the following manually:');
+        if ($result->failed()) {
+            $this->warn('Failed to install npm packages:');
+            $this->warn(mb_trim($result->errorOutput() ?: $result->output()));
+            $this->warn('You may need to run the following manually:');
             $this->warn('npm install ' . implode(' ', $packages) . ' --save-dev');
         } else {
             $this->line('<info>NPM packages installed successfully.</info>');
@@ -359,17 +304,7 @@ class NoerdInstallCommand extends Command
      */
     protected function displaySummary(array $results): void
     {
-        $this->line('');
-        $this->info('Installation Summary:');
-        $this->table(
-            ['Operation', 'Count'],
-            [
-                ['Directories created', $results['created_dirs']],
-                ['Files copied', $results['copied_files']],
-                ['Files overwritten', $results['overwritten_files']],
-                ['Files skipped', $results['skipped_files']],
-            ],
-        );
+        $this->displayPublishSummary($results);
     }
 
     /**
@@ -456,15 +391,57 @@ class NoerdInstallCommand extends Command
         }
 
         if (file_exists($targetPath)) {
-            if (!$this->option('force')) {
-                if (!$this->confirm('config/noerd.php already exists. Do you want to overwrite it?', false)) {
-                    $this->line('<comment>Skipped config/noerd.php publishing.</comment>');
+            $this->refreshExistingNoerdConfig($sourcePath, $targetPath);
 
-                    return;
-                }
-            }
-            $this->line('<comment>Overwriting config/noerd.php...</comment>');
+            return;
         }
+
+        if (copy($sourcePath, $targetPath)) {
+            $this->line('<info>Published config/noerd.php successfully.</info>');
+        } else {
+            $this->warn('Failed to publish config/noerd.php');
+        }
+    }
+
+    /**
+     * An existing config/noerd.php belongs to the host — never clobber it
+     * silently. The stub is diffed against it: missing top-level keys are
+     * reported (the documented contract is that noerd:update carries new keys
+     * into existing installations), and an overwrite — via --force or an
+     * explicit confirmation — first writes a one-generation .bak backup.
+     */
+    protected function refreshExistingNoerdConfig(string $sourcePath, string $targetPath): void
+    {
+        $missing = [];
+        try {
+            $stub = require $sourcePath;
+            $current = require $targetPath;
+            if (is_array($stub) && is_array($current)) {
+                $missing = array_keys(array_diff_key($stub, $current));
+            }
+        } catch (Exception) {
+            // A config that cannot be evaluated is treated as customized.
+        }
+
+        if (!$this->option('force')) {
+            if ($missing === []) {
+                $this->line('<comment>config/noerd.php already exists and declares every stub key — left untouched.</comment>');
+
+                return;
+            }
+
+            $this->warn('config/noerd.php is missing new top-level keys: ' . implode(', ', $missing));
+
+            if (!$this->input->isInteractive()
+                || !$this->confirm('Overwrite config/noerd.php with the current stub (a .bak backup is written)?', false)) {
+                $this->line('<comment>Skipped config/noerd.php publishing. Add the missing keys manually (see stubs/noerd.php.stub).</comment>');
+
+                return;
+            }
+        }
+
+        @copy($targetPath, $targetPath . '.bak');
+        $this->line('<comment>Overwriting config/noerd.php (backup: config/noerd.php.bak)...</comment>');
 
         if (copy($sourcePath, $targetPath)) {
             $this->line('<info>Published config/noerd.php successfully.</info>');
@@ -751,32 +728,7 @@ class NoerdInstallCommand extends Command
             return;
         }
 
-        $this->line('Running npm run build...');
-        $this->newLine();
-
-        $process = proc_open(
-            'npm run build',
-            [
-                0 => STDIN,
-                1 => STDOUT,
-                2 => STDERR,
-            ],
-            $pipes,
-            base_path(),
-        );
-
-        if (is_resource($process)) {
-            $exitCode = proc_close($process);
-
-            $this->newLine();
-            if ($exitCode === 0) {
-                $this->info('Frontend assets compiled successfully!');
-            } else {
-                $this->warn('npm run build finished with errors. You may need to run it manually.');
-            }
-        } else {
-            $this->warn('Could not execute npm run build. Please run it manually.');
-        }
+        $this->executeNpmBuild();
     }
 
     /**

--- a/src/Commands/NoerdUpdateCommand.php
+++ b/src/Commands/NoerdUpdateCommand.php
@@ -64,31 +64,6 @@ class NoerdUpdateCommand extends NoerdInstallCommand
     protected function runNpmBuildWithoutPrompt(): void
     {
         $this->newLine();
-        $this->line('Running npm run build...');
-        $this->newLine();
-
-        $process = proc_open(
-            'npm run build',
-            [
-                0 => STDIN,
-                1 => STDOUT,
-                2 => STDERR,
-            ],
-            $pipes,
-            base_path(),
-        );
-
-        if (is_resource($process)) {
-            $exitCode = proc_close($process);
-
-            $this->newLine();
-            if ($exitCode === 0) {
-                $this->info('Frontend assets compiled successfully!');
-            } else {
-                $this->warn('npm run build finished with errors. You may need to run it manually.');
-            }
-        } else {
-            $this->warn('Could not execute npm run build. Please run it manually.');
-        }
+        $this->executeNpmBuild();
     }
 }

--- a/src/Commands/stubs/module/detail.stub
+++ b/src/Commands/stubs/module/detail.stub
@@ -14,7 +14,7 @@ new class extends Component {
 
 <x-noerd::page>
     <x-slot:header>
-        <x-noerd::modal-title>{{Model}}</x-noerd::modal-title>
+        <x-noerd::modal-title>{{ __('{{Model}}') }}</x-noerd::modal-title>
     </x-slot:header>
 
     <x-noerd::tab-content :layout="$pageLayout" :modelId="$modelId" />

--- a/src/Commands/stubs/resource/detail.blade.stub
+++ b/src/Commands/stubs/resource/detail.blade.stub
@@ -14,7 +14,7 @@ new class extends Component {
 
 <x-noerd::page>
     <x-slot:header>
-        <x-noerd::modal-title>{{ModelBaseName}}</x-noerd::modal-title>
+        <x-noerd::modal-title>{{ __('{{ModelBaseName}}') }}</x-noerd::modal-title>
     </x-slot:header>
 
     <x-noerd::tab-content :layout="$pageLayout" :modelId="$modelId" />

--- a/src/Commands/stubs/resource/list.blade.stub
+++ b/src/Commands/stubs/resource/list.blade.stub
@@ -7,16 +7,9 @@ use {{ModelClass}};
 new class extends Component {
     use NoerdList;
 
+    public $listModel = {{ModelBaseName}}::class;
+
     public $detailComponent = '{{entity}}-detail';
-
-    public function with(): array
-    {
-        $rows = $this->listQuery({{ModelBaseName}}::class)->paginate($this->perPage);
-
-        return [
-            'listConfig' => $this->buildList($rows),
-        ];
-    }
 }; ?>
 
 <x-noerd::page>

--- a/src/Commands/stubs/resource/page.blade.stub
+++ b/src/Commands/stubs/resource/page.blade.stub
@@ -8,7 +8,7 @@ new class extends Component {
 
 <x-noerd::page>
     <x-slot:header>
-        <x-noerd::modal-title>{{ModelBaseName}}</x-noerd::modal-title>
+        <x-noerd::modal-title>{{ __('{{ModelBaseName}}') }}</x-noerd::modal-title>
     </x-slot>
 
     <p class="py-8 text-sm">

--- a/src/Helpers/SetupCollectionHelper.php
+++ b/src/Helpers/SetupCollectionHelper.php
@@ -8,6 +8,32 @@ use Noerd\Models\SetupLanguage;
 
 class SetupCollectionHelper
 {
+    /**
+     * Field types a collection definition may use, value => display label.
+     * The single source for the noerd:make-collection prompt AND the
+     * definition editor UI — the two used to carry diverging hardcoded lists.
+     * Deliberately curated rather than derived from FieldTypeRegistry, which
+     * also contains structural and relation types that make no sense on a
+     * collection entry.
+     *
+     * @var array<string, string>
+     */
+    public const FIELD_TYPES = [
+        'text' => 'Text',
+        'textarea' => 'Textarea',
+        'translatableText' => 'Translatable Text',
+        'translatableTextarea' => 'Translatable Textarea',
+        'translatableRichText' => 'Translatable RichText',
+        'image' => 'Image',
+        'email' => 'E-Mail',
+        'tel' => 'Tel',
+        'checkbox' => 'Checkbox',
+        'select' => 'Select',
+        'date' => 'Date',
+        'datetime' => 'DateTime',
+        'number' => 'Number',
+    ];
+
     public function __construct(
         private readonly SetupCollectionDefinitionRepositoryContract $repository,
     ) {}

--- a/src/Traits/HasModuleInstallation.php
+++ b/src/Traits/HasModuleInstallation.php
@@ -10,6 +10,9 @@ use Symfony\Component\Yaml\Yaml;
 
 trait HasModuleInstallation
 {
+    use \Noerd\Commands\Concerns\PublishesConfigDirectory;
+    use \Noerd\Commands\Concerns\RunsNpmBuild;
+
     private array $installResults = [
         'created_dirs' => 0,
         'copied_files' => 0,
@@ -107,42 +110,7 @@ trait HasModuleInstallation
         $this->line('');
 
         try {
-            // Copy lists
-            $listsSource = $sourceDir . DIRECTORY_SEPARATOR . 'lists';
-            $listsTarget = $targetDir . DIRECTORY_SEPARATOR . 'lists';
-            if (is_dir($listsSource)) {
-                $this->copyDirectoryContents($listsSource, $listsTarget);
-            }
-
-            // Copy details
-            $detailsSource = $sourceDir . DIRECTORY_SEPARATOR . 'details';
-            $detailsTarget = $targetDir . DIRECTORY_SEPARATOR . 'details';
-            if (is_dir($detailsSource)) {
-                $this->copyDirectoryContents($detailsSource, $detailsTarget);
-            }
-
-            // Copy pages
-            $pagesSource = $sourceDir . DIRECTORY_SEPARATOR . 'pages';
-            $pagesTarget = $targetDir . DIRECTORY_SEPARATOR . 'pages';
-            if (is_dir($pagesSource)) {
-                $this->copyDirectoryContents($pagesSource, $pagesTarget);
-            }
-
-            // Copy settings
-            $settingsSource = $sourceDir . DIRECTORY_SEPARATOR . 'settings';
-            $settingsTarget = $targetDir . DIRECTORY_SEPARATOR . 'settings';
-            if (is_dir($settingsSource)) {
-                $this->copyDirectoryContents($settingsSource, $settingsTarget);
-            }
-
-            // Copy additional subdirectories
-            foreach ($this->getAdditionalSubdirectories() as $subdir) {
-                $additionalSource = $sourceDir . DIRECTORY_SEPARATOR . $subdir;
-                $additionalTarget = $targetDir . DIRECTORY_SEPARATOR . $subdir;
-                if (is_dir($additionalSource)) {
-                    $this->copyDirectoryContents($additionalSource, $additionalTarget);
-                }
-            }
+            $this->copyConfigSubdirectories($sourceDir, $targetDir);
 
             // Copy navigation.yml
             $navSource = $sourceDir . DIRECTORY_SEPARATOR . 'navigation.yml';
@@ -259,42 +227,7 @@ trait HasModuleInstallation
         }
 
         try {
-            // Copy lists
-            $listsSource = $sourceDir . DIRECTORY_SEPARATOR . 'lists';
-            $listsTarget = $targetDir . DIRECTORY_SEPARATOR . 'lists';
-            if (is_dir($listsSource)) {
-                $this->copyDirectoryContents($listsSource, $listsTarget);
-            }
-
-            // Copy details
-            $detailsSource = $sourceDir . DIRECTORY_SEPARATOR . 'details';
-            $detailsTarget = $targetDir . DIRECTORY_SEPARATOR . 'details';
-            if (is_dir($detailsSource)) {
-                $this->copyDirectoryContents($detailsSource, $detailsTarget);
-            }
-
-            // Copy pages
-            $pagesSource = $sourceDir . DIRECTORY_SEPARATOR . 'pages';
-            $pagesTarget = $targetDir . DIRECTORY_SEPARATOR . 'pages';
-            if (is_dir($pagesSource)) {
-                $this->copyDirectoryContents($pagesSource, $pagesTarget);
-            }
-
-            // Copy settings
-            $settingsSource = $sourceDir . DIRECTORY_SEPARATOR . 'settings';
-            $settingsTarget = $targetDir . DIRECTORY_SEPARATOR . 'settings';
-            if (is_dir($settingsSource)) {
-                $this->copyDirectoryContents($settingsSource, $settingsTarget);
-            }
-
-            // Copy additional subdirectories (e.g., collections, forms for CMS)
-            foreach ($this->getAdditionalSubdirectories() as $subdir) {
-                $additionalSource = $sourceDir . DIRECTORY_SEPARATOR . $subdir;
-                $additionalTarget = $targetDir . DIRECTORY_SEPARATOR . $subdir;
-                if (is_dir($additionalSource)) {
-                    $this->copyDirectoryContents($additionalSource, $additionalTarget);
-                }
-            }
+            $this->copyConfigSubdirectories($sourceDir, $targetDir);
 
             $this->installAsNewApp($sourceDir, $targetDir, $isHidden);
 
@@ -486,71 +419,36 @@ trait HasModuleInstallation
     }
 
     /**
-     * Copy directory contents recursively.
+     * Copy every standard app-config subdirectory (lists, details, pages,
+     * settings, plus the module's getAdditionalSubdirectories()) from the
+     * module source into the project. Shared by install and update — the two
+     * flows used to carry identical copies of this sequence.
+     */
+    protected function copyConfigSubdirectories(string $sourceDir, string $targetDir): void
+    {
+        $subdirectories = array_merge(
+            ['lists', 'details', 'pages', 'settings'],
+            $this->getAdditionalSubdirectories(),
+        );
+
+        foreach ($subdirectories as $subdir) {
+            $source = $sourceDir . DIRECTORY_SEPARATOR . $subdir;
+            if (is_dir($source)) {
+                $this->copyDirectoryContents($source, $targetDir . DIRECTORY_SEPARATOR . $subdir);
+            }
+        }
+    }
+
+    /**
+     * Copy directory contents recursively, accumulating the module-wide
+     * install counters (see PublishesConfigDirectory).
      */
     protected function copyDirectoryContents(string $sourceDir, string $targetDir): void
     {
-        if (!is_dir($targetDir)) {
-            if (!mkdir($targetDir, 0755, true)) {
-                throw new Exception("Failed to create directory: {$targetDir}");
-            }
-            $relativePath = str_replace(base_path('app-configs') . DIRECTORY_SEPARATOR, '', $targetDir);
-            $this->line("<info>Created directory:</info> {$relativePath}");
-            $this->installResults['created_dirs']++;
-        }
+        $results = $this->publishConfigDirectory($sourceDir, $targetDir, base_path('app-configs'));
 
-        $iterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($sourceDir, RecursiveDirectoryIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::SELF_FIRST,
-        );
-
-        foreach ($iterator as $item) {
-            $sourcePath = $item->getPathname();
-            $relativePath = mb_substr($sourcePath, mb_strlen($sourceDir) + 1);
-            $targetPath = $targetDir . DIRECTORY_SEPARATOR . $relativePath;
-
-            if ($item->isDir()) {
-                if (!is_dir($targetPath)) {
-                    if (!mkdir($targetPath, 0755, true)) {
-                        throw new Exception("Failed to create directory: {$targetPath}");
-                    }
-                    $displayPath = str_replace(base_path('app-configs') . DIRECTORY_SEPARATOR, '', $targetPath);
-                    $this->line("<info>Created directory:</info> {$displayPath}");
-                    $this->installResults['created_dirs']++;
-                }
-            } else {
-                $displayPath = str_replace(base_path('app-configs') . DIRECTORY_SEPARATOR, '', $targetPath);
-
-                if (file_exists($targetPath)) {
-                    if (!$this->option('force')) {
-                        $choice = $this->choice(
-                            "File already exists: {$displayPath}. What do you want to do?",
-                            ['skip', 'overwrite', 'overwrite-all'],
-                            'skip',
-                        );
-
-                        if ($choice === 'skip') {
-                            $this->line("<comment>Skipped:</comment> {$displayPath}");
-                            $this->installResults['skipped_files']++;
-
-                            continue;
-                        }
-                        if ($choice === 'overwrite-all') {
-                            $this->input->setOption('force', true);
-                        }
-                    }
-
-                    $this->line("<comment>Overwriting:</comment> {$displayPath}");
-                    $this->installResults['overwritten_files']++;
-                } else {
-                    $this->line("<info>Copying:</info> {$displayPath}");
-                    $this->installResults['copied_files']++;
-                }
-
-                if (!copy($sourcePath, $targetPath)) {
-                    throw new Exception("Failed to copy file: {$sourcePath} to {$targetPath}");
-                }
-            }
+        foreach ($results as $key => $count) {
+            $this->installResults[$key] += $count;
         }
     }
 
@@ -597,17 +495,7 @@ trait HasModuleInstallation
      */
     protected function displayInstallSummary(): void
     {
-        $this->line('');
-        $this->info('Installation Summary:');
-        $this->table(
-            ['Operation', 'Count'],
-            [
-                ['Directories created', $this->installResults['created_dirs']],
-                ['Files copied', $this->installResults['copied_files']],
-                ['Files overwritten', $this->installResults['overwritten_files']],
-                ['Files skipped', $this->installResults['skipped_files']],
-            ],
-        );
+        $this->displayPublishSummary($this->installResults);
     }
 
     /**
@@ -834,32 +722,7 @@ trait HasModuleInstallation
         $this->line('');
 
         if ($this->confirm('Would you like to run "npm run build" to compile frontend assets?', true)) {
-            $this->line('Running npm run build...');
-            $this->line('');
-
-            $process = proc_open(
-                'npm run build',
-                [
-                    0 => STDIN,
-                    1 => STDOUT,
-                    2 => STDERR,
-                ],
-                $pipes,
-                base_path(),
-            );
-
-            if (is_resource($process)) {
-                $exitCode = proc_close($process);
-
-                $this->line('');
-                if ($exitCode === 0) {
-                    $this->info('Frontend assets compiled successfully!');
-                } else {
-                    $this->warn('npm run build finished with errors. You may need to run it manually.');
-                }
-            } else {
-                $this->warn('Could not execute npm run build. Please run it manually.');
-            }
+            $this->executeNpmBuild();
         } else {
             $this->line('<comment>Skipping npm build. You can run it manually later with: npm run build</comment>');
         }

--- a/tests/Commands/NoerdConfigPublishTest.php
+++ b/tests/Commands/NoerdConfigPublishTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Support\Facades\File;
+use Noerd\Commands\NoerdInstallCommand;
+use Noerd\Tests\TestCase;
+
+uses(TestCase::class);
+
+/*
+ | publishNoerdConfig() must never clobber a host's config/noerd.php silently:
+ | an existing file is diffed against the stub, missing top-level keys are
+ | reported, and an overwrite writes a .bak backup first.
+ */
+
+class ConfigPublishFixtureCommand extends NoerdInstallCommand
+{
+    protected $signature = 'test:config-publish {--force : Overwrite existing files}';
+
+    public function handle()
+    {
+        $this->publishNoerdConfig();
+
+        return 0;
+    }
+}
+
+beforeEach(function (): void {
+    $this->app[Kernel::class]->registerCommand(new ConfigPublishFixtureCommand());
+    $this->configPath = base_path('config/noerd.php');
+    $this->originalConfig = File::exists($this->configPath) ? File::get($this->configPath) : null;
+});
+
+afterEach(function (): void {
+    if ($this->originalConfig === null) {
+        File::delete($this->configPath);
+    } else {
+        File::put($this->configPath, $this->originalConfig);
+    }
+    File::delete($this->configPath . '.bak');
+});
+
+it('publishes the stub when no config exists yet', function (): void {
+    File::delete($this->configPath);
+
+    $this->artisan('test:config-publish', ['--no-interaction' => true])
+        ->expectsOutputToContain('Published config/noerd.php successfully.')
+        ->assertExitCode(0);
+
+    expect(File::exists($this->configPath))->toBeTrue();
+});
+
+it('leaves an up-to-date config untouched', function (): void {
+    File::copy(dirname(__DIR__, 2) . '/stubs/noerd.php.stub', $this->configPath);
+    File::append($this->configPath, "\n// host marker\n");
+    $before = File::get($this->configPath);
+
+    $this->artisan('test:config-publish', ['--no-interaction' => true])
+        ->expectsOutputToContain('left untouched')
+        ->assertExitCode(0);
+
+    expect(File::get($this->configPath))->toBe($before);
+});
+
+it('reports missing top-level keys and keeps the file without --force', function (): void {
+    File::put($this->configPath, "<?php\n\nreturn ['routes' => ['prefix' => 'noerd']];\n");
+
+    $this->artisan('test:config-publish', ['--no-interaction' => true])
+        ->expectsOutputToContain('missing new top-level keys')
+        ->assertExitCode(0);
+
+    expect(File::get($this->configPath))->toContain("['prefix' => 'noerd']");
+});
+
+it('overwrites with --force and writes a .bak backup', function (): void {
+    File::put($this->configPath, "<?php\n\nreturn ['routes' => ['prefix' => 'custom']];\n");
+
+    $this->artisan('test:config-publish', ['--force' => true, '--no-interaction' => true])
+        ->expectsOutputToContain('backup: config/noerd.php.bak')
+        ->assertExitCode(0);
+
+    expect(File::get($this->configPath . '.bak'))->toContain("'prefix' => 'custom'")
+        ->and(File::get($this->configPath))->not->toContain("'prefix' => 'custom'");
+});


### PR DESCRIPTION
Pre-release quality review, phase 6b of 7. Stacked on #48.

## Deduplication (~200 lines of copy-paste)
- **`PublishesConfigDirectory`**: the two divergent ~65-line `copyDirectoryContents()` implementations (NoerdInstallCommand returning counters, HasModuleInstallation mutating `$installResults`) collapse into one shared recursive publisher; the duplicated summary tables follow.
- **`RunsNpmBuild`**: three byte-identical `proc_open('npm run build', …)` blocks (install, update, module installers) become one concern.
- **`copyConfigSubdirectories()`**: `runModuleInstallation()` and `runModuleUpdate()` carried identical five-block copy sequences (lists/details/pages/settings + additional subdirectories) — now one loop.

## Update robustness
- **Every overwrite writes a one-generation `.bak` first** — `noerd:update --force` previously replaced the host's customized `app-configs/setup/` YAMLs and `config/noerd.php` wholesale with no recovery path (the package itself documented the damage in `NoerdUpdateAllCommand`'s comments).
- **`publishNoerdConfig()` is no longer copy-or-clobber.** An existing `config/noerd.php` is diffed against the stub: with every stub key present it is left untouched; missing top-level keys are reported by name (the documented contract is that `noerd:update` carries new keys into existing installs) and overwriting requires `--force` or an explicit confirmation — always with a `.bak`. Covered by a new `NoerdConfigPublishTest`.
- `installNpmPackages()` runs through `Process::path(base_path())` instead of a string-built `cd <path> && npm install …` (broke on paths with spaces) and prints npm's diagnostics on failure; a failed frontend scaffold is now an `error` with a recovery hint instead of a `warn` that still ends in "Application ready!".

## Generators
- `noerd:make-resource`'s list stub emits the slim `$listModel` syntax the guideline mandates (the module scaffolder already did; the two generators produced different idioms for the same thing).
- Scaffolded detail/page titles are wrapped in `__()` — generated components no longer start out untranslatable.
- The collection field-type list lives ONCE (`SetupCollectionHelper::FIELD_TYPES`) and drives both the `noerd:make-collection` prompt and the definition-editor UI, which previously disagreed about which types exist. Deliberately curated rather than derived from `FieldTypeRegistry` (that registry also holds structural/relation types that make no sense on a collection entry).

Full package suite: 966 passed, 1 skipped.