### PR TITLE
Close test coverage gaps, enforce Pint in CI and fix pre-existing style violations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,3 +55,24 @@ jobs:
 
       - name: Run tests
         run: vendor/bin/pest --colors=always --compact
+
+  lint:
+    name: Pint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: composer:v2
+          coverage: none
+
+      - name: Install dependencies
+        run: composer update --no-interaction --no-progress --prefer-dist
+
+      - name: Run Pint
+        run: vendor/bin/pint --test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,10 +59,12 @@ and are NOT repeated here. Read that guideline first; it applies to code in this
 
 ## Code style
 
-- Laravel Pint with the `pint.json` in this repository (PER preset + project rules):
-  `vendor/bin/pint --dirty` after `composer require laravel/pint --dev` in a standalone checkout, or
-  from the host project's root (`vendor/bin/pint app-modules/noerd/...`) — the host ships an
-  identical config, both runs must produce the same result.
+- Laravel Pint with the `pint.json` in this repository (PER preset + project rules). Pint is a
+  dev dependency: run `composer lint` (check) / `vendor/bin/pint --dirty` (fix) from the PACKAGE
+  root, and CI enforces `pint --test`. NEVER rely on the host root's `vendor/bin/pint --dirty` for
+  files in this repository — the submodule's files are not part of the host's git working tree, so
+  a host `--dirty` run silently skips every one of them. A host-root run must name the paths
+  explicitly (`vendor/bin/pint app-modules/noerd/...`); the configs are identical.
 - PHP 8.3+, strict comparisons, explicit return types, constructor property promotion, `$guarded`
   instead of `$fillable`, Eloquent models never stored as Livewire properties.
 - Comments, Artisan prompts, docs and commit messages are written in English.

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     },
     "require-dev": {
         "orchestra/testbench": "^10.6 || ^11.1",
-        "pestphp/pest": "^4.0"
+        "pestphp/pest": "^4.0",
+        "laravel/pint": "^1.18"
     },
     "autoload": {
         "psr-4": {
@@ -39,5 +40,9 @@
                 "Noerd\\Providers\\NoerdServiceProvider"
             ]
         }
+    },
+    "scripts": {
+        "test": "pest",
+        "lint": "pint --test"
     }
 }

--- a/database/migrations/2026_08_28_000001_add_integrity_constraints_to_tenant_pivots.php
+++ b/database/migrations/2026_08_28_000001_add_integrity_constraints_to_tenant_pivots.php
@@ -11,8 +11,7 @@ use Illuminate\Support\Facades\Schema;
  * users()/tenants() result) and the same app assigned to a tenant twice.
  * Existing duplicate rows are collapsed first, so the constraints always apply.
  */
-return new class extends Migration
-{
+return new class extends Migration {
     public function up(): void
     {
         $this->constrainUsersTenants();

--- a/src/Commands/Concerns/PublishesConfigDirectory.php
+++ b/src/Commands/Concerns/PublishesConfigDirectory.php
@@ -30,7 +30,7 @@ trait PublishesConfigDirectory
             'overwritten_files' => 0,
         ];
 
-        $display = function (string $path) use ($sourceDir, $targetDir, $displayBase): string {
+        $display = function (string $path) use ($targetDir, $displayBase): string {
             if ($displayBase !== null) {
                 return str_replace($displayBase . DIRECTORY_SEPARATOR, '', $path);
             }

--- a/src/Commands/NoerdUpdateAllCommand.php
+++ b/src/Commands/NoerdUpdateAllCommand.php
@@ -10,13 +10,6 @@ class NoerdUpdateAllCommand extends Command
 {
     use RequiresNoerdInstallation;
 
-    protected $signature = 'noerd:update-all
-        {--force : Overwrite existing files without asking}
-        {--build : Run npm build after the core noerd:update}
-        {--except=* : Skip a command; module key or full name (--except=cms, --except=noerd:update)}';
-
-    protected $description = 'Run noerd:update and every installed module\'s noerd:update-{module} command';
-
     private const CORE = 'noerd:update';
 
     /**
@@ -24,6 +17,13 @@ class NoerdUpdateAllCommand extends Command
      * that a preceding `noerd:update --force` overwrites with the core template.
      */
     private const RUN_LAST = ['noerd:update-plus'];
+
+    protected $signature = 'noerd:update-all
+        {--force : Overwrite existing files without asking}
+        {--build : Run npm build after the core noerd:update}
+        {--except=* : Skip a command; module key or full name (--except=cms, --except=noerd:update)}';
+
+    protected $description = 'Run noerd:update and every installed module\'s noerd:update-{module} command';
 
     /**
      * Only the modules whose service provider is loaded register an update command,
@@ -118,7 +118,7 @@ class NoerdUpdateAllCommand extends Command
     private function partition(array $names): array
     {
         $except = array_map(
-            static fn (string $value): string => str_contains($value, ':') ? $value : 'noerd:update-' . $value,
+            static fn(string $value): string => str_contains($value, ':') ? $value : 'noerd:update-' . $value,
             (array) $this->option('except'),
         );
 
@@ -193,7 +193,7 @@ class NoerdUpdateAllCommand extends Command
             $rows[] = [$name, '<comment>skipped</comment>', '--except'];
         }
 
-        $failed = array_filter($results, static fn (array $result): bool => $result['status'] === 'failed');
+        $failed = array_filter($results, static fn(array $result): bool => $result['status'] === 'failed');
 
         $this->newLine();
         $this->info('Update summary:');

--- a/src/Helpers/SetupCollectionHelper.php
+++ b/src/Helpers/SetupCollectionHelper.php
@@ -66,6 +66,40 @@ class SetupCollectionHelper
     }
 
     /**
+     * Build select options from a setup collection's entries for the current
+     * tenant: value = `data[valueField]` (or the entry id when no valueField is
+     * given), label = `data[displayField]` resolved to the active language.
+     * Shared by the `setupCollectionSelect` form element and the list picklist
+     * badges, so both always agree on values and labels.
+     *
+     * @return array<int, array{value: mixed, label: string}>
+     */
+    public static function selectOptions(string $collectionKey, string $displayField = 'name', ?string $valueField = null): array
+    {
+        $collection = SetupCollection::where('collection_key', $collectionKey)->first();
+        if (! $collection) {
+            return [];
+        }
+
+        $locale = session('selectedLanguage') ?? app()->getLocale();
+        $options = [];
+
+        foreach ($collection->entries as $entry) {
+            $label = $entry->data[$displayField] ?? '';
+            if (is_array($label)) {
+                $label = $label[$locale] ?? $label[SetupLanguage::getDefaultCode()] ?? reset($label) ?: '';
+            }
+
+            $options[] = [
+                'value' => $valueField ? ($entry->data[$valueField] ?? '') : $entry->id,
+                'label' => (string) $label,
+            ];
+        }
+
+        return $options;
+    }
+
+    /**
      * Instance method: resolve collection fields via the repository.
      */
     public function resolveCollectionFields(?string $collection): ?array
@@ -119,40 +153,6 @@ class SetupCollectionHelper
         }
 
         return $table;
-    }
-
-    /**
-     * Build select options from a setup collection's entries for the current
-     * tenant: value = `data[valueField]` (or the entry id when no valueField is
-     * given), label = `data[displayField]` resolved to the active language.
-     * Shared by the `setupCollectionSelect` form element and the list picklist
-     * badges, so both always agree on values and labels.
-     *
-     * @return array<int, array{value: mixed, label: string}>
-     */
-    public static function selectOptions(string $collectionKey, string $displayField = 'name', ?string $valueField = null): array
-    {
-        $collection = SetupCollection::where('collection_key', $collectionKey)->first();
-        if (! $collection) {
-            return [];
-        }
-
-        $locale = session('selectedLanguage') ?? app()->getLocale();
-        $options = [];
-
-        foreach ($collection->entries as $entry) {
-            $label = $entry->data[$displayField] ?? '';
-            if (is_array($label)) {
-                $label = $label[$locale] ?? $label[SetupLanguage::getDefaultCode()] ?? reset($label) ?: '';
-            }
-
-            $options[] = [
-                'value' => $valueField ? ($entry->data[$valueField] ?? '') : $entry->id,
-                'label' => (string) $label,
-            ];
-        }
-
-        return $options;
     }
 
     /**

--- a/src/Helpers/StaticConfigHelper.php
+++ b/src/Helpers/StaticConfigHelper.php
@@ -269,27 +269,6 @@ class StaticConfigHelper
         return self::$runtimeCache[$cacheKey] = self::buildNavigationStructure($currentApp);
     }
 
-    /**
-     * @see getNavigationStructure()
-     */
-    private static function buildNavigationStructure(string $currentApp): ?array
-    {
-        $yamlPath = base_path("app-configs/{$currentApp}/navigation.yml");
-
-        if (!file_exists($yamlPath)) {
-            return null;
-        }
-
-        $navigationStructure = self::parseYamlFile($yamlPath);
-
-        // Process dynamic navigation blocks
-        if ($navigationStructure) {
-            $navigationStructure = self::processDynamicNavigation($navigationStructure);
-        }
-
-        return $navigationStructure;
-    }
-
     public static function getCurrentApp(): ?string
     {
         $selectedApp = TenantHelper::getSelectedApp();
@@ -480,6 +459,27 @@ class StaticConfigHelper
         self::$yamlCache[$path] = [$version, $parsed];
 
         return $parsed;
+    }
+
+    /**
+     * @see getNavigationStructure()
+     */
+    private static function buildNavigationStructure(string $currentApp): ?array
+    {
+        $yamlPath = base_path("app-configs/{$currentApp}/navigation.yml");
+
+        if (!file_exists($yamlPath)) {
+            return null;
+        }
+
+        $navigationStructure = self::parseYamlFile($yamlPath);
+
+        // Process dynamic navigation blocks
+        if ($navigationStructure) {
+            $navigationStructure = self::processDynamicNavigation($navigationStructure);
+        }
+
+        return $navigationStructure;
     }
 
     /**

--- a/src/Models/NoerdUser.php
+++ b/src/Models/NoerdUser.php
@@ -27,17 +27,6 @@ class NoerdUser extends Authenticatable implements HasLocalePreference
         'api_token',
     ];
 
-    protected function casts(): array
-    {
-        return [
-            'email_verified_at' => 'datetime',
-            'password' => 'hashed',
-            'is_owner' => 'boolean',
-            'super_admin' => 'boolean',
-            'last_login_at' => 'datetime',
-        ];
-    }
-
     /**
      * The framework notification links to route('password.reset') — a name
      * noerd does not claim. Send noerd's own notification instead, which
@@ -204,5 +193,16 @@ class NoerdUser extends Authenticatable implements HasLocalePreference
     protected static function newFactory(): NoerdUserFactory
     {
         return NoerdUserFactory::new();
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'email_verified_at' => 'datetime',
+            'password' => 'hashed',
+            'is_owner' => 'boolean',
+            'super_admin' => 'boolean',
+            'last_login_at' => 'datetime',
+        ];
     }
 }

--- a/src/Models/SetupCollectionEntry.php
+++ b/src/Models/SetupCollectionEntry.php
@@ -13,13 +13,6 @@ class SetupCollectionEntry extends Model
 
     protected $guarded = [];
 
-    protected function casts(): array
-    {
-        return [
-            'data' => 'array',
-        ];
-    }
-
     /**
      * Get the parent collection
      */
@@ -45,5 +38,12 @@ class SetupCollectionEntry extends Model
                 }
             }
         });
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'data' => 'array',
+        ];
     }
 }

--- a/src/Models/SetupLanguage.php
+++ b/src/Models/SetupLanguage.php
@@ -15,14 +15,6 @@ class SetupLanguage extends Model
 
     protected $guarded = [];
 
-    protected function casts(): array
-    {
-        return [
-            'is_active' => 'boolean',
-            'is_default' => 'boolean',
-        ];
-    }
-
     /**
      * Get all active languages
      */
@@ -135,5 +127,13 @@ class SetupLanguage extends Model
                 $newDefault?->update(['is_default' => true]);
             }
         });
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'is_active' => 'boolean',
+            'is_default' => 'boolean',
+        ];
     }
 }

--- a/src/Models/Tenant.php
+++ b/src/Models/Tenant.php
@@ -29,13 +29,6 @@ class Tenant extends Authenticatable
         'updated_at',
     ];
 
-    protected function casts(): array
-    {
-        return [
-            'email_verified_at' => 'datetime',
-        ];
-    }
-
     /**
      * Get the UUID attribute with fallback to hash for backward compatibility.
      */
@@ -76,5 +69,12 @@ class Tenant extends Authenticatable
     protected static function newFactory(): TenantFactory
     {
         return TenantFactory::new();
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'email_verified_at' => 'datetime',
+        ];
     }
 }

--- a/src/Models/TenantApp.php
+++ b/src/Models/TenantApp.php
@@ -10,14 +10,6 @@ class TenantApp extends Model
 {
     protected $guarded = [];
 
-    protected function casts(): array
-    {
-        return [
-            'is_active' => 'boolean',
-            'is_public' => 'boolean',
-        ];
-    }
-
     public function scopePublic(Builder $query): Builder
     {
         return $query->where('is_public', true);
@@ -52,5 +44,13 @@ class TenantApp extends Model
     public function tenants(): BelongsToMany
     {
         return $this->belongsToMany(Tenant::class, 'tenant_app');
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'is_active' => 'boolean',
+            'is_public' => 'boolean',
+        ];
     }
 }

--- a/src/Providers/NoerdServiceProvider.php
+++ b/src/Providers/NoerdServiceProvider.php
@@ -70,9 +70,9 @@ use Noerd\Services\ThemeRegistry;
 use Noerd\Services\TopBarRegistry;
 use Noerd\Support\ComponentAccessHook;
 use Noerd\Support\DefaultCountries;
+use Noerd\Support\FieldContext;
 use Noerd\Support\FieldTypeDefinition;
 use Noerd\Support\LockedPropertiesHook;
-use Noerd\Support\FieldContext;
 use Noerd\Support\QuickCreateExitHook;
 use Noerd\Support\RelationFieldDefinition;
 use Noerd\Support\RelationFormPersistHook;
@@ -170,26 +170,6 @@ class NoerdServiceProvider extends ServiceProvider
         // singleton keeps it at one build per request (the structure itself is
         // additionally memoized in StaticConfigHelper's runtime cache).
         $this->app->singleton(NavigationService::class);
-    }
-
-    /**
-     * Drop every request-scoped PHP static the package maintains. Runs on app
-     * boot (fresh per test in one Pest process, per-request no-op under FPM)
-     * and — via the Octane RequestReceived listener — before every Octane
-     * request. The schema column listing is deliberately not part of this
-     * flush: it describes the database structure, not request state (see the
-     * boot hook and the MigrationsEnded listener).
-     */
-    private function flushRequestState(): void
-    {
-        StaticConfigHelper::flushRuntimeCaches();
-        TenantHelper::clearCache();
-        ThemeHelper::clearCache();
-        ThemeContext::clear();
-        FieldContext::clear();
-        CurrencyHelper::clearCache();
-        DatabaseSetupCollectionDefinitionRepository::resetCache();
-        $this->app->make(ThemeRegistry::class)->clearCache();
     }
 
     public function boot(): void
@@ -406,6 +386,26 @@ class NoerdServiceProvider extends ServiceProvider
                 ExportSetupCollectionDefinitionsCommand::class,
             ]);
         }
+    }
+
+    /**
+     * Drop every request-scoped PHP static the package maintains. Runs on app
+     * boot (fresh per test in one Pest process, per-request no-op under FPM)
+     * and — via the Octane RequestReceived listener — before every Octane
+     * request. The schema column listing is deliberately not part of this
+     * flush: it describes the database structure, not request state (see the
+     * boot hook and the MigrationsEnded listener).
+     */
+    private function flushRequestState(): void
+    {
+        StaticConfigHelper::flushRuntimeCaches();
+        TenantHelper::clearCache();
+        ThemeHelper::clearCache();
+        ThemeContext::clear();
+        FieldContext::clear();
+        CurrencyHelper::clearCache();
+        DatabaseSetupCollectionDefinitionRepository::resetCache();
+        $this->app->make(ThemeRegistry::class)->clearCache();
     }
 
     /**

--- a/src/Services/RelationTitleResolver.php
+++ b/src/Services/RelationTitleResolver.php
@@ -35,17 +35,6 @@ final class RelationTitleResolver
     }
 
     /**
-     * Memo key including the current tenant: the convention lookup is a raw
-     * unscoped DB read, so a memoized title must never be served to another
-     * tenant a long-lived worker later handles (defense in depth on top of the
-     * per-request reset in the provider's Octane listener).
-     */
-    private function memoKey(string $fkColumn, mixed $id): string
-    {
-        return (TenantHelper::currentTenantId() ?? 0) . '|' . $fkColumn . '|' . $id;
-    }
-
-    /**
      * Prime the per-request memo for a whole page of ids in ONE query per source
      * instead of one per row: a registered relation type loads via a single
      * whereIn on its model (tenant scopes and the titleResolver apply exactly
@@ -103,6 +92,17 @@ final class RelationTitleResolver
         foreach ($pending as $idKey => $id) {
             $this->titles[$this->memoKey($fkColumn, $id)] = $resolved[$idKey] ?? (string) $id;
         }
+    }
+
+    /**
+     * Memo key including the current tenant: the convention lookup is a raw
+     * unscoped DB read, so a memoized title must never be served to another
+     * tenant a long-lived worker later handles (defense in depth on top of the
+     * per-request reset in the provider's Octane listener).
+     */
+    private function memoKey(string $fkColumn, mixed $id): string
+    {
+        return (TenantHelper::currentTenantId() ?? 0) . '|' . $fkColumn . '|' . $id;
     }
 
     private function resolve(string $fkColumn, mixed $id): string

--- a/src/Support/DetailSaveHook.php
+++ b/src/Support/DetailSaveHook.php
@@ -32,6 +32,8 @@ abstract class DetailSaveHook extends ComponentHook
 {
     private const SAVE_ACTIONS = ['store', 'save', 'update'];
 
+    abstract protected function afterSave(Component $component, Model $record): void;
+
     public function call($method, $params, $returnEarly, $metadata, $componentContext): callable
     {
         $effective = $method;
@@ -78,6 +80,4 @@ abstract class DetailSaveHook extends ComponentHook
             $this->afterSave($component, $record);
         };
     }
-
-    abstract protected function afterSave(Component $component, Model $record): void;
 }

--- a/src/Support/RelationFormSync.php
+++ b/src/Support/RelationFormSync.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Support\Str;
+use LogicException;
 use Noerd\Contracts\DeclaresRelationForms;
 
 /**
@@ -136,7 +137,7 @@ final class RelationFormSync
         }
 
         foreach ($data as $value) {
-            if (is_string($value) ? trim($value) !== '' : $value !== null) {
+            if (is_string($value) ? mb_trim($value) !== '' : $value !== null) {
                 return true;
             }
         }
@@ -147,7 +148,7 @@ final class RelationFormSync
     private static function defaultPersist(Model $owner, RelationFormDefinition $definition, array $data): void
     {
         $data = array_map(
-            fn (mixed $value): mixed => is_string($value) && trim($value) === '' ? null : $value,
+            fn(mixed $value): mixed => is_string($value) && mb_trim($value) === '' ? null : $value,
             $data,
         );
 
@@ -173,7 +174,7 @@ final class RelationFormSync
             return;
         }
 
-        throw new \LogicException(sprintf(
+        throw new LogicException(sprintf(
             'Relation form [%s] on [%s] uses an unsupported relation type [%s] — declare a persistUsing closure.',
             $definition->relation,
             $owner::class,

--- a/src/Traits/NoerdList.php
+++ b/src/Traits/NoerdList.php
@@ -8,7 +8,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
@@ -403,13 +402,9 @@ trait NoerdList
         $this->resetPage();
     }
 
-    public function updatedSortField(): void
-    {
-    }
+    public function updatedSortField(): void {}
 
-    public function updatedSortAsc(): void
-    {
-    }
+    public function updatedSortAsc(): void {}
 
     public function sortBy(string $field): void
     {
@@ -800,6 +795,27 @@ trait NoerdList
     public function builtListConfig(): array
     {
         return $this->builtListConfigCache ??= $this->resolvedListConfig();
+    }
+
+    /**
+     * The table's schema columns keyed by column name, introspected at most once
+     * per table and process (see SchemaColumnCache) — on an 8-column list the
+     * uncached Schema::hasColumn() calls used to mean a two-digit number of
+     * metadata queries per render.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    protected static function tableColumns(string $table): array
+    {
+        return SchemaColumnCache::columns($table);
+    }
+
+    /**
+     * Cached replacement for Schema::hasColumn() (see tableColumns()).
+     */
+    protected static function tableHasColumn(string $table, string $column): bool
+    {
+        return SchemaColumnCache::hasColumn($table, $column);
     }
 
     /**
@@ -1267,27 +1283,6 @@ trait NoerdList
     }
 
     /**
-     * The table's schema columns keyed by column name, introspected at most once
-     * per table and process (see SchemaColumnCache) — on an 8-column list the
-     * uncached Schema::hasColumn() calls used to mean a two-digit number of
-     * metadata queries per render.
-     *
-     * @return array<string, array<string, mixed>>
-     */
-    protected static function tableColumns(string $table): array
-    {
-        return SchemaColumnCache::columns($table);
-    }
-
-    /**
-     * Cached replacement for Schema::hasColumn() (see tableColumns()).
-     */
-    protected static function tableHasColumn(string $table, string $column): bool
-    {
-        return SchemaColumnCache::hasColumn($table, $column);
-    }
-
-    /**
      * One shared instance of the resolved model class for table-name and cast
      * introspection — the render path asks for it many times per request.
      */
@@ -1545,36 +1540,6 @@ trait NoerdList
     }
 
     /**
-     * @see getListConfig()
-     */
-    private function resolveListConfig(?string $customName): array
-    {
-        if ($customName === null && $this->listActionMethod === 'selectAction' && $this->selectListConfig) {
-            return StaticConfigHelper::getListConfig($this->selectListConfig, $this->listModel ?? null);
-        }
-        $name = $customName ?? $this->listConfigComponent();
-
-        // An active alternate view only applies to this component's own config,
-        // never to an explicitly requested custom config. A view from another
-        // app resolves via explicit-app lookup; the session app stays untouched.
-        if ($customName === null && ($this->listView !== null || $this->listViewApp !== null)) {
-            $viewName = $this->listView !== null ? "{$name}--{$this->listView}" : $name;
-            $config = $this->listViewApp !== null
-                ? StaticConfigHelper::getListConfigForApp($this->listViewApp, $viewName, $this->listModel ?? null)
-                : StaticConfigHelper::getListConfig($viewName, $this->listModel ?? null);
-            if ($config !== []) {
-                return $config;
-            }
-            // The view's YAML disappeared mid-session — fall back to the default view.
-            $this->listView = null;
-            $this->listViewApp = null;
-            $this->syncListViewParam();
-        }
-
-        return StaticConfigHelper::getListConfig($name, $this->listModel ?? null);
-    }
-
-    /**
      * Override in the component to enable CSV export.
      *
      * @return array{0: Builder, 1: array, 2: string}
@@ -1658,6 +1623,36 @@ trait NoerdList
         }
 
         return $listeners;
+    }
+
+    /**
+     * @see getListConfig()
+     */
+    private function resolveListConfig(?string $customName): array
+    {
+        if ($customName === null && $this->listActionMethod === 'selectAction' && $this->selectListConfig) {
+            return StaticConfigHelper::getListConfig($this->selectListConfig, $this->listModel ?? null);
+        }
+        $name = $customName ?? $this->listConfigComponent();
+
+        // An active alternate view only applies to this component's own config,
+        // never to an explicitly requested custom config. A view from another
+        // app resolves via explicit-app lookup; the session app stays untouched.
+        if ($customName === null && ($this->listView !== null || $this->listViewApp !== null)) {
+            $viewName = $this->listView !== null ? "{$name}--{$this->listView}" : $name;
+            $config = $this->listViewApp !== null
+                ? StaticConfigHelper::getListConfigForApp($this->listViewApp, $viewName, $this->listModel ?? null)
+                : StaticConfigHelper::getListConfig($viewName, $this->listModel ?? null);
+            if ($config !== []) {
+                return $config;
+            }
+            // The view's YAML disappeared mid-session — fall back to the default view.
+            $this->listView = null;
+            $this->listViewApp = null;
+            $this->syncListViewParam();
+        }
+
+        return StaticConfigHelper::getListConfig($name, $this->listModel ?? null);
     }
 
     /**

--- a/src/Traits/NoerdPage.php
+++ b/src/Traits/NoerdPage.php
@@ -134,28 +134,6 @@ trait NoerdPage
         });
     }
 
-    /**
-     * Shared init skeleton of initPage()/initDetail()/initSettings(): routed-
-     * modal redirect, the object-read guard (canReadObject() is unrestricted
-     * for components without $detailModel and overridden by settings pages),
-     * then the component-specific loading. The three inits used to be three
-     * drifting copies of exactly this sequence.
-     */
-    protected function initNoerdComponent(callable $load): void
-    {
-        if ($this->prepareRoutedModal()) {
-            return;
-        }
-
-        if (!$this->canReadObject()) {
-            $this->objectReadBlocked = true;
-
-            return;
-        }
-
-        $load();
-    }
-
     public function closeModalProcess(?string $source = null): void
     {
         $this->currentTab = 1;
@@ -340,6 +318,28 @@ trait NoerdPage
         if ($id) {
             Noerd::modalFor($detailRoute, $detailComponent, ['modelId' => $id]);
         }
+    }
+
+    /**
+     * Shared init skeleton of initPage()/initDetail()/initSettings(): routed-
+     * modal redirect, the object-read guard (canReadObject() is unrestricted
+     * for components without $detailModel and overridden by settings pages),
+     * then the component-specific loading. The three inits used to be three
+     * drifting copies of exactly this sequence.
+     */
+    protected function initNoerdComponent(callable $load): void
+    {
+        if ($this->prepareRoutedModal()) {
+            return;
+        }
+
+        if (!$this->canReadObject()) {
+            $this->objectReadBlocked = true;
+
+            return;
+        }
+
+        $load();
     }
 
     /**

--- a/src/Traits/RoutedModal.php
+++ b/src/Traits/RoutedModal.php
@@ -58,10 +58,10 @@ trait RoutedModal
     protected function routedModalArguments(): array
     {
         $parameters = array_map(
-            fn (mixed $value): mixed => $value === 'new' ? null : $value,
+            fn(mixed $value): mixed => $value === 'new' ? null : $value,
             array_filter(
                 request()->route()?->parameters() ?? [],
-                fn (string $name): bool => property_exists($this, $name),
+                fn(string $name): bool => property_exists($this, $name),
                 ARRAY_FILTER_USE_KEY,
             ),
         );

--- a/tests/Commands/NoerdUpdateAllTest.php
+++ b/tests/Commands/NoerdUpdateAllTest.php
@@ -82,8 +82,8 @@ beforeEach(function (): void {
     // Any real update command that happens to be registered is excluded per run, so
     // the assertions hold no matter which modules the host application loads.
     $this->excluded = collect(array_keys(Artisan::all()))
-        ->filter(fn (string $name): bool => $name === 'noerd:update' || str_starts_with($name, 'noerd:update-'))
-        ->reject(fn (string $name): bool => in_array($name, ['noerd:update-all', 'noerd:update', 'noerd:update-plus'], true))
+        ->filter(fn(string $name): bool => $name === 'noerd:update' || str_starts_with($name, 'noerd:update-'))
+        ->reject(fn(string $name): bool => in_array($name, ['noerd:update-all', 'noerd:update', 'noerd:update-plus'], true))
         ->values()
         ->all();
 
@@ -95,7 +95,7 @@ beforeEach(function (): void {
     $kernel->registerCommand(new RecordingUpdateCommand('noerd:update-zz-alpha'));
     $kernel->registerCommand(new RecordingUpdateCommand('noerd:update-plus'));
 
-    $this->run = fn (array $parameters = []) => $this->artisan(
+    $this->run = fn(array $parameters = []) => $this->artisan(
         'noerd:update-all',
         array_merge(['--except' => $this->excluded], $parameters),
     );

--- a/tests/Feature/DefaultCountriesTest.php
+++ b/tests/Feature/DefaultCountriesTest.php
@@ -29,7 +29,7 @@ it('seeds the default countries with iso codes for a tenant', function (): void 
 
     expect($entries)->toHaveCount(count(DefaultCountries::COUNTRIES));
 
-    $germany = $entries->first(fn (SetupCollectionEntry $entry): bool => ($entry->data['code'] ?? null) === 'DE');
+    $germany = $entries->first(fn(SetupCollectionEntry $entry): bool => ($entry->data['code'] ?? null) === 'DE');
     expect($germany)->not->toBeNull();
     expect($germany->data['name']['de'])->toBe('Deutschland');
     expect($germany->data['name']['en'])->toBe('Germany');
@@ -42,7 +42,7 @@ it('is idempotent and preserves tenant edits', function (): void {
     $germany = SetupCollectionEntry::withoutGlobalScopes()
         ->where('setup_collection_id', $collection->id)
         ->get()
-        ->first(fn (SetupCollectionEntry $entry): bool => ($entry->data['code'] ?? null) === 'DE');
+        ->first(fn(SetupCollectionEntry $entry): bool => ($entry->data['code'] ?? null) === 'DE');
 
     $germany->update(['data' => array_merge($germany->data, ['name' => ['de' => 'BRD', 'en' => 'Germany']])]);
 
@@ -65,7 +65,7 @@ it('backfills the code onto existing name-only entries instead of duplicating th
     SetupCollectionEntry::withoutGlobalScopes()
         ->where('setup_collection_id', $collection->id)
         ->get()
-        ->each(fn (SetupCollectionEntry $entry) => $entry->update([
+        ->each(fn(SetupCollectionEntry $entry) => $entry->update([
             'data' => ['name' => $entry->data['name']],
         ]));
 
@@ -76,5 +76,5 @@ it('backfills the code onto existing name-only entries instead of duplicating th
         ->get();
 
     expect($entries)->toHaveCount(count(DefaultCountries::COUNTRIES));
-    expect($entries->every(fn (SetupCollectionEntry $entry): bool => ($entry->data['code'] ?? '') !== ''))->toBeTrue();
+    expect($entries->every(fn(SetupCollectionEntry $entry): bool => ($entry->data['code'] ?? '') !== ''))->toBeTrue();
 });

--- a/tests/Feature/DetailActionsTest.php
+++ b/tests/Feature/DetailActionsTest.php
@@ -300,5 +300,5 @@ it('keeps a conditional modal action clickable with a single Alpine scope', func
 
     expect($html)->toContain('$modal(')
         ->toContain('x-show="$wire.hasAccount"')
-        ->and(substr_count($html, 'x-data'))->toBe(1);
+        ->and(mb_substr_count($html, 'x-data'))->toBe(1);
 });

--- a/tests/Feature/NoerdDetailStoreRoundtripTest.php
+++ b/tests/Feature/NoerdDetailStoreRoundtripTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Component;
+use Livewire\Livewire;
+use Noerd\Models\NoerdUser;
+use Noerd\Models\Tenant;
+use Noerd\Tests\TestCase;
+use Noerd\Traits\NoerdDetail;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+/*
+ | The generic NoerdDetail store roundtrip: persisting through the declared
+ | $detailModel, the finishStore() tail (success indicator, adopted id, the
+ | detailStored-{name} event a hosting page listens for) and the identity-
+ | column stripping of writableDetailData().
+ */
+
+class ZzStoreRoundtripComponent extends Component
+{
+    use NoerdDetail;
+
+    public const COMPONENT = 'zz-store-roundtrip-page';
+
+    public $detailModel = Tenant::class;
+
+    public function render(): string
+    {
+        return '<div></div>';
+    }
+}
+
+beforeEach(function (): void {
+    $this->actingAs(NoerdUser::factory()->adminUser()->withSelectedApp('setup')->create());
+
+    Livewire::component('zz-store-roundtrip-page', ZzStoreRoundtripComponent::class);
+});
+
+it('creates the record, adopts its id and reports it to a hosting page', function (): void {
+    $component = Livewire::test('zz-store-roundtrip-page')
+        ->set('detailData', validDetailPayload(Tenant::class))
+        ->set('detailData.name', 'Roundtrip Tenant')
+        ->call('store')
+        ->assertSet('showSuccessIndicator', true);
+
+    $tenant = Tenant::query()->where('name', 'Roundtrip Tenant')->first();
+
+    expect($tenant)->not->toBeNull();
+
+    $component->assertSet('modelId', $tenant->id)
+        ->assertDispatched('detailStored-zz-store-roundtrip-page', modelId: $tenant->id);
+});
+
+it('updates the mounted record instead of creating a new one', function (): void {
+    $tenant = Tenant::factory()->create(['name' => 'Before']);
+
+    $countBefore = Tenant::query()->count();
+
+    Livewire::test('zz-store-roundtrip-page', ['modelId' => $tenant->id])
+        ->set('detailData.name', 'After')
+        ->call('store');
+
+    expect(Tenant::query()->count())->toBe($countBefore)
+        ->and($tenant->refresh()->name)->toBe('After');
+});
+
+it('never mass-assigns identity or timestamp columns from the client payload', function (): void {
+    $tenant = Tenant::factory()->create(['name' => 'Original']);
+    $other = Tenant::factory()->create(['name' => 'Other']);
+
+    Livewire::test('zz-store-roundtrip-page', ['modelId' => $tenant->id])
+        ->set('detailData.id', $other->id)
+        ->set('detailData.name', 'Injected')
+        ->call('store');
+
+    // The id key was stripped: the mounted record was updated, the other left alone.
+    expect($tenant->refresh()->name)->toBe('Injected')
+        ->and($other->refresh()->name)->toBe('Other');
+});

--- a/tests/Feature/PageAutoDetailActionsTest.php
+++ b/tests/Feature/PageAutoDetailActionsTest.php
@@ -81,7 +81,7 @@ it('renders the actions exactly once with the opt-out plus an explicit include',
 
     // The label also appears in the serialized wire:snapshot (pageLayout is a
     // public property), so count the rendered button attribute instead.
-    expect(substr_count($component->html(), 'wire:click="doProbe"'))->toBe(1);
+    expect(mb_substr_count($component->html(), 'wire:click="doProbe"'))->toBe(1);
 });
 
 it('resolves url actions through the detailActionUrls convention', function (): void {

--- a/tests/Feature/RelationFormSyncTest.php
+++ b/tests/Feature/RelationFormSyncTest.php
@@ -73,7 +73,7 @@ class ZzRelationSpyHost extends ZzRelationHost
                 relation: 'zzChild',
                 fields: ['line_1', 'city'],
             )
-                ->persistWhen(fn (array $data): bool => ($data['line_1'] ?? '') !== 'skip-me')
+                ->persistWhen(fn(array $data): bool => ($data['line_1'] ?? '') !== 'skip-me')
                 ->persistUsing(function (Model $owner, array $data): void {
                     self::$spy = ['owner_id' => $owner->id, 'data' => $data];
                 }),

--- a/tests/Feature/RoutedModalRedirectTest.php
+++ b/tests/Feature/RoutedModalRedirectTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Component;
+use Livewire\Livewire;
+use Noerd\Models\NoerdUser;
+use Noerd\Models\Tenant;
+use Noerd\Tests\TestCase;
+use Noerd\Traits\NoerdPage;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+/*
+ | RoutedModal mechanics: pasting a routed-modal URL (…?modal=true) into a tab
+ | with browsing history redirects back to the previous page and flashes the
+ | reopen instruction the modal stack consumes; without history the plain full
+ | page renders. The `new` sentinel maps back to a null modelId.
+ */
+
+class ZzRoutedModalPageComponent extends Component
+{
+    use NoerdPage;
+
+    public const COMPONENT = 'zz-routed-modal-page';
+
+    public $detailModel = Tenant::class;
+
+    public function render(): string
+    {
+        return '<div>zz-routed-modal-page</div>';
+    }
+}
+
+beforeEach(function (): void {
+    $this->actingAs(NoerdUser::factory()->adminUser()->withSelectedApp('setup')->create());
+
+    // The factory registers the app tile with a module icon view that does not
+    // exist in the testbench — full-page renders need a resolvable icon.
+    \Noerd\Models\TenantApp::query()->update(['icon' => 'heroicon:outline:cog-6-tooth']);
+
+    Livewire::component('zz-routed-modal-page', ZzRoutedModalPageComponent::class);
+    registerTestLivewireRoute('zz-routed/{modelId}', 'zz-routed-modal-page', 'zz.routed.page');
+});
+
+it('redirects a ?modal=true page load back to the previous page and flashes the reopen instruction', function (): void {
+    $tenant = Tenant::factory()->create();
+
+    $response = $this->session(['_previous' => ['url' => url('/setup')]])
+        ->get(route('zz.routed.page', ['modelId' => $tenant->id, 'modal' => true]));
+
+    $response->assertRedirect(url('/setup'));
+
+    $flash = session('noerd-modal.open');
+    expect($flash['component'])->toBe('zz-routed-modal-page')
+        ->and($flash['arguments']['modelId'])->toBe((string) $tenant->id)
+        ->and($flash['url'])->toContain('modal=');
+});
+
+it('renders the plain full page without a previous url', function (): void {
+    $tenant = Tenant::factory()->create();
+
+    $this->get(route('zz.routed.page', ['modelId' => $tenant->id, 'modal' => true]))
+        ->assertOk()
+        ->assertSee('zz-routed-modal-page');
+});
+
+it('renders the plain full page without the modal flag', function (): void {
+    $tenant = Tenant::factory()->create();
+
+    $this->session(['_previous' => ['url' => url('/setup')]])
+        ->get(route('zz.routed.page', ['modelId' => $tenant->id]))
+        ->assertOk();
+});
+
+it('maps the new sentinel back to a null modelId in the reopen instruction', function (): void {
+    $response = $this->session(['_previous' => ['url' => url('/setup')]])
+        ->get(route('zz.routed.page', ['modelId' => 'new', 'modal' => true]));
+
+    $response->assertRedirect(url('/setup'));
+
+    expect(session('noerd-modal.open')['arguments']['modelId'])->toBeNull();
+});

--- a/tests/Feature/TranslatableFieldMarkerTest.php
+++ b/tests/Feature/TranslatableFieldMarkerTest.php
@@ -40,7 +40,7 @@ describe('Translatable field marker in detail forms', function (): void {
         ])->assertSuccessful()->html();
 
         assertElementHasClasses($html, ['border-sky-300', 'rounded-lg']);
-        expect(substr_count($html, 'border-sky-300'))->toBeGreaterThanOrEqual(2);
+        expect(mb_substr_count($html, 'border-sky-300'))->toBeGreaterThanOrEqual(2);
     });
 
     it('frames a translatable field in blue in the compact theme and keeps the compact layout', function (): void {
@@ -92,7 +92,7 @@ describe('Translatable field marker in detail forms', function (): void {
         ])->assertSuccessful()->html();
 
         // One language affordance per translatable field, carrying the explanation.
-        expect(substr_count($html, 'This field is translatable.'))->toBe(4)
+        expect(mb_substr_count($html, 'This field is translatable.'))->toBe(4)
             ->and($html)->toContain('text-sky-500');
     })->with(['default', 'compact', 'numbered']);
 
@@ -204,7 +204,7 @@ YAML);
         expect($html)->toContain('Germany')->toContain('DE');
         // … but only the translatable cell carries the tinted background, and it is a
         // background — never a frame, which would fight the table's own grid lines.
-        expect(substr_count($html, 'bg-sky-50 group-hover:bg-transparent'))->toBe(1)
+        expect(mb_substr_count($html, 'bg-sky-50 group-hover:bg-transparent'))->toBe(1)
             ->and($html)->not->toContain('border-sky-300!');
     });
 

--- a/tests/Traits/NoerdListMultiSelectTest.php
+++ b/tests/Traits/NoerdListMultiSelectTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Component;
+use Livewire\Livewire;
+use Noerd\Models\NoerdUser;
+use Noerd\Tests\TestCase;
+use Noerd\Traits\NoerdList;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+/*
+ | Mechanics of the generic multi-select/picker/bulk features on NoerdList:
+ | select-all toggling, the picker confirmation events, and the YAML-guarded
+ | generic deleteSelected() bulk action. Synthetic components with inline
+ | configs — never assertions against shipped YAML.
+ */
+
+/** List whose YAML declares the generic bulk delete. */
+class ZzBulkDeleteListComponent extends Component
+{
+    use NoerdList;
+
+    public const COMPONENT = 'zz-bulk-delete-list';
+
+    public function with(): array
+    {
+        return [
+            'listConfig' => $this->buildList(
+                $this->listQuery(NoerdUser::class)->paginate($this->perPage),
+            ),
+        ];
+    }
+
+    public function render(): string
+    {
+        return '<div></div>';
+    }
+
+    protected function getListConfig(?string $customName = null): array
+    {
+        return [
+            'title' => 'Bulk Users',
+            'multiSelect' => true,
+            'columns' => [
+                ['field' => 'name', 'label' => 'Name'],
+            ],
+            'bulkActions' => [
+                ['label' => 'Delete', 'action' => 'deleteSelected'],
+            ],
+        ];
+    }
+}
+
+/** Identical list WITHOUT the bulk action declared — deleteSelected must refuse. */
+class ZzNoBulkListComponent extends Component
+{
+    use NoerdList;
+
+    public const COMPONENT = 'zz-no-bulk-list';
+
+    public function with(): array
+    {
+        return [
+            'listConfig' => $this->buildList(
+                $this->listQuery(NoerdUser::class)->paginate($this->perPage),
+            ),
+        ];
+    }
+
+    public function render(): string
+    {
+        return '<div></div>';
+    }
+
+    protected function getListConfig(?string $customName = null): array
+    {
+        return [
+            'title' => 'Plain Users',
+            'columns' => [
+                ['field' => 'name', 'label' => 'Name'],
+            ],
+        ];
+    }
+}
+
+it('toggles a single record in and out of the selection', function (): void {
+    $component = Livewire::test(ZzBulkDeleteListComponent::class)
+        ->call('toggleRecordSelection', 7)
+        ->assertSet('selectedRecordIds', [7])
+        ->call('toggleRecordSelection', '7')
+        ->assertSet('selectedRecordIds', []);
+});
+
+it('selects and deselects every visible row via toggleSelectAllVisible', function (): void {
+    $users = NoerdUser::factory()->count(3)->create();
+
+    $component = Livewire::test(ZzBulkDeleteListComponent::class)
+        ->call('toggleSelectAllVisible');
+
+    expect($component->get('selectedRecordIds'))
+        ->toEqualCanonicalizing($users->pluck('id')->all());
+
+    $component->call('toggleSelectAllVisible');
+
+    expect($component->get('selectedRecordIds'))->toBe([]);
+});
+
+it('confirms a picker selection with ids, context and a modal close', function (): void {
+    Livewire::test(ZzBulkDeleteListComponent::class, ['returnsSelection' => true, 'context' => 'zzPicker'])
+        ->call('toggleRecordSelection', 3)
+        ->call('toggleRecordSelection', 5)
+        ->call('confirmRecordSelection')
+        ->assertDispatched('recordsSelected', ids: [3, 5], context: 'zzPicker')
+        ->assertDispatched('closeTopModal');
+});
+
+it('ticks a row instead of opening it while in picker mode', function (): void {
+    $user = NoerdUser::factory()->create();
+
+    Livewire::test(ZzBulkDeleteListComponent::class, ['returnsSelection' => true])
+        ->call('openListRow', $user->id)
+        ->assertSet('selectedRecordIds', [$user->id])
+        ->assertNotDispatched('noerdModal');
+});
+
+it('bulk-deletes the selected records through the generic deleteSelected action', function (): void {
+    $users = NoerdUser::factory()->count(3)->create();
+    $keep = $users->pop();
+
+    $component = Livewire::test(ZzBulkDeleteListComponent::class)
+        ->set('selectedRecordIds', $users->pluck('id')->all())
+        ->call('deleteSelected')
+        ->assertSet('selectedRecordIds', []);
+
+    expect(NoerdUser::query()->pluck('id')->all())->toBe([$keep->id]);
+});
+
+it('refuses deleteSelected when the list config declares no such bulk action', function (): void {
+    $users = NoerdUser::factory()->count(2)->create();
+
+    Livewire::test(ZzNoBulkListComponent::class)
+        ->set('selectedRecordIds', $users->pluck('id')->all())
+        ->call('deleteSelected');
+
+    expect(NoerdUser::query()->count())->toBe(2);
+});


### PR DESCRIPTION
Pre-release quality review, phase 7 of 7. Stacked on #51.

## New coverage for previously untested generic features
- **`NoerdListMultiSelectTest`**: select-all toggling, picker confirmation (`recordsSelected` with ids + context, modal close), row clicks ticking instead of opening in picker mode, and the generic `deleteSelected()` bulk action — including the guard that a list whose config declares no such bulk action can never be bulk-deleted through it. (`bulkActions`, `confirmRecordSelection` and `toggleSelectAllVisible` had zero tests.)
- **`RoutedModalRedirectTest`**: the "paste the URL into a fresh tab" contract — a `?modal=true` page load with browsing history redirects to the previous page and flashes the reopen instruction, renders the plain page without history or without the flag, and maps the `new` sentinel back to a null `modelId`. (The trait had zero direct coverage.)
- **`NoerdDetailStoreRoundtripTest`**: the generic store tail — created record's id adopted, `detailStored-{name}` dispatched for hosting pages, update-in-place, and the identity-column stripping of `writableDetailData()` proven against an injected foreign `id`.

## CI & tooling
- `laravel/pint` is a dev dependency with `composer lint`/`composer test` scripts, and a **Pint job in CI** — AGENTS.md mandated Pint, but nothing enforced it.
- **All 23 pre-existing/accumulated style violations are fixed** (`vendor/bin/pint`). Root cause worth knowing: the documented "run pint from the host root with `--dirty`" workflow NEVER covered this repository — a submodule's files are not part of the host's git working tree, so `--dirty` silently skips them all. Even `main` violated its own config in 11 files. AGENTS.md now documents the package-root workflow.

Full package suite: 979 passed, 1 skipped; `pint --test` green.