### PR TITLE
Document the module-developer journey

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -62,9 +62,14 @@ $router->middlewareGroup('noerd', ['web', NoerdAuthenticate::class . ':noerd', '
 $router->middlewareGroup('noerd-guest', ['web', NoerdRedirectIfAuthenticated::class . ':noerd']);
 ```
 
-Every noerd-based module protects its routes with `['noerd']` (plus module-specific aliases such
-as `app-access:crm`) instead of `['web', 'auth', 'verified']`. The `noerd:module` scaffolder
-generates routes with the `noerd` group.
+Every noerd-based module protects its routes with `['noerd', 'app-access:{module}']` instead of
+`['web', 'auth', 'verified']`. `app-access` is a **core** middleware alias (registered by
+`NoerdServiceProvider`, backed by `Noerd\Middleware\AppAccessMiddleware`) that takes the app key as
+its parameter: `app-access:crm` only lets requests through when the selected tenant has the CRM app
+assigned and the per-app authorization gate allows it. Without it, any authenticated user of any
+tenant app can open the module's screens. The `noerd:module` scaffolder currently generates routes
+with the `noerd` group only — add the `app-access:{module}` alias when hardening the generated
+routes (see [Creating Modules](creating-modules.md)).
 
 `Noerd\Middleware\NoerdAuthenticate` extends Laravel's `Authenticate` and pins the guest redirect
 to `route('noerd.login')`; `Noerd\Middleware\NoerdRedirectIfAuthenticated` extends

--- a/docs/creating-modules.md
+++ b/docs/creating-modules.md
@@ -25,14 +25,77 @@ After the command completes:
 # 1. Register the module
 composer update noerd/{module-name}
 
-# 2. Run migrations
-php artisan migrate
-
-# 3. Create TenantApp
-php artisan noerd:create-app
-# Name: {ModuleName}
-# Route: {module-name}.index
+# 2. Install the app: copies the YAML configs into app-configs/{module}/,
+#    registers the tenant app and runs the module's migrations
+php artisan noerd:install-{module-name}
 ```
+
+Never register the app manually via `noerd:create-app` — the generated install command does all of
+it and stays re-runnable. Before the `composer update`, check that the generated module's
+`composer.json` constraint for `noerd/noerd` covers the core version you actually have installed
+(`composer show noerd/noerd`) and widen it if needed — otherwise Composer refuses the resolution or
+silently keeps an older core.
+
+## Hardening the scaffold
+
+The generated module works out of the box, but every shipped noerd module applies four conventions
+on top. Do this before your first migrate:
+
+### Routes
+
+Replace the generated route group with the standard form — the `app-access:{module}` core
+middleware (tenant must have the app assigned, see [Authentication](auth.md)), namespaced component
+references, and the route **naming convention** that route modals, `newRoute:` navigation entries
+and relation fields depend on: `{module}.{entities}` for lists, `{module}.{entity}.detail` for a
+single record.
+
+```php
+Route::group(['middleware' => ['noerd', 'app-access:inventory']], function (): void {
+    Route::livewire('inventory', 'inventory::items-list')->name('inventory');
+    Route::livewire('inventory/items', 'inventory::items-list')->name('inventory.items');
+    Route::livewire('inventory/item/{modelId}', 'inventory::item-detail')->name('inventory.item.detail');
+});
+```
+
+On the generated list component, declare the record route as the preferred target and keep the
+component as the fallback:
+
+```php
+public ?string $detailRoute = 'inventory.item.detail';
+public $detailComponent = 'inventory::item-detail';
+```
+
+### Table names
+
+Module tables are prefixed with the module key (`crm_contracts`, `hr_employees`) so two modules can
+never collide — rename the generated table in the migration and set the explicit `$table` on the
+model. Every table carries `tenant_id` and a nullable `custom_attributes` JSON column (see
+[Custom Attributes](#custom-attributes)).
+
+### Tenant-app name and route
+
+The tenant app's `name` is the **UPPERCASE** module key (`CRM`, `HR`) — gates and test traits
+compare it exactly. In the generated install command, return the uppercase name from
+`getModuleName()` / `getDefaultAppTitle()`, and return the module key (`'inventory'`, not
+`'inventory.index'`) from `getAppRoute()` so the app tile opens the dashboard route.
+
+### Test autoloading
+
+Add the tests namespace to the module's `composer.json` so the module's own test traits autoload:
+
+```json
+"autoload": {
+    "psr-4": {
+        "Noerd\\Inventory\\": "src/",
+        "Noerd\\Inventory\\Tests\\": "tests/",
+        "Noerd\\Inventory\\Database\\Factories\\": "database/factories/",
+        "Noerd\\Inventory\\Database\\Seeders\\": "database/seeders/"
+    }
+}
+```
+
+Run `composer update noerd/{module-name}` again after editing the module's `composer.json` — a
+plain `dump-autoload` does not refresh the package metadata Composer cached at install time.
 
 ## Install and update commands (required)
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -38,6 +38,55 @@ Tests, test traits (`tests/Traits/`), factories and seeders belong to the module
 (`app-modules/{module}/tests/`, `app-modules/{module}/database/`) — never to the host project.
 Run them the same way: `php artisan test --compact app-modules/{module}/tests/...`.
 
+## Module test setup
+
+Module tests run under the **host project's** test case, and every test file binds its own setup —
+there is no per-module `Pest.php`:
+
+```php
+uses(Tests\TestCase::class, RefreshDatabase::class, CreatesInventoryUser::class);
+
+beforeEach(function (): void {
+    $this->user = $this->withInventoryModule();
+    $tenant = $this->user->tenants()->firstOrFail();
+    $this->user->update(['selected_tenant_id' => $tenant->id]);
+    $this->actingAs($this->user);
+    $this->tenantId = $tenant->id;
+});
+```
+
+`Creates{Module}User` is the module's own trait in `tests/Traits/` (autoloaded via the module's
+`Noerd\{Module}\Tests\` PSR-4 entry). It builds a user whose tenant has the app — note the
+**uppercase** tenant-app name, which gates compare exactly:
+
+```php
+trait CreatesInventoryUser
+{
+    protected function withInventoryModule(): NoerdUser
+    {
+        $user = NoerdUser::factory()->create();
+        $tenant = Tenant::factory()->create();
+        $user->tenants()->attach($tenant->id);
+
+        TenantHelper::setSelectedTenantId($tenant->id);
+        TenantHelper::setSelectedApp('INVENTORY');
+
+        $app = TenantApp::firstOrCreate(
+            ['name' => 'INVENTORY'],
+            [
+                'title' => 'Inventory',
+                'icon' => 'inventory::icons.app',
+                'route' => 'inventory',
+                'is_active' => true,
+            ],
+        );
+        $tenant->tenantApps()->syncWithoutDetaching([$app->id]);
+
+        return $user;
+    }
+}
+```
+
 ## Tests prove mechanics, not configuration
 
 The YAML files under `app-configs/` are per-installation configuration: the theme, titles, labels,


### PR DESCRIPTION
Closes documentation gaps found while dogfooding the docs against a real new module build (the HR tutorial module, noerd-dev/hr). Every fix corresponds to information a module developer needed that the docs did not carry:

## creating-modules.md
- **Next Steps** now points to `noerd:install-{module}` instead of the manual `php artisan migrate` + `noerd:create-app` flow, which contradicted the "Install and update commands (required)" section on the same page (and the scaffolder's own console output).
- New **"Hardening the scaffold"** section documenting the four conventions every shipped module applies on top of the scaffold, none of which were written down anywhere:
  - Routes: `app-access:{module}` middleware, namespaced component references, and the route naming convention (`{module}.{entities}` / `{module}.{entity}.detail`) that route modals, `newRoute:` entries and relation fields depend on; `$detailRoute` + `$detailComponent` on the list.
  - Table names: module-key prefix (`hr_employees`) + explicit `$table`.
  - Tenant-app name: UPPERCASE module key (gates and test traits compare exactly) and `getAppRoute()` returning the module key.
  - Test autoloading: the `Noerd\{Module}\Tests\` PSR-4 entry, plus the pitfall that a plain `dump-autoload` does not refresh path-repo package metadata.
- Note to verify the generated `noerd/noerd` constraint against the installed core before `composer update`.

## auth.md
- Corrected the `app-access` description: it is a **core** middleware alias (registered by `NoerdServiceProvider`, backed by `AppAccessMiddleware`, parameterized with the app key), not a module-specific alias — and stated what happens without it.

## testing.md
- New **"Module test setup"** section with the standard test-file binding (`uses(Tests\TestCase::class, RefreshDatabase::class, Creates{Module}User::class)`) and the `Creates{Module}User` trait skeleton every module suite starts from — previously only discoverable by reading another module's tests.

Docs only, no code changes. Follow-up candidates (separate PR): align the `noerd:module` stubs with these conventions (routes.stub, composer.stub version pin + tests PSR-4, install-command.stub uppercase name, list.stub `$detailRoute`) and a non-interactive `--model=` option for the scaffolder.