### PR TITLE
Add pivot integrity constraints, centralize app-name lookups and unify model casts

### DIFF
--- a/database/migrations/2026_08_28_000001_add_integrity_constraints_to_tenant_pivots.php
+++ b/database/migrations/2026_08_28_000001_add_integrity_constraints_to_tenant_pivots.php
@@ -1,0 +1,115 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Integrity constraints the pivot tables were missing: without them the same
+ * user could be attached to the same tenant N times (duplicating every
+ * users()/tenants() result) and the same app assigned to a tenant twice.
+ * Existing duplicate rows are collapsed first, so the constraints always apply.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $this->constrainUsersTenants();
+        $this->constrainTenantApp();
+        $this->indexTenantAppsName();
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasTable('users_tenants') && Schema::hasIndex('users_tenants', ['user_id', 'tenant_id'])) {
+            Schema::table('users_tenants', function (Blueprint $table): void {
+                $table->dropPrimary(['user_id', 'tenant_id']);
+            });
+        }
+
+        if (Schema::hasTable('tenant_app') && Schema::hasIndex('tenant_app', 'tenant_app_tenant_app_id_tenant_id_unique')) {
+            Schema::table('tenant_app', function (Blueprint $table): void {
+                $table->dropUnique(['tenant_app_id', 'tenant_id']);
+            });
+        }
+
+        if (Schema::hasTable('tenant_apps')) {
+            Schema::table('tenant_apps', function (Blueprint $table): void {
+                if (Schema::hasIndex('tenant_apps', 'tenant_apps_name_unique')) {
+                    $table->dropUnique(['name']);
+                }
+                if (Schema::hasIndex('tenant_apps', 'tenant_apps_name_index')) {
+                    $table->dropIndex(['name']);
+                }
+            });
+        }
+    }
+
+    private function constrainUsersTenants(): void
+    {
+        if (! Schema::hasTable('users_tenants') || Schema::hasIndex('users_tenants', ['user_id', 'tenant_id'])) {
+            return;
+        }
+
+        // The table has no primary key, so duplicates are collapsed portably:
+        // read, unique by (user, tenant) keeping the newest row, rewrite.
+        $rows = DB::table('users_tenants')->orderBy('created_at')->get();
+        $unique = $rows->keyBy(fn($row) => $row->user_id . '|' . $row->tenant_id);
+
+        if ($rows->count() !== $unique->count()) {
+            DB::transaction(function () use ($unique): void {
+                DB::table('users_tenants')->delete();
+                DB::table('users_tenants')->insert(
+                    $unique->values()->map(fn($row) => (array) $row)->all(),
+                );
+            });
+        }
+
+        Schema::table('users_tenants', function (Blueprint $table): void {
+            $table->primary(['user_id', 'tenant_id']);
+        });
+    }
+
+    private function constrainTenantApp(): void
+    {
+        if (! Schema::hasTable('tenant_app') || Schema::hasIndex('tenant_app', ['tenant_app_id', 'tenant_id'])) {
+            return;
+        }
+
+        // Keep the oldest row per (app, tenant) pair.
+        $keep = DB::table('tenant_app')
+            ->selectRaw('MIN(id) as id')
+            ->groupBy('tenant_app_id', 'tenant_id')
+            ->pluck('id');
+
+        DB::table('tenant_app')->whereNotIn('id', $keep)->delete();
+
+        Schema::table('tenant_app', function (Blueprint $table): void {
+            $table->unique(['tenant_app_id', 'tenant_id']);
+        });
+    }
+
+    private function indexTenantAppsName(): void
+    {
+        if (! Schema::hasTable('tenant_apps')
+            || Schema::hasIndex('tenant_apps', 'tenant_apps_name_unique')
+            || Schema::hasIndex('tenant_apps', 'tenant_apps_name_index')) {
+            return;
+        }
+
+        // `name` is the app identity (the app-configs/{name} folder key). A
+        // unique index enforces that — but an installation that already carries
+        // duplicates must not be bricked by an update, so it degrades to a
+        // plain index there (the install commands prevent new duplicates).
+        try {
+            Schema::table('tenant_apps', function (Blueprint $table): void {
+                $table->unique('name');
+            });
+        } catch (Throwable) {
+            Schema::table('tenant_apps', function (Blueprint $table): void {
+                $table->index('name');
+            });
+        }
+    }
+};

--- a/src/Middleware/AppAccessMiddleware.php
+++ b/src/Middleware/AppAccessMiddleware.php
@@ -56,13 +56,17 @@ class AppAccessMiddleware
             explode(',', $appName),
         );
 
+        // ONE query for all candidates; the first candidate in route order wins,
+        // matching the old per-candidate loop (which cost one query each).
+        $assignedByLower = $tenant->tenantApps()
+            ->namedAny($appNames)
+            ->pluck('name')
+            ->keyBy(fn(string $name): string => mb_strtolower($name));
+
         $matchingApp = null;
         foreach ($appNames as $candidate) {
-            $found = $tenant->tenantApps()
-                ->whereRaw('LOWER(name) = ?', [$candidate])
-                ->value('name');
-            if ($found) {
-                $matchingApp = $found;
+            if ($assignedByLower->has($candidate)) {
+                $matchingApp = $assignedByLower[$candidate];
                 break;
             }
         }

--- a/src/Middleware/PublicAppMiddleware.php
+++ b/src/Middleware/PublicAppMiddleware.php
@@ -24,7 +24,7 @@ class PublicAppMiddleware
     public function handle(Request $request, Closure $next, string $appName): Response
     {
         $publicApp = TenantApp::query()
-            ->whereRaw('LOWER(name) = ?', [mb_strtolower($appName)])
+            ->named($appName)
             ->where('is_active', true)
             ->where('is_public', true)
             ->first();
@@ -53,7 +53,7 @@ class PublicAppMiddleware
         }
 
         $hasApp = $tenant->tenantApps()
-            ->whereRaw('LOWER(name) = ?', [mb_strtolower($appName)])
+            ->named($appName)
             ->exists();
 
         if (!$hasApp) {

--- a/src/Models/NoerdUser.php
+++ b/src/Models/NoerdUser.php
@@ -27,13 +27,16 @@ class NoerdUser extends Authenticatable implements HasLocalePreference
         'api_token',
     ];
 
-    protected $casts = [
-        'email_verified_at' => 'datetime',
-        'password' => 'hashed',
-        'is_owner' => 'boolean',
-        'super_admin' => 'boolean',
-        'last_login_at' => 'datetime',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'email_verified_at' => 'datetime',
+            'password' => 'hashed',
+            'is_owner' => 'boolean',
+            'super_admin' => 'boolean',
+            'last_login_at' => 'datetime',
+        ];
+    }
 
     /**
      * The framework notification links to route('password.reset') — a name

--- a/src/Models/SetupCollectionEntry.php
+++ b/src/Models/SetupCollectionEntry.php
@@ -13,9 +13,12 @@ class SetupCollectionEntry extends Model
 
     protected $guarded = [];
 
-    protected $casts = [
-        'data' => 'array',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'data' => 'array',
+        ];
+    }
 
     /**
      * Get the parent collection

--- a/src/Models/SetupLanguage.php
+++ b/src/Models/SetupLanguage.php
@@ -15,10 +15,13 @@ class SetupLanguage extends Model
 
     protected $guarded = [];
 
-    protected $casts = [
-        'is_active' => 'boolean',
-        'is_default' => 'boolean',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'is_active' => 'boolean',
+            'is_default' => 'boolean',
+        ];
+    }
 
     /**
      * Get all active languages

--- a/src/Models/Tenant.php
+++ b/src/Models/Tenant.php
@@ -9,6 +9,12 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Noerd\Database\Factories\TenantFactory;
 
+/**
+ * Extends Authenticatable ON PURPOSE: optional frontend modules authenticate a
+ * tenant directly (e.g. liefertool registers an auth provider with
+ * `model => Tenant::class` for the restaurant login), so the model must
+ * satisfy the guard contract even though the core itself never logs a tenant in.
+ */
 class Tenant extends Authenticatable
 {
     use HasFactory;
@@ -23,9 +29,12 @@ class Tenant extends Authenticatable
         'updated_at',
     ];
 
-    protected $casts = [
-        'email_verified_at' => 'datetime',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'email_verified_at' => 'datetime',
+        ];
+    }
 
     /**
      * Get the UUID attribute with fallback to hash for backward compatibility.

--- a/src/Models/TenantApp.php
+++ b/src/Models/TenantApp.php
@@ -2,6 +2,7 @@
 
 namespace Noerd\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
@@ -9,14 +10,43 @@ class TenantApp extends Model
 {
     protected $guarded = [];
 
-    protected $casts = [
-        'is_active' => 'boolean',
-        'is_public' => 'boolean',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'is_active' => 'boolean',
+            'is_public' => 'boolean',
+        ];
+    }
 
-    public function scopePublic($query)
+    public function scopePublic(Builder $query): Builder
     {
         return $query->where('is_public', true);
+    }
+
+    /**
+     * Case-insensitive app-name match. `name` is canonically the UPPERCASE
+     * module key, but historical rows exist in lowercase — every lookup
+     * normalizes both sides through this ONE scope instead of scattering
+     * whereRaw('LOWER(name) = ?') across middlewares.
+     */
+    public function scopeNamed(Builder $query, string $name): Builder
+    {
+        return $query->whereRaw('LOWER(name) = ?', [mb_strtolower(mb_trim($name))]);
+    }
+
+    /**
+     * Case-insensitive match against several candidate names in one query.
+     *
+     * @param  array<int, string>  $names
+     */
+    public function scopeNamedAny(Builder $query, array $names): Builder
+    {
+        $normalized = array_map(fn(string $name): string => mb_strtolower(mb_trim($name)), $names);
+
+        return $query->whereIn(
+            $query->getQuery()->getConnection()->raw('LOWER(name)'),
+            $normalized,
+        );
     }
 
     public function tenants(): BelongsToMany

--- a/src/Services/DetailSlotsRegistry.php
+++ b/src/Services/DetailSlotsRegistry.php
@@ -29,10 +29,6 @@ class DetailSlotsRegistry
     /** @return array<int, string> */
     public function for(string $slot): array
     {
-        $entries = $this->slots[$slot] ?? [];
-
-        usort($entries, fn(array $a, array $b): int => $a['sort'] <=> $b['sort']);
-
-        return array_column($entries, 'component');
+        return \Noerd\Support\SortedRegistrations::payloads($this->slots[$slot] ?? [], 'component');
     }
 }

--- a/src/Services/RelationBoxRegistry.php
+++ b/src/Services/RelationBoxRegistry.php
@@ -52,8 +52,6 @@ class RelationBoxRegistry
             }
         }
 
-        usort($entries, fn(array $a, array $b): int => $a['sort'] <=> $b['sort']);
-
-        return array_column($entries, 'tile');
+        return \Noerd\Support\SortedRegistrations::payloads($entries, 'tile');
     }
 }

--- a/src/Support/SortedRegistrations.php
+++ b/src/Support/SortedRegistrations.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Noerd\Support;
+
+/**
+ * Shared ordering rule of every sort-aware registry (detail slots, relation
+ * box tiles): lower sorts first, equal sorts keep registration order.
+ */
+final class SortedRegistrations
+{
+    /**
+     * Order the entries by their 'sort' value and return the payload column.
+     *
+     * @param  array<int, array<string, mixed>>  $entries
+     * @return array<int, mixed>
+     */
+    public static function payloads(array $entries, string $payloadKey): array
+    {
+        usort($entries, fn(array $a, array $b): int => $a['sort'] <=> $b['sort']);
+
+        return array_column($entries, $payloadKey);
+    }
+}


### PR DESCRIPTION
Pre-release quality review, phase 6d of 7. Stacked on #50.

## Schema integrity
- New migration `add_integrity_constraints_to_tenant_pivots`: `users_tenants` gets its composite primary key (the same user could previously be attached to the same tenant N times, silently duplicating every `users()`/`tenants()` result), `tenant_app` a unique pair constraint, and `tenant_apps.name` — the app identity behind the `app-configs/{name}` folder — a unique index. Existing duplicate rows are collapsed first (portably, keeping the newest/oldest per pair), and the name index degrades to a plain index on an installation that already carries duplicate names rather than bricking its update. Verified against the real host database.

## App-name lookups
- The case-insensitive `whereRaw('LOWER(name) = ?')` convention lives ONCE as `TenantApp::scopeNamed()`/`scopeNamedAny()` (with the documented reason: names are canonically the UPPERCASE module key, but historical lowercase rows exist). `AppAccessMiddleware` resolves all route candidates in ONE query (previously one query per candidate, first-match-wins order preserved); `PublicAppMiddleware` shares the scopes.

## Models
- `casts()` method form unified across all models (two already used it, five didn't).
- `Tenant` KEEPS extending `Authenticatable` — the review flagged it, but the host's auth config registers a `liefertool` provider with `model => Tenant::class` (restaurant login), so the guard contract is load-bearing; that reasoning is now documented on the class. The `$hidden` password entries stay as serialization defense.
- `DetailSlotsRegistry`/`RelationBoxRegistry` share the sort-and-extract ordering through `SortedRegistrations` (the one genuinely duplicated registry logic). The keyed-map registries are deliberately NOT collapsed into a generic trait: they are typed 6-line methods each, and the indirection would cost more clarity than the duplication.
- `SetupCollectionEntry::saving()` deliberately stays a model hook (the review suggested moving it into the detail-save path): the conversion must also run for programmatic/API saves, which never pass through a detail component.

Full package suite: 966 passed, 1 skipped; migration verified against the host database (all three constraints active).