### PR TITLE
Close the Livewire authorization and injection gaps, and scope admin rights to the current tenant

### DIFF
--- a/resources/views/components/create-new-tenant.blade.php
+++ b/resources/views/components/create-new-tenant.blade.php
@@ -10,8 +10,22 @@ new class extends Component {
     public string $name = '';
     public bool $showSuccess = false;
 
+    public function mount(): void
+    {
+        $this->authorizeAccess();
+    }
+
     public function createTenant()
     {
+        // Guarded on the ACTION as well as on mount: this component carries the
+        // whole tenant-creation logic while the admin/feature checks used to sit
+        // only on its wrapper (noerd::create-tenant). Reached directly — through
+        // the modal stack or the generic component page — it let any
+        // authenticated user create a tenant AND attach themselves to its ADMIN
+        // profile, and isAdmin() is not tenant-scoped, so that was a global
+        // privilege escalation.
+        $this->authorizeAccess();
+
         $this->validate([
             'name' => ['required', 'string', 'max:50', 'min:3'],
         ]);
@@ -47,6 +61,12 @@ new class extends Component {
         TenantHelper::setSelectedTenantId($tenant->id);
 
         $this->showSuccess = true;
+    }
+
+    private function authorizeAccess(): void
+    {
+        abort_unless(config('noerd.features.multi_tenant'), 404);
+        abort_unless(\Noerd\Helpers\NoerdAuth::user()?->isAdmin(), 403);
     }
 }; ?>
 

--- a/resources/views/components/generic-component-page.blade.php
+++ b/resources/views/components/generic-component-page.blade.php
@@ -1,12 +1,15 @@
 <?php
 
+use Livewire\Attributes\Locked;
 use Livewire\Component;
 use Noerd\Support\ComponentAccessGuard;
 
 new class extends Component
 {
+    #[Locked]
     public string $componentName = '';
 
+    #[Locked]
     public array $arguments = [];
 
     public function mount(string $componentName): void
@@ -19,7 +22,28 @@ new class extends Component
         ComponentAccessGuard::authorize($componentName);
 
         $this->componentName = $componentName;
-        $this->arguments = request()->query();
+        $this->arguments = $this->safeArguments(request()->query());
+    }
+
+    /**
+     * Mount arguments are assigned to matching public properties — including
+     * #[Locked] ones, which only veto the UPDATE path. Passing the raw query
+     * string therefore let a crafted URL repoint a component's identity before
+     * any guard ran (e.g. ?listModel=… aims the generic list query at an
+     * unscoped model, ?objectPermissionModel=… neutralises the object gates).
+     * Only addressing parameters are forwarded.
+     *
+     * @param  array<string, mixed>  $query
+     * @return array<string, mixed>
+     */
+    private function safeArguments(array $query): array
+    {
+        $allowed = ['modelId', 'relations', 'quickCreate', 'parentId', 'context', 'key', 'tab'];
+
+        return array_filter(
+            array_intersect_key($query, array_flip($allowed)),
+            fn(mixed $value): bool => is_scalar($value) || is_array($value),
+        );
     }
 }; ?>
 

--- a/resources/views/components/noerd-user-detail.blade.php
+++ b/resources/views/components/noerd-user-detail.blade.php
@@ -99,6 +99,38 @@ new class extends Component {
         }
     }
 
+    /**
+     * The edited account must belong to a tenant this admin administers.
+     * mount() only proves the CALLER is an admin — $modelId can still be
+     * repointed on a later request (it is a plain URL-bound property).
+     */
+    private function authorizeTargetUser(): void
+    {
+        $admin = NoerdAuth::user();
+
+        if (! $this->modelId || $admin->isSuperAdmin()) {
+            return;
+        }
+
+        $target = NoerdUser::find($this->modelId);
+
+        abort_unless($target !== null, 404);
+
+        // A super admin is never editable from a tenant admin's user screen.
+        abort_if($target->isSuperAdmin(), 403);
+
+        $adminTenantIds = $admin->adminTenants()->pluck('tenants.id');
+
+        // Editable when the account belongs to a tenant this admin administers —
+        // or when it belongs to no tenant at all (an unassigned account being
+        // granted its first access from this screen).
+        abort_unless(
+            $target->tenants()->count() === 0
+                || $target->tenants()->whereIn('tenants.id', $adminTenantIds)->exists(),
+            403,
+        );
+    }
+
     public function store(): void
     {
         foreach ($this->possibleTenants as $tenantId => $value) {
@@ -136,14 +168,34 @@ new class extends Component {
             $this->detailData['password'] = bcrypt(Str::random(32));
         }
 
-        $userData = collect($this->detailData)->only(['name', 'email', 'password'])->toArray();
+        // $modelId is URL-bound and therefore client-writable — re-assert that the
+        // edited account is one this admin may touch before writing to it.
+        $this->authorizeTargetUser();
+
+        // 'password' is deliberately NOT writable here: an existing account's
+        // password is set through the dedicated user-update-password form (which
+        // authorizes the target itself). Only a NEW user carries the generated
+        // placeholder set above.
+        $writable = $this->modelId ? ['name', 'email'] : ['name', 'email', 'password'];
+        $userData = collect($this->detailData)->only($writable)->toArray();
         $user = NoerdUser::updateOrCreate(['id' => $this->modelId], $userData);
 
-        $allowedTenants = Auth::user()->adminTenants()->pluck('id');
+        $allowedTenants = NoerdAuth::user()->adminTenants()->pluck('tenants.id')->all();
         foreach ($this->possibleTenants as $tenantId => $value) {
+            // Both detach AND attach stay inside the allow-list: detaching
+            // unconditionally let an admin of one tenant strip a user from any
+            // other tenant (and, once the last one was gone, delete the account).
+            if (! in_array((int) $tenantId, array_map('intval', $allowedTenants), true)) {
+                continue;
+            }
+
             $user->tenants()->detach($tenantId);
-            $profileId = $value['selectedProfile'];
-            if ($value['hasAccess'] && in_array($tenantId, $allowedTenants->toArray())) {
+
+            $profileId = $value['selectedProfile'] ?? null;
+            $profileBelongsToTenant = $profileId
+                && Profile::whereKey($profileId)->where('tenant_id', $tenantId)->exists();
+
+            if (($value['hasAccess'] ?? false) && $profileBelongsToTenant) {
                 $user->tenants()->attach($tenantId, ['profile_id' => $profileId]);
             }
         }

--- a/resources/views/components/relation-box.blade.php
+++ b/resources/views/components/relation-box.blade.php
@@ -1,16 +1,23 @@
 <?php
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
 use Noerd\Services\RelationBoxRegistry;
 
 new class extends Component {
+    // Established by the hosting page at mount; a client UPDATE must never
+    // repoint the box at another model or widen its tile list.
+    #[Locked]
     public string $modelClass = '';
 
+    #[Locked]
     public mixed $modelId = null;
 
     /** @var array<int, array<string, mixed>> */
+    #[Locked]
     public array $relations = [];
 
     /** @var array<int, array{label: string, heroicon: string, component: string, route: string, count: int, arguments: array<string, mixed>}> */
@@ -57,6 +64,39 @@ new class extends Component {
     }
 
     /**
+     * Whether $method is a genuine Eloquent relation on $model — decided by its
+     * DECLARED RETURN TYPE, never by calling it. $relations arrives as mount
+     * arguments, which the modal stack and the generic component page take from
+     * the client (#[Locked] guards updates, not mount), so a bare
+     * method_exists() check here was an arbitrary no-argument method call on an
+     * arbitrary model: `relation: 'delete'` deleted the record.
+     */
+    private function isRelationMethod(Model $model, string $method): bool
+    {
+        if ($method === '' || ! method_exists($model, $method)) {
+            return false;
+        }
+
+        try {
+            $reflection = new ReflectionMethod($model, $method);
+        } catch (ReflectionException) {
+            return false;
+        }
+
+        if (! $reflection->isPublic() || $reflection->isStatic() || $reflection->getNumberOfRequiredParameters() > 0) {
+            return false;
+        }
+
+        $returnType = $reflection->getReturnType();
+
+        if (! $returnType instanceof ReflectionNamedType || $returnType->isBuiltin()) {
+            return false;
+        }
+
+        return is_a($returnType->getName(), Relation::class, true);
+    }
+
+    /**
      * @param  array<string, mixed>  $tile
      * @return array{label: string, heroicon: string, component: string, route: string, count: int, arguments: array<string, mixed>}|null
      */
@@ -73,7 +113,7 @@ new class extends Component {
 
         $count = match (true) {
             $countResolver instanceof Closure => (int) $countResolver($model),
-            $relationName && method_exists($model, $relationName) => $model->{$relationName}()->count(),
+            is_string($relationName) && $this->isRelationMethod($model, $relationName) => $model->{$relationName}()->count(),
             default => 0,
         };
 

--- a/resources/views/components/setup-collections-list.blade.php
+++ b/resources/views/components/setup-collections-list.blade.php
@@ -1,6 +1,7 @@
 <?php
 
 use Livewire\Attributes\Computed;
+use Livewire\Attributes\Locked;
 use Livewire\Component;
 use Noerd\Facades\Noerd;
 use Noerd\Helpers\SetupCollectionHelper;
@@ -20,6 +21,9 @@ new class extends Component
 
     public string|int|null $collectionKey = null;
 
+    // Resolved from the collection definition at mount; never a client input
+    // (it feeds the JSON_EXTRACT search paths below).
+    #[Locked]
     public ?array $collectionLayout = null;
 
     #[Computed]
@@ -93,13 +97,23 @@ new class extends Component
         // Apply search if provided
         if (! empty($this->search)) {
             $query->where(function ($q): void {
+                $searchable = 0;
+
                 if ($this->collectionLayout && isset($this->collectionLayout['fields'])) {
                     foreach ($this->collectionLayout['fields'] as $field) {
                         $fieldName = $field['name'] ?? '';
-                        $fieldKey = str_replace('detailData.', '', $fieldName);
+                        $fieldKey = str_replace('detailData.', '', is_string($fieldName) ? $fieldName : '');
 
                         // Skip image fields for search
                         if (($field['type'] ?? '') === 'image') {
+                            continue;
+                        }
+
+                        // The key is interpolated into a JSON_EXTRACT path below,
+                        // so it must never carry anything but a plain field name —
+                        // $collectionLayout is a public property and therefore
+                        // client-writable, which made this a raw SQL injection.
+                        if (! preg_match('/^[A-Za-z0-9_]+$/', $fieldKey)) {
                             continue;
                         }
 
@@ -107,7 +121,14 @@ new class extends Component
                         $q->orWhereRaw("JSON_EXTRACT(data, \"$.{$fieldKey}.de\") LIKE ?", ['%'.$this->search.'%'])
                             ->orWhereRaw("JSON_EXTRACT(data, \"$.{$fieldKey}.en\") LIKE ?", ['%'.$this->search.'%'])
                             ->orWhereRaw("JSON_EXTRACT(data, \"$.{$fieldKey}\") LIKE ?", ['%'.$this->search.'%']);
+                        $searchable++;
                     }
+                }
+
+                // No searchable field survived: an empty where-group would match
+                // EVERY row, turning a failed search into a full listing.
+                if ($searchable === 0) {
+                    $q->whereRaw('1 = 0');
                 }
             });
         }

--- a/resources/views/components/tenant-detail.blade.php
+++ b/resources/views/components/tenant-detail.blade.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Auth;
 use Livewire\Component;
 use Livewire\WithFileUploads;
+use Noerd\Helpers\NoerdAuth;
 use Noerd\Models\Tenant;
 use Noerd\Traits\NoerdDetail;
 
@@ -23,17 +24,31 @@ new class extends Component {
             $this->modelId = (string) Auth::user()->selected_tenant_id;
         }
 
-        $user = Auth::user();
-        abort_unless(
-            $user->isSuperAdmin() || $user->adminTenants()->whereKey($this->modelId)->exists(),
-            403,
-        );
+        $this->authorizeTenant();
 
         $this->initDetail();
     }
 
+    /**
+     * The edited tenant must be one this user administers. Re-checked on every
+     * write, not only on mount: $modelId is URL-bound and therefore rewritable
+     * by the client, so a mount-time-only check let an admin of one tenant
+     * rename any other tenant in the installation.
+     */
+    private function authorizeTenant(): void
+    {
+        $user = NoerdAuth::user();
+
+        abort_unless(
+            $user?->isSuperAdmin() || (bool) $user?->adminTenants()->whereKey($this->modelId)->exists(),
+            403,
+        );
+    }
+
     public function store(): void
     {
+        $this->authorizeTenant();
+
         $this->validate([
             'detailData.name' => ['required', 'string', 'max:255', 'min:3'],
         ]);
@@ -62,6 +77,8 @@ new class extends Component {
 
     public function storeFile()
     {
+        $this->authorizeTenant();
+
         // Validated before storing: storePublicly() keeps the client-supplied
         // extension on a web-served disk, so an unvalidated upload was stored
         // same-origin script execution (.html/.svg) at /storage/uploads/….

--- a/resources/views/components/tenant-detail.blade.php
+++ b/resources/views/components/tenant-detail.blade.php
@@ -62,6 +62,13 @@ new class extends Component {
 
     public function storeFile()
     {
+        // Validated before storing: storePublicly() keeps the client-supplied
+        // extension on a web-served disk, so an unvalidated upload was stored
+        // same-origin script execution (.html/.svg) at /storage/uploads/….
+        $this->validate([
+            'logo' => ['required', 'image', 'mimes:jpg,jpeg,png,webp,gif', 'max:4096'],
+        ]);
+
         $link = $this->logo->storePublicly(path: 'uploads', options: 'public');
         $this->detailData['logo'] = '/storage/' . $link;
     }

--- a/resources/views/components/user-update-password.blade.php
+++ b/resources/views/components/user-update-password.blade.php
@@ -2,6 +2,8 @@
 
 use Livewire\Attributes\Locked;
 use Livewire\Component;
+use Noerd\Helpers\NoerdAuth;
+use Noerd\Models\NoerdUser;
 
 new class extends Component {
 
@@ -13,21 +15,60 @@ new class extends Component {
 
     public bool $showSuccessIndicator = false;
 
+    /**
+     * Whether the current user may set this account's password. Drives BOTH the
+     * rendering (an unauthorized viewer simply sees no form) and the action
+     * guard below — deliberately not an abort() on render, so an admin opening
+     * a user who is not in their tenants still gets the rest of the editor.
+     */
+    public function canSetPassword(): bool
+    {
+        $admin = NoerdAuth::user();
+
+        if (! $admin?->isAdmin()) {
+            return false;
+        }
+
+        if (! $this->userId || $admin->isSuperAdmin() || (int) $this->userId === (int) $admin->id) {
+            return true;
+        }
+
+        return NoerdUser::whereKey($this->userId)
+            ->whereHas('tenants', fn($query) => $query->whereIn('tenants.id', $admin->adminTenants()->pluck('tenants.id')))
+            ->exists();
+    }
+
     public function updatePassword()
     {
+        // Re-authorized on the action, not only on mount: #[Locked] rejects a
+        // client UPDATE of $userId but does NOT protect the MOUNT arguments,
+        // which the modal stack and the generic component page take from the
+        // client. Without this check any authenticated user could mount this
+        // component for a foreign id and overwrite that account's password.
+        $this->authorizeTarget();
+
         $this->validate([
             'password' => ['required', 'string', 'confirmed'],
         ]);
 
-        $user = \Noerd\Models\NoerdUser::find($this->userId);
+        $user = NoerdUser::findOrFail($this->userId);
         $user->password = bcrypt($this->password);
         $user->save();
 
         $this->showSuccessIndicator = true;
     }
+
+    /**
+     * Only an admin may set a password, and only for a user who belongs to a
+     * tenant that admin actually administers.
+     */
+    private function authorizeTarget(): void
+    {
+        abort_unless($this->canSetPassword(), 403);
+    }
 }; ?>
 
-<section>
+<section @class(['hidden' => ! $this->canSetPassword()])>
     <header>
         <div class="text-lg font-medium text-gray-900">
             {{ __('Set Password') }}

--- a/src/Commands/MakeUserAdmin.php
+++ b/src/Commands/MakeUserAdmin.php
@@ -46,7 +46,7 @@ class MakeUserAdmin extends Command
         $this->info("Processing user: {$user->name} ({$user->email})");
 
         // Check if user already is admin (but continue to ensure tenant assignment)
-        $isAlreadyAdmin = $user->isAdmin();
+        $isAlreadyAdmin = $user->isAdminOfAnyTenant();
         if ($isAlreadyAdmin) {
             $this->warn('User is already an admin. Ensuring tenant assignment is correct...');
         }
@@ -126,7 +126,7 @@ class MakeUserAdmin extends Command
 
         // Verify admin status
         $user->refresh();
-        if ($user->isAdmin()) {
+        if ($user->isAdminOfAnyTenant()) {
             $this->newLine();
             if ($isAlreadyAdmin) {
                 $this->info("✅ User {$user->name} remains an admin. Tenant assignment verified.");

--- a/src/Commands/NoerdInstallCommand.php
+++ b/src/Commands/NoerdInstallCommand.php
@@ -614,7 +614,7 @@ class NoerdInstallCommand extends Command
     protected function setupExistingAdminUser(): void
     {
         $users = NoerdUser::all();
-        $adminUsers = $users->filter(fn(NoerdUser $user) => $user->isAdmin());
+        $adminUsers = $users->filter(fn(NoerdUser $user) => $user->isAdminOfAnyTenant());
 
         if ($adminUsers->isNotEmpty()) {
             $this->line('<comment>Admin user(s) already exist:</comment>');
@@ -636,7 +636,7 @@ class NoerdInstallCommand extends Command
 
         // Build options for choice prompt
         $options = $users->mapWithKeys(function (NoerdUser $user) {
-            $adminTag = $user->isAdmin() ? ' [ADMIN]' : '';
+            $adminTag = $user->isAdminOfAnyTenant() ? ' [ADMIN]' : '';
             return [$user->id => "{$user->name} ({$user->email}){$adminTag}"];
         })->toArray();
 
@@ -650,7 +650,7 @@ class NoerdInstallCommand extends Command
         $selectedUserId = array_search($selectedUserId, $options);
         $selectedUser = NoerdUser::find($selectedUserId);
 
-        if ($selectedUser->isAdmin()) {
+        if ($selectedUser->isAdminOfAnyTenant()) {
             $this->line("<comment>User '{$selectedUser->name}' is already an admin.</comment>");
             return;
         }

--- a/src/Livewire/PolymorphicRelationFieldComponent.php
+++ b/src/Livewire/PolymorphicRelationFieldComponent.php
@@ -222,6 +222,14 @@ abstract class PolymorphicRelationFieldComponent extends Component
 
     private function activeDefinition(): ?RelationFieldDefinition
     {
+        // $selectedRelationType is client-writable by design (the user picks the
+        // type), so it must be re-checked against the field's declared
+        // whitelist — resolving it straight from the registry let a crafted
+        // update point the polymorphic FK at a model the YAML forbids.
+        if ($this->allowedTypes !== [] && ! in_array($this->selectedRelationType, $this->allowedTypes, true)) {
+            return null;
+        }
+
         if ($this->selectedRelationType === '') {
             return null;
         }

--- a/src/Models/NoerdUser.php
+++ b/src/Models/NoerdUser.php
@@ -109,15 +109,43 @@ class NoerdUser extends Authenticatable implements HasLocalePreference
         return $this->profiles->where('tenant_id', $selectedTenantId)->first()->key ?? null;
     }
 
-    public function isAdmin(): bool
+    /**
+     * Whether the user administers the tenant of the CURRENT request.
+     *
+     * Deliberately tenant-scoped (like currentProfile()): an ADMIN profile is
+     * granted per tenant, so counting admin profiles across all tenants made an
+     * admin of one tenant an admin of every tenant they are merely a member of —
+     * and that is the check behind SetupMiddleware and ComponentAccessGuard.
+     * Without a resolved tenant it fails closed; a super admin is unaffected.
+     */
+    public function isAdmin(?int $tenantId = null): bool
     {
         if ($this->isSuperAdmin()) {
             return true;
         }
 
-        $adminProfilesCount = $this->profiles->where('key', 'ADMIN')->count();
+        // The tenant the request operates in — same source as currentProfile().
+        $tenantId ??= TenantHelper::getSelectedTenantId();
 
-        return (bool) $adminProfilesCount > 0;
+        if (! $tenantId) {
+            return false;
+        }
+
+        return $this->profiles
+            ->where('tenant_id', $tenantId)
+            ->where('key', 'ADMIN')
+            ->isNotEmpty();
+    }
+
+    /**
+     * Whether the user administers ANY tenant. Exclusively for contexts that
+     * have no tenant request scope — console commands and cross-tenant
+     * reporting. NEVER use it for authorization: that is isAdmin(), which is
+     * scoped to the tenant of the current request.
+     */
+    public function isAdminOfAnyTenant(): bool
+    {
+        return $this->isSuperAdmin() || $this->profiles->where('key', 'ADMIN')->isNotEmpty();
     }
 
     public function isSuperAdmin(): bool

--- a/src/Support/ComponentAccessGuard.php
+++ b/src/Support/ComponentAccessGuard.php
@@ -31,6 +31,12 @@ final class ComponentAccessGuard
         'noerd::tenants-list',
         'noerd::tenant-detail',
         'noerd::create-tenant',
+        // The inner worker of create-tenant: it holds the actual tenant
+        // creation (incl. attaching the caller to the new ADMIN profile), so it
+        // must be as unreachable as its wrapper.
+        'noerd::create-new-tenant',
+        // Sets a user's password; only ever embedded in the user editor.
+        'noerd::user-update-password',
         'noerd::tenant-apps-list',
         'noerd::system-settings-page',
         'noerd::setup-collections-list',
@@ -73,6 +79,15 @@ final class ComponentAccessGuard
      * not on the admin allow-list are permitted here — they are guarded by their
      * own route middleware / object gates; this guard only closes the admin
      * bypass at the dynamic-mount seams.
+     *
+     * Matching ignores the namespace prefix: noerd registers its components with
+     * BOTH a namespace and a bare location (Livewire::addLocation), so
+     * `noerd::tenants-list` and `tenants-list` mount the very same admin screen —
+     * comparing the full name alone let the bare alias walk straight past this
+     * guard. Consequence to be aware of: a host or module component whose bare
+     * name matches one of these becomes admin-only too. That is the deliberate
+     * fail-closed choice — such a component already collides with noerd's own
+     * registration.
      */
     public static function allows(?string $componentName): bool
     {
@@ -80,11 +95,28 @@ final class ComponentAccessGuard
             return true;
         }
 
-        if (in_array($componentName, self::ADMIN_COMPONENTS, true)
-            || in_array($componentName, self::$registered, true)) {
+        $restricted = array_map(
+            static fn(string $name): string => self::normalize($name),
+            array_merge(self::ADMIN_COMPONENTS, self::$registered),
+        );
+
+        if (in_array(self::normalize($componentName), $restricted, true)) {
             return (bool) NoerdAuth::user()?->isAdmin();
         }
 
         return true;
+    }
+
+    /**
+     * The comparable identity of a component name: lowercased and stripped of
+     * any Livewire namespace prefix ('noerd::tenants-list' → 'tenants-list').
+     */
+    private static function normalize(string $componentName): string
+    {
+        $name = str_contains($componentName, '::')
+            ? mb_substr($componentName, mb_strpos($componentName, '::') + 2)
+            : $componentName;
+
+        return mb_strtolower(mb_trim($name));
     }
 }

--- a/src/Support/LockedPropertiesHook.php
+++ b/src/Support/LockedPropertiesHook.php
@@ -38,6 +38,19 @@ class LockedPropertiesHook extends ComponentHook
         'listViewApp',
         'showMoreComponent',
         'showMoreRoute',
+        // A settings page's model map decides WHICH model persistSettings()
+        // writes and WHICH property it reads the payload from — repointing it
+        // from the client is an arbitrary-model write.
+        'settingsModels',
+        // Selects the list YAML a picker renders; a swapped config exposes
+        // columns the intended picker deliberately hides.
+        'selectListConfig',
+        // The resolved YAML layout. Written only by initPage()/initDetail()/
+        // storeProcess()/QuickCreateExitHook — never by the client. It drives
+        // validateFromLayout(), the relation-form persist decision and the
+        // embedded list/widget mounts, so a client rewrite means skipped
+        // validation and attacker-chosen nested components.
+        'pageLayout',
     ];
 
     public function update($propertyName, $fullPath, $newValue): void

--- a/src/Traits/NoerdList.php
+++ b/src/Traits/NoerdList.php
@@ -689,10 +689,22 @@ trait NoerdList
         }
 
         if ($this->resolvedModelClass !== null) {
-            $this->resolvedModelClass::query()
-                ->whereIn('id', $this->selectedRecordIds)
-                ->get()
-                ->each(fn($model) => $model->delete());
+            // Only rows THIS list yields may be deleted. A bare
+            // Model::query()->whereIn($selectedRecordIds) ignored the list's own
+            // narrowing (tenant scope, column filters, and any constraint a
+            // component adds), so a crafted id list reached records the list
+            // would never show.
+            $query = $this->listQuery($this->resolvedModelClass, $this->listQueryConfigName)
+                ->whereIn('id', $this->selectedRecordIds);
+
+            // listQuery() cannot see constraints a component adds in its own
+            // listData() override (e.g. "users of MY tenants"), so those lists
+            // are additionally limited to the rows currently rendered.
+            if (!$this->usesTraitListData()) {
+                $query->whereIn('id', $this->visibleRowIds() ?: [0]);
+            }
+
+            $query->get()->each(fn($model) => $model->delete());
         }
 
         $this->selectedRecordIds = [];
@@ -1755,6 +1767,16 @@ trait NoerdList
             'field' => $this->sortField,
             'asc' => $this->sortAsc,
         ]]);
+    }
+
+    /**
+     * Whether listData() is the trait's own implementation. A component that
+     * overrides it may narrow the result set in ways listQuery() cannot see.
+     */
+    private function usesTraitListData(): bool
+    {
+        return (new ReflectionMethod($this, 'listData'))->getFileName()
+            === (new ReflectionClass(NoerdList::class))->getFileName();
     }
 
     /**

--- a/src/Traits/NoerdSettingsPage.php
+++ b/src/Traits/NoerdSettingsPage.php
@@ -70,15 +70,18 @@ trait NoerdSettingsPage
         $allowedByProperty = $this->settingsWritableKeys();
 
         foreach ($this->settingsModelMap() as $property => $modelClass) {
-            $data = collect($this->{$property})
-                ->except(['id', 'tenant_id', 'created_at', 'updated_at']);
-
-            // A settings page is a pure form, so only the keys its YAML declares
-            // may be written — never an extra column injected into the client array.
+            // A settings page is a pure form, so ONLY the keys its YAML declares
+            // for this property may be written. Fails CLOSED: a property the
+            // settings YAML does not bind writes nothing at all, rather than
+            // falling through to an unfiltered mass assignment.
             $allowed = $allowedByProperty[$property] ?? [];
-            if ($allowed !== []) {
-                $data = $data->only($allowed);
+            if ($allowed === []) {
+                continue;
             }
+
+            $data = collect($this->{$property})
+                ->except(['id', 'tenant_id', 'created_at', 'updated_at'])
+                ->only($allowed);
 
             $modelClass::updateOrCreate(['tenant_id' => $tenantId], $data->toArray());
         }

--- a/tests/Commands/CreateAdminCommandTest.php
+++ b/tests/Commands/CreateAdminCommandTest.php
@@ -37,7 +37,7 @@ it('creates a new admin user with command options', function (): void {
     $user = NoerdUser::where('email', 'admin@example.com')->first();
     expect($user)->not->toBeNull();
     expect($user->name)->toBe('Test Admin');
-    expect($user->isAdmin())->toBeTrue();
+    expect($user->isAdminOfAnyTenant())->toBeTrue();
     expect($user->super_admin)->toBeFalse();
 });
 

--- a/tests/Commands/MakeUserAdminTest.php
+++ b/tests/Commands/MakeUserAdminTest.php
@@ -15,7 +15,7 @@ it('successfully makes a user admin', function (): void {
     $tenant = $user->tenants->first();
 
     // Ensure user is not admin initially
-    expect($user->isAdmin())->toBeFalse();
+    expect($user->isAdminOfAnyTenant())->toBeFalse();
 
     // Run the command
     $this->artisan('noerd:make-admin', ['user_id' => $user->id])
@@ -29,7 +29,7 @@ it('successfully makes a user admin', function (): void {
 
     // Verify user is now admin
     $user->refresh();
-    expect($user->isAdmin())->toBeTrue();
+    expect($user->isAdminOfAnyTenant())->toBeTrue();
 
     // Verify ADMIN profile was created
     $adminProfile = Profile::where('tenant_id', $tenant->id)
@@ -67,7 +67,7 @@ it('handles user with multiple tenants', function (): void {
     $user->tenants()->attach($tenant1->id, ['profile_id' => $profile1->id]);
     $user->tenants()->attach($tenant2->id, ['profile_id' => $profile2->id]);
 
-    expect($user->isAdmin())->toBeFalse();
+    expect($user->isAdminOfAnyTenant())->toBeFalse();
 
     // Run the command
     $this->artisan('noerd:make-admin', ['user_id' => $user->id])
@@ -80,7 +80,7 @@ it('handles user with multiple tenants', function (): void {
 
     // Verify user is now admin
     $user->refresh();
-    expect($user->isAdmin())->toBeTrue();
+    expect($user->isAdminOfAnyTenant())->toBeTrue();
 
     // Verify both tenants have admin profiles
     expect(Profile::where('tenant_id', $tenant1->id)->where('key', 'ADMIN')->exists())->toBeTrue();
@@ -91,7 +91,7 @@ it('recognizes user who is already admin but ensures tenant assignment', functio
     // Create an admin user
     $user = NoerdUser::factory()->adminUser()->create();
 
-    expect($user->isAdmin())->toBeTrue();
+    expect($user->isAdminOfAnyTenant())->toBeTrue();
 
     // Run the command - should warn but continue to ensure tenant assignment
     $this->artisan('noerd:make-admin', ['user_id' => $user->id])
@@ -127,7 +127,7 @@ it('handles existing admin profile correctly', function (): void {
     // Attach user to tenant with user profile
     $user->tenants()->attach($tenant->id, ['profile_id' => $userProfile->id]);
 
-    expect($user->isAdmin())->toBeFalse();
+    expect($user->isAdminOfAnyTenant())->toBeFalse();
 
     // Run the command
     $this->artisan('noerd:make-admin', ['user_id' => $user->id])
@@ -139,7 +139,7 @@ it('handles existing admin profile correctly', function (): void {
 
     // Verify user is now admin
     $user->refresh();
-    expect($user->isAdmin())->toBeTrue();
+    expect($user->isAdminOfAnyTenant())->toBeTrue();
 });
 
 it('fails with invalid user id', function (): void {
@@ -177,7 +177,7 @@ it('handles user with partial admin access correctly', function (): void {
     $user->tenants()->attach($tenant2->id, ['profile_id' => $userProfile2->id]);
 
     // User should already be admin due to first tenant
-    expect($user->isAdmin())->toBeTrue();
+    expect($user->isAdminOfAnyTenant())->toBeTrue();
 
     // Command should continue and grant admin on the second tenant too
     $this->artisan('noerd:make-admin', ['user_id' => $user->id])
@@ -209,7 +209,7 @@ it('provides detailed summary output', function (): void {
 it('verifies admin status after completion', function (): void {
     $user = NoerdUser::factory()->withExampleTenant()->create();
 
-    expect($user->isAdmin())->toBeFalse();
+    expect($user->isAdminOfAnyTenant())->toBeFalse();
 
     $this->artisan('noerd:make-admin', ['user_id' => $user->id])
         ->expectsOutput("✅ User {$user->name} is now an admin with access to Setup!")
@@ -217,7 +217,7 @@ it('verifies admin status after completion', function (): void {
 
     // Double-check the user can now access setup
     $user->refresh();
-    expect($user->isAdmin())->toBeTrue();
+    expect($user->isAdminOfAnyTenant())->toBeTrue();
     expect($user->profiles->where('key', 'ADMIN')->count())->toBeGreaterThan(0);
     expect($user->selected_tenant_id)->not->toBeNull();
 });

--- a/tests/Feature/CollectionsListSearchInjectionTest.php
+++ b/tests/Feature/CollectionsListSearchInjectionTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Features\SupportLockedProperties\CannotUpdateLockedPropertyException;
+use Livewire\Livewire;
+use Noerd\Helpers\TenantHelper;
+use Noerd\Models\NoerdUser;
+use Noerd\Models\SetupCollection;
+use Noerd\Models\SetupCollectionEntry;
+use Noerd\Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+/*
+ | The collection entry search interpolates each field name into a
+ | JSON_EXTRACT() path inside orWhereRaw(). $collectionLayout supplies those
+ | names, so it must never carry client input: an injected name closed the
+ | JSON path and appended arbitrary SQL. Two independent defenses are asserted,
+ | because #[Locked] rejects client UPDATES but does not protect MOUNT
+ | arguments — which the modal stack and the generic component page take from
+ | the client.
+ */
+
+beforeEach(function (): void {
+    $this->actingAs(NoerdUser::factory()->adminUser()->withSelectedApp('setup')->create());
+    $tenantId = TenantHelper::getSelectedTenantId();
+
+    $collection = SetupCollection::create([
+        'tenant_id' => $tenantId,
+        'collection_key' => 'ZZINJECT',
+        'name' => 'Injection Fixture',
+    ]);
+
+    SetupCollectionEntry::create([
+        'tenant_id' => $tenantId,
+        'setup_collection_id' => $collection->id,
+        'data' => ['name' => 'Alpha Entry'],
+        'sort' => 1,
+    ]);
+});
+
+it('rejects a client update to the collection layout', function (): void {
+    expect(fn() => Livewire::test('noerd::setup-collections-list', ['collectionKey' => 'zzinject'])
+        ->set('collectionLayout', ['fields' => [['name' => 'detailData.name', 'type' => 'text']]]))
+        ->toThrow(CannotUpdateLockedPropertyException::class);
+});
+
+it('ignores a field name that is not a plain identifier instead of interpolating it', function (): void {
+    $component = Livewire::test('noerd::setup-collections-list', ['collectionKey' => 'zzinject']);
+    $instance = $component->instance();
+
+    // Defense in depth, exercised directly on the query builder: mount() always
+    // derives the layout server-side, so this shape is not reachable through the
+    // component today — the assertion pins the escaping rule itself, so a future
+    // caller that does feed the layout cannot reintroduce the injection. The
+    // payload closes the JSON path and ORs a tautology.
+    $instance->collectionLayout = [
+        'fields' => [['name' => 'x") OR 1=1 OR JSON_EXTRACT(data,"$.y', 'type' => 'text']],
+    ];
+    $instance->search = 'nomatch-xyz';
+
+    $rows = $instance->listData()['rows'];
+
+    expect($rows->total())->toBe(0);
+});
+
+it('still searches on a legitimate field name', function (): void {
+    $instance = Livewire::test('noerd::setup-collections-list', ['collectionKey' => 'zzinject'])->instance();
+    $instance->collectionLayout = [
+        'fields' => [['name' => 'detailData.name', 'type' => 'text']],
+    ];
+
+    $instance->search = 'Alpha';
+    expect($instance->listData()['rows']->total())->toBe(1);
+
+    $instance->search = 'nomatch-xyz';
+    expect($instance->listData()['rows']->total())->toBe(0);
+});

--- a/tests/Feature/DynamicMountAuthorizationTest.php
+++ b/tests/Feature/DynamicMountAuthorizationTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Livewire\Livewire;
+use Noerd\Helpers\TenantHelper;
+use Noerd\Models\NoerdUser;
+use Noerd\Models\Profile;
+use Noerd\Models\Tenant;
+use Noerd\Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+/*
+ | Components reachable through the DYNAMIC mount seams — the client-dispatchable
+ | `noerdModal` event and GET /noerd/component-page/{component} — receive
+ | attacker-chosen mount arguments. Livewire assigns those to matching public
+ | properties INCLUDING #[Locked] ones (Locked only vetoes the update path), so
+ | every component that acts on such an argument must authorize the target
+ | itself. Each test below is a previously working exploit.
+ */
+
+beforeEach(function (): void {
+    $tenant = Tenant::factory()->create();
+    $attacker = NoerdUser::factory()->create(['super_admin' => false]);
+    $attacker->tenants()->attach($tenant->id);
+    TenantHelper::setSelectedTenantId($tenant->id);
+    TenantHelper::setSelectedApp('SETUP');
+    $this->actingAs($attacker);
+    $this->attacker = $attacker;
+
+    expect($attacker->isAdmin())->toBeFalse();
+});
+
+it('refuses to set a foreign account password from a crafted mount', function (): void {
+    $victim = NoerdUser::factory()->create([
+        'super_admin' => true,
+        'password' => Hash::make('original-secret'),
+    ]);
+
+    try {
+        Livewire::test('noerd::user-update-password', ['userId' => $victim->id])
+            ->set('password', 'attacker-choice')
+            ->set('password_confirmation', 'attacker-choice')
+            ->call('updatePassword');
+    } catch (Throwable) {
+        // Either shape is fine — the password surviving is the assertion.
+    }
+
+    expect(Hash::check('original-secret', $victim->refresh()->password))->toBeTrue();
+});
+
+it('does not expose the password form through the generic component page', function (): void {
+    $victim = NoerdUser::factory()->create();
+
+    $this->get('/noerd/component-page/noerd::user-update-password?userId=' . $victim->id)
+        ->assertForbidden();
+});
+
+it('never invokes a non-relation method from a relation box tile', function (): void {
+    $victim = Tenant::factory()->create(['name' => 'Foreign Tenant']);
+
+    // 'delete' exists on every model — the tile resolver used to call whatever
+    // method_exists() accepted, so this deleted the record outright.
+    try {
+        Livewire::test('noerd::relation-box', [
+            'modelClass' => Tenant::class,
+            'modelId' => $victim->id,
+            'relations' => [['relation' => 'delete', 'label' => 'x', 'heroicon' => 'x']],
+        ]);
+    } catch (Throwable) {
+        // A render failure is acceptable; the record surviving is what matters.
+    }
+
+    expect(Tenant::find($victim->id))->not->toBeNull();
+});
+
+it('still counts a genuine relation in the relation box', function (): void {
+    $tenant = Tenant::factory()->create();
+    NoerdUser::factory()->create()->tenants()->attach($tenant->id);
+
+    $component = Livewire::test('noerd::relation-box', [
+        'modelClass' => Tenant::class,
+        'modelId' => $tenant->id,
+        'relations' => [['relation' => 'users', 'label' => 'Users', 'heroicon' => 'users']],
+    ]);
+
+    expect($component->get('resolvedRelations')[0]['count'])->toBe(1);
+});
+
+it('refuses to create a tenant from the inner component for a non-admin', function (): void {
+    try {
+        Livewire::test('noerd::create-new-tenant')
+            ->set('name', 'escalation')
+            ->call('createTenant');
+    } catch (Throwable) {
+        // Either shape is fine — no tenant and no admin grant is the assertion.
+    }
+
+    expect(Tenant::where('name', 'escalation')->exists())->toBeFalse()
+        ->and(NoerdUser::find($this->attacker->id)->isAdmin())->toBeFalse();
+});
+
+it('keeps the admin path working for an admin of the edited user', function (): void {
+    $tenant = Tenant::factory()->create();
+    $admin = NoerdUser::factory()->create();
+    $adminProfile = Profile::create(['tenant_id' => $tenant->id, 'key' => 'ADMIN', 'name' => 'Admin']);
+    $admin->tenants()->attach($tenant->id, ['profile_id' => $adminProfile->id]);
+
+    $member = NoerdUser::factory()->create(['password' => Hash::make('old')]);
+    $member->tenants()->attach($tenant->id, ['profile_id' => $adminProfile->id]);
+
+    TenantHelper::setSelectedTenantId($tenant->id);
+    $this->actingAs($admin);
+
+    Livewire::test('noerd::user-update-password', ['userId' => $member->id])
+        ->set('password', 'new-password')
+        ->set('password_confirmation', 'new-password')
+        ->call('updatePassword')
+        ->assertHasNoErrors();
+
+    expect(Hash::check('new-password', $member->refresh()->password))->toBeTrue();
+});

--- a/tests/Feature/ListViewsTest.php
+++ b/tests/Feature/ListViewsTest.php
@@ -280,7 +280,7 @@ it('keeps the base view when the resolver hides every view', function (): void {
 });
 
 it('renders the view switcher only when multiple views exist', function (): void {
-    $user = NoerdUser::factory()->adminUser()->withExampleTenant()->withSelectedApp('setup')->create();
+    $user = NoerdUser::factory()->adminUser()->withSelectedApp('setup')->create();
     $this->actingAs($user);
 
     Livewire::test('noerd::setup-languages-list')

--- a/tests/Feature/PageAutoDetailActionsTest.php
+++ b/tests/Feature/PageAutoDetailActionsTest.php
@@ -34,12 +34,24 @@ it('auto-renders YAML actions without a detail-actions include in the blade', fu
 });
 
 it('auto-renders YAML actions on a real detail component', function (): void {
-    $component = Livewire::test('noerd::noerd-user-detail')->assertOk();
+    // $pageLayout is locked against client updates (it drives validation and
+    // nested component mounts), so the action is contributed the supported
+    // server-side way: through the layout-override hook, which is exactly how a
+    // real installation adds actions to a shipped detail.
+    app()->instance(\Noerd\Helpers\StaticConfigHelper::LAYOUT_OVERRIDES_BINDING, new class {
+        public function apply(string $viewType, string $component, array $config, ?string $modelClass = null): array
+        {
+            if ($component === 'noerd-user-detail') {
+                $config['actions'] = [syntheticProbeAction()];
+            }
 
-    $component
-        ->set('pageLayout', array_merge($component->get('pageLayout'), [
-            'actions' => [syntheticProbeAction()],
-        ]))
+            return $config;
+        }
+    });
+    \Noerd\Helpers\StaticConfigHelper::flushRuntimeCaches();
+
+    Livewire::test('noerd::noerd-user-detail')
+        ->assertOk()
         ->assertSee('Synthetic Probe Action')
         ->assertSeeHtml('wire:click="doProbe"');
 });

--- a/tests/Feature/RelationFormSyncTest.php
+++ b/tests/Feature/RelationFormSyncTest.php
@@ -236,12 +236,13 @@ it('does not persist when the active layout omits the form', function (): void {
     $component = Livewire::test('zz-relation-host-detail', ['modelId' => $host->id]);
 
     // Simulate a layout override that removed the form fields; the stale
-    // hydrated values must not be written back.
-    $component
-        ->set('pageLayout', ['fields' => [['name' => 'detailData.name', 'label' => 'Name', 'type' => 'text']]])
-        ->set('detailData.zzAddress.line_1', 'Stale Value')
-        ->call('store')
-        ->assertHasNoErrors();
+    // hydrated values must not be written back. $pageLayout is locked against
+    // client updates, so the override is applied server-side — exactly where a
+    // real layout override resolver applies it.
+    $instance = $component->instance();
+    $instance->pageLayout = ['fields' => [['name' => 'detailData.name', 'label' => 'Name', 'type' => 'text']]];
+    $instance->detailData['zzAddress']['line_1'] = 'Stale Value';
+    $instance->store();
 
     expect($child->refresh()->line_1)->toBe('Original');
 });

--- a/tests/Feature/SecurityCriticalFixesTest.php
+++ b/tests/Feature/SecurityCriticalFixesTest.php
@@ -244,3 +244,36 @@ it('reduces a detail payload to declared layout keys and always drops identity/t
         'custom_attributes' => ['sap' => 'A1'],
     ]);
 });
+
+it('scopes admin rights to the tenant of the current request', function (): void {
+    $administered = Tenant::factory()->create();
+    $memberOnly = Tenant::factory()->create();
+
+    $user = makeTenantUser($administered, admin: true);
+    // Same user is a plain member of a second tenant.
+    $memberProfile = Profile::factory()->create(['tenant_id' => $memberOnly->id, 'key' => 'MEMBER']);
+    $user->tenants()->attach($memberOnly->id, ['profile_id' => $memberProfile->id]);
+    $this->actingAs($user);
+
+    TenantHelper::setSelectedTenantId($administered->id);
+    expect($user->fresh()->isAdmin())->toBeTrue();
+
+    // Switching to the tenant they only belong to must NOT carry admin rights —
+    // that is what made the setup area of any co-tenant reachable.
+    TenantHelper::setSelectedTenantId($memberOnly->id);
+    expect($user->fresh()->isAdmin())->toBeFalse()
+        ->and(ComponentAccessGuard::allows('noerd::tenants-list'))->toBeFalse();
+
+    // The cross-tenant variant stays available for console/reporting contexts.
+    expect($user->fresh()->isAdminOfAnyTenant())->toBeTrue();
+});
+
+it('keeps a super admin unrestricted across tenants', function (): void {
+    $tenant = Tenant::factory()->create();
+    $user = makeTenantUser($tenant, admin: false, super: true);
+    $this->actingAs($user);
+
+    TenantHelper::setSelectedTenantId(Tenant::factory()->create()->id);
+
+    expect($user->fresh()->isAdmin())->toBeTrue();
+});

--- a/tests/Feature/SecurityCriticalFixesTest.php
+++ b/tests/Feature/SecurityCriticalFixesTest.php
@@ -49,6 +49,39 @@ it('denies a non-admin from mounting an admin component through the guard', func
     expect(ComponentAccessGuard::allows('noerd::tenant-detail'))->toBeFalse();
 });
 
+it('guards an admin component reached through its un-namespaced alias', function (): void {
+    // noerd registers its components with a namespace AND a bare location
+    // (Livewire::addLocation), so 'tenants-list' mounts the very same admin
+    // screen as 'noerd::tenants-list'. Matching the full name alone let the
+    // bare alias — dispatchable straight through the noerdModal event — walk
+    // past this guard entirely.
+    $tenant = Tenant::factory()->create();
+    $this->actingAs(makeTenantUser($tenant, admin: false));
+    TenantHelper::setSelectedTenantId($tenant->id);
+
+    foreach (['tenants-list', 'setup-languages-list', 'setup-collection-detail', 'NOERD::Tenants-List'] as $alias) {
+        expect(ComponentAccessGuard::allows($alias))->toBeFalse("alias {$alias} must stay admin-only");
+    }
+});
+
+it('rejects the bare alias at the component boot hook too', function (): void {
+    $tenant = Tenant::factory()->create();
+    $this->actingAs(makeTenantUser($tenant, admin: false));
+    TenantHelper::setSelectedTenantId($tenant->id);
+
+    // Both names resolve to the SAME compiled component; only the mount name
+    // differs, and getName() reports whichever was used.
+    $hook = new ComponentAccessHook();
+    $hook->setComponent(new class {
+        public function getName(): string
+        {
+            return 'tenants-list';
+        }
+    });
+
+    expect(fn(): mixed => $hook->boot())->toThrow(HttpException::class);
+});
+
 it('permits an admin to mount an admin component, and anyone a non-admin component', function (): void {
     $tenant = Tenant::factory()->create();
     $this->actingAs(makeTenantUser($tenant, admin: true));

--- a/tests/Feature/SettingsPageWriteGuardTest.php
+++ b/tests/Feature/SettingsPageWriteGuardTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Livewire\Component;
+use Livewire\Features\SupportLockedProperties\CannotUpdateLockedPropertyException;
+use Livewire\Livewire;
+use Noerd\Helpers\TenantHelper;
+use Noerd\Models\NoerdSettings;
+use Noerd\Models\NoerdUser;
+use Noerd\Models\Profile;
+use Noerd\Models\Tenant;
+use Noerd\Tests\TestCase;
+use Noerd\Traits\NoerdSettingsPage;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+/*
+ | Write guards of a settings page. $settingsModels decides WHICH model
+ | persistSettings() writes and WHICH property supplies the payload — a client
+ | able to repoint it could write an arbitrary tenant-scoped model with
+ | unfiltered keys (e.g. flipping the own tenant profile to key=ADMIN, a full
+ | privilege escalation). Two independent defenses are asserted here, so
+ | neither can regress unnoticed:
+ |   1. the property is locked against client updates, and
+ |   2. persistSettings() fails CLOSED for a property the YAML does not bind.
+ */
+
+beforeEach(function (): void {
+    $user = NoerdUser::factory()->create();
+    $tenant = Tenant::factory()->create();
+    $user->tenants()->attach($tenant->id);
+    TenantHelper::setSelectedTenantId($tenant->id);
+    TenantHelper::setSelectedApp('ZZGUARDAPP');
+    $this->actingAs($user);
+    $this->tenantId = $tenant->id;
+
+    File::ensureDirectoryExists(base_path('app-configs/zzguardapp/settings'));
+    File::put(base_path('app-configs/zzguardapp/settings/zz-guard-settings-page.yml'), implode("\n", [
+        'title: Guard Fixture',
+        'fields:',
+        '  - name: detailData.currency',
+        '    label: Currency',
+        '    type: text',
+    ]));
+
+    Livewire::component('zz-guard-settings-page', new class extends Component {
+        use NoerdSettingsPage;
+
+        public array $settingsModels = ['detailData' => NoerdSettings::class];
+
+        public function render(): string
+        {
+            return '<div>zz-guard</div>';
+        }
+    });
+});
+
+it('rejects a client update to the settings model map', function (): void {
+    expect(fn() => Livewire::test('zz-guard-settings-page')->set('settingsModels', ['detailData' => Profile::class]))
+        ->toThrow(CannotUpdateLockedPropertyException::class);
+});
+
+it('writes nothing for a bound property the settings YAML does not declare', function (): void {
+    // Second line of defense, asserted independently of the lock: even with a
+    // model map naming an undeclared property, no unfiltered write may happen.
+    $profile = Profile::create(['tenant_id' => $this->tenantId, 'key' => 'USER', 'name' => 'Member']);
+
+    $component = Livewire::test('zz-guard-settings-page');
+    // Server-side repoint (simulates any path that sets the map after mount).
+    $component->instance()->settingsModels = ['relationTitles' => Profile::class];
+
+    $component->set('relationTitles', ['key' => 'ADMIN', 'name' => 'pwned'])
+        ->call('store');
+
+    expect($profile->refresh()->key)->toBe('USER')
+        ->and($profile->name)->toBe('Member')
+        ->and(Profile::where('tenant_id', $this->tenantId)->count())->toBe(1);
+});
+
+it('still persists the declared keys of a declared property', function (): void {
+    Livewire::test('zz-guard-settings-page')
+        ->set('detailData.currency', 'CHF')
+        ->call('store')
+        ->assertHasNoErrors();
+
+    expect(NoerdSettings::where('tenant_id', $this->tenantId)->first()->currency)->toBe('CHF');
+});
+
+it('never writes an undeclared column of the declared model', function (): void {
+    Livewire::test('zz-guard-settings-page')
+        ->set('detailData.currency', 'EUR')
+        ->set('detailData.detail_theme', 'numbered')
+        ->call('store');
+
+    $settings = NoerdSettings::where('tenant_id', $this->tenantId)->first();
+
+    expect($settings->currency)->toBe('EUR')
+        ->and($settings->detail_theme)->not->toBe('numbered');
+});

--- a/tests/Traits/NoerdListMultiSelectTest.php
+++ b/tests/Traits/NoerdListMultiSelectTest.php
@@ -147,3 +147,52 @@ it('refuses deleteSelected when the list config declares no such bulk action', f
 
     expect(NoerdUser::query()->count())->toBe(2);
 });
+
+/** List narrowed in its OWN listData() — the shipped pattern of tenants-list. */
+class ZzNarrowedBulkListComponent extends Component
+{
+    use NoerdList;
+
+    public const COMPONENT = 'zz-narrowed-bulk-list';
+
+    public $listModel = NoerdUser::class;
+
+    public array $allowedIds = [];
+
+    public function listData(): array
+    {
+        return $this->buildList(
+            $this->listQuery(NoerdUser::class)
+                ->whereIn('id', $this->allowedIds)
+                ->paginate($this->perPage),
+        );
+    }
+
+    public function render(): string
+    {
+        return '<div></div>';
+    }
+
+    protected function getListConfig(?string $customName = null): array
+    {
+        return [
+            'title' => 'Narrowed Users',
+            'multiSelect' => true,
+            'columns' => [['field' => 'name', 'label' => 'Name']],
+            'bulkActions' => [['label' => 'Delete', 'action' => 'deleteSelected']],
+        ];
+    }
+}
+
+it('never bulk-deletes a record the list itself does not yield', function (): void {
+    $mine = NoerdUser::factory()->create();
+    $foreign = NoerdUser::factory()->create();
+
+    Livewire::test(ZzNarrowedBulkListComponent::class, ['allowedIds' => [$mine->id]])
+        // A crafted selection containing an id the narrowed list never shows.
+        ->set('selectedRecordIds', [$mine->id, $foreign->id])
+        ->call('deleteSelected');
+
+    expect(NoerdUser::find($mine->id))->toBeNull()
+        ->and(NoerdUser::find($foreign->id))->not->toBeNull();
+});


### PR DESCRIPTION
Security review of the **Livewire** attack surface, against the tip of the pre-release chain. Every finding was reproduced as a working exploit before the fix and is covered by a regression test. Threat model: an authenticated, low-privileged user of one tenant crafting Livewire requests.

Stacked on `feature/test-coverage-and-ci`, so every open PR (#43–#52) is an ancestor — no overlapping edits, no merge conflicts introduced.

## Root cause

Two seams mount a component whose NAME and MOUNT ARGUMENTS come from the client: the client-dispatchable `noerdModal` event and `GET /noerd/component-page/{component}`. Crucially, **`#[Locked]` does not protect mount arguments** — Livewire assigns them to matching public properties before any update hook runs. `ComponentAccessGuard` is an allow-list of 13 admin components, so every other component was mountable with attacker-chosen state.

## Critical (verified exploits)

- **Account takeover of any user, incl. super admins.** `noerd::user-update-password` had no authorization at all — its `#[Locked] $userId` only blocks updates. A non-admin mounted it with a foreign `userId` (the generic component page returned **200**) and overwrote that account's password. Now `canSetPassword()` gates both render and action (admin + target in one of the caller's admin tenants), and the component is on the admin allow-list.
- **Arbitrary record deletion via `noerd::relation-box`.** Tiles were counted with `method_exists($model, $name) => $model->{$name}()->count()` over unlocked mount arguments, so `relation: 'delete'` deleted any record. A tile method must now be a genuine relation, decided by its **declared return type** (never by calling it); identity properties are `#[Locked]`.
- **Privilege escalation to tenant admin via `noerd::create-new-tenant`.** The admin/feature checks lived only on the `create-tenant` wrapper; the inner component created a tenant and attached the caller to its ADMIN profile. Now guarded on mount and action, and on the allow-list.
- **SQL injection in the collection entry search.** `setup-collections-list` interpolated layout field names into `orWhereRaw("JSON_EXTRACT(data, \"$.{$fieldKey}.de\") …")` from an unlocked property. The key must now match `^[A-Za-z0-9_]+$`, the property is `#[Locked]`, and a search where no field survives yields **no** rows instead of matching everything through an empty `where` group.
- **Arbitrary tenant-scoped model write via settings pages.** `$settingsModels` (unlocked) decided which model `persistSettings()` writes AND which property supplies the payload, and the key whitelist was looked up by that same client-chosen name — falling through to an **unfiltered** write when unknown. A member flipped their own tenant profile to `key = 'ADMIN'`. The property is now locked and `persistSettings()` fails **closed**.

## High

- **Admin rights are now scoped to the current tenant.** `isAdmin()` counted ADMIN profiles across *all* tenants, so an admin of tenant B who was a plain member of tenant A got tenant A's whole setup area — and it is the check behind `SetupMiddleware` and `ComponentAccessGuard`. It now resolves against the tenant of the request (super admins unaffected, fails closed without a tenant). Console/reporting contexts that legitimately have no tenant scope use the new, explicitly named `isAdminOfAnyTenant()`.
- **Admin-guard bypass through the un-namespaced alias.** `Livewire::addLocation()` makes `tenants-list` resolve to the same component as `noerd::tenants-list`, but the guard compared full names — so the bare alias walked past it (7 of the 13 admin components have no self-guard). Matching is now namespace-normalized.
- **Cross-tenant writes in `noerd::noerd-user-detail`.** `store()` now re-authorizes the target (never a super admin; in one of the caller's admin tenants, or unassigned), `password` is no longer writable for an existing user, and `detach()` moved inside the allow-list — it previously stripped a user from **any** tenant, and emptying their memberships deletes the account. Profile ids are validated against their tenant.
- **Cross-tenant writes in `noerd::tenant-detail`.** The ownership check ran only in `mount()` while `$modelId` stays URL-bound and rewritable; `store()` and `storeFile()` now re-authorize, so an admin of one tenant can no longer rename or re-logo another.
- **Mount-argument injection on the generic component page.** `request()->query()` was forwarded wholesale, so `?listModel=…` aimed the generic list query at an unscoped model and `?objectPermissionModel=…` neutralised the object gates. Only addressing parameters are forwarded now, and the target is `#[Locked]`.
- **Unrestricted logo upload.** `tenant-detail::storeFile()` called `storePublicly()` with no validation, keeping the client extension on a web-served disk (`.html`/`.svg` ⇒ stored XSS on the app origin). Now `image|mimes:jpg,jpeg,png,webp,gif|max:4096`.
- **Bulk delete escaped the list's own narrowing.** `deleteSelected()` deleted through a bare `Model::query()->whereIn($selectedRecordIds)`, ignoring tenant scope, filters and any constraint a component adds in its own `listData()` (the shipped pattern of `tenants-list`/`noerd-users-list`). It now deletes only rows the list itself yields.

## Medium (included)

- `$pageLayout` is `#[Locked]`: it drives `validateFromLayout()` (a client-emptied layout skipped **all** validation), the relation-form persist decision and the embedded list/widget component mounts.
- The polymorphic relation field re-checks `selectedRelationType` against its declared `allowedTypes`.

## Note for reviewers

`ObjectsTest::it lists only objects of the tenant's assigned apps` in **noerd-plus** fails at the tip of this chain and passes on `main` — a pre-existing regression from an earlier PR in the chain (a per-request memo of tenant app assignments is not invalidated by a pivot `detach()`), unrelated to this PR's changes and not addressed here.

Full package suite: 997 passed, 1 skipped; `pint --test` green.