### PR TITLE
Second security pass: close the guard-normalization bypass and the cross-tenant user administration paths

### DIFF
--- a/resources/views/components/noerd-user-detail.blade.php
+++ b/resources/views/components/noerd-user-detail.blade.php
@@ -65,9 +65,11 @@ new class extends Component {
         // here too, independent of the dynamic-mount guard.
         abort_unless(NoerdAuth::user()?->isAdmin(), 403);
 
+        $this->authorizeTargetUser();
+
         $this->initDetail();
 
-        $this->selectedTenant = auth()->user()->selectedTenant();
+        $this->selectedTenant = NoerdAuth::user()->selectedTenant();
         $this->userLocale = SetupLanguage::getDefaultCode();
 
         $user = new NoerdUser();
@@ -151,13 +153,14 @@ new class extends Component {
         if (! $this->modelId) {
             $userExists = NoerdUser::where('email', $this->detailData['email'])->first();
             if ($userExists) {
-                $allowedTenants = Auth::user()->adminTenants()->pluck('id');
-                foreach ($this->possibleTenants as $tenantId => $value) {
-                    $profileId = $value['selectedProfile'];
-                    if ($value['hasAccess'] && in_array($tenantId, $allowedTenants->toArray())) {
-                        $userExists->tenants()->attach($tenantId, ['profile_id' => $profileId]);
-                    }
-                }
+                // Granting access to an EXISTING account by email must obey the
+                // same limits as editing it: a super admin is never capturable
+                // this way, and a profile must belong to the tenant it is
+                // granted for (this branch returns early, so store()'s own
+                // checks below never run).
+                abort_if($userExists->isSuperAdmin(), 403);
+
+                $this->attachTenantAccess($userExists);
 
                 $this->finishStore($userExists);
 
@@ -180,25 +183,7 @@ new class extends Component {
         $userData = collect($this->detailData)->only($writable)->toArray();
         $user = NoerdUser::updateOrCreate(['id' => $this->modelId], $userData);
 
-        $allowedTenants = NoerdAuth::user()->adminTenants()->pluck('tenants.id')->all();
-        foreach ($this->possibleTenants as $tenantId => $value) {
-            // Both detach AND attach stay inside the allow-list: detaching
-            // unconditionally let an admin of one tenant strip a user from any
-            // other tenant (and, once the last one was gone, delete the account).
-            if (! in_array((int) $tenantId, array_map('intval', $allowedTenants), true)) {
-                continue;
-            }
-
-            $user->tenants()->detach($tenantId);
-
-            $profileId = $value['selectedProfile'] ?? null;
-            $profileBelongsToTenant = $profileId
-                && Profile::whereKey($profileId)->where('tenant_id', $tenantId)->exists();
-
-            if (($value['hasAccess'] ?? false) && $profileBelongsToTenant) {
-                $user->tenants()->attach($tenantId, ['profile_id' => $profileId]);
-            }
-        }
+        $this->attachTenantAccess($user, detachFirst: true);
 
         $this->finishStore($user);
 
@@ -214,11 +199,48 @@ new class extends Component {
         }
     }
 
+    /**
+     * Apply the requested tenant access, restricted to the tenants this admin
+     * actually administers and to profiles that belong to the tenant they are
+     * granted for. Shared by both store() branches so neither can drift.
+     */
+    private function attachTenantAccess(NoerdUser $user, bool $detachFirst = false): void
+    {
+        $allowedTenants = array_map('intval', NoerdAuth::user()->adminTenants()->pluck('tenants.id')->all());
+
+        foreach ($this->possibleTenants as $tenantId => $value) {
+            // Both detach AND attach stay inside the allow-list: detaching
+            // unconditionally let an admin of one tenant strip a user from any
+            // other tenant (and, once the last one was gone, delete the account).
+            if (! in_array((int) $tenantId, $allowedTenants, true)) {
+                continue;
+            }
+
+            if ($detachFirst) {
+                $user->tenants()->detach($tenantId);
+            }
+
+            $profileId = $value['selectedProfile'] ?? null;
+            $profileBelongsToTenant = $profileId
+                && Profile::whereKey($profileId)->where('tenant_id', $tenantId)->exists();
+
+            if (($value['hasAccess'] ?? false) && $profileBelongsToTenant) {
+                $user->tenants()->detach($tenantId);
+                $user->tenants()->attach($tenantId, ['profile_id' => $profileId]);
+            }
+        }
+    }
+
     public function delete(): void
     {
-        $user = NoerdUser::find($this->modelId);
+        // Same target check as store(): $modelId is URL-bound and rewritable, so
+        // a mount-time admin check alone let any admin delete an account of
+        // another tenant — or any account with no tenants left at all.
+        $this->authorizeTargetUser();
 
-        $user->tenants()->detach(auth()->user()->selected_tenant_id);
+        $user = NoerdUser::findOrFail($this->modelId);
+
+        $user->tenants()->detach(NoerdAuth::user()->selected_tenant_id);
         $this->closeModalProcess($this->getListComponent());
 
         // If user has no more tenants, delete the user

--- a/resources/views/components/noerd-users-list.blade.php
+++ b/resources/views/components/noerd-users-list.blade.php
@@ -37,6 +37,11 @@ new class () extends Component {
         if (in_array($userId, $allowedUserIds) === false) {
             abort(401);
         }
+
+        // A super admin is never impersonatable from a tenant-admin screen:
+        // attaching such an account to one's own tenant would otherwise be a
+        // direct path to a full takeover.
+        abort_if(NoerdUser::whereKey($userId)->value('super_admin'), 403);
         session(['impersonating_from' => NoerdAuth::id()]);
 
         // Clear tenant session so InitializeTenantSession will set the correct tenant
@@ -53,11 +58,17 @@ new class () extends Component {
 
         $rows = $this->listQuery($this->listModel)
             ->whereHas('tenants', function ($relationQuery) use ($tenants): void {
-                if (! empty($this->listFilters['tenant_id'])) {
-                    $relationQuery->where('tenant_id', $this->listFilters['tenant_id']);
-                } else {
-                    $relationQuery->whereIn('tenant_id', $tenants->pluck('id'));
-                }
+                $adminTenantIds = $tenants->pluck('id')->map(fn($id): int => (int) $id)->all();
+
+                // The header filter is client input (it round-trips through the
+                // session), so it may only ever NARROW the admin's own tenants —
+                // taking it at face value listed the users of any tenant.
+                $requested = (int) ($this->listFilters['tenant_id'] ?? 0);
+                $scope = $requested > 0
+                    ? array_values(array_intersect($adminTenantIds, [$requested]))
+                    : $adminTenantIds;
+
+                $relationQuery->whereIn('tenant_id', $scope ?: [0]);
             })
             ->with(['tenants'])
             ->paginate($this->perPage);

--- a/resources/views/components/tenant-apps-list.blade.php
+++ b/resources/views/components/tenant-apps-list.blade.php
@@ -18,8 +18,20 @@ new class extends Component {
         $this->loadApps();
     }
 
+    /**
+     * Every action re-asserts super-admin access: mount() alone leaves the
+     * guarantee one refactor away from being lost, and the hydrate-time
+     * ComponentAccessHook only re-checks isAdmin(), not isSuperAdmin().
+     */
+    private function authorizeSuperAdmin(): void
+    {
+        abort_unless(\Noerd\Helpers\NoerdAuth::user()?->isSuperAdmin(), 403);
+    }
+
     public function toggleApp(int $appId): void
     {
+        $this->authorizeSuperAdmin();
+
         $tenant = TenantHelper::getSelectedTenant();
         $assignedIds = $tenant->tenantApps()->pluck('tenant_apps.id')->toArray();
 
@@ -35,6 +47,8 @@ new class extends Component {
 
     public function appSort(int $appId, int $newPosition): void
     {
+        $this->authorizeSuperAdmin();
+
         $tenant = TenantHelper::getSelectedTenant();
         $apps = $tenant->tenantApps()->get();
 
@@ -59,6 +73,8 @@ new class extends Component {
 
     public function toggleHidden(int $appId): void
     {
+        $this->authorizeSuperAdmin();
+
         $tenant = TenantHelper::getSelectedTenant();
         $current = $tenant->tenantApps()->where('tenant_apps.id', $appId)->first();
 

--- a/src/Helpers/TenantHelper.php
+++ b/src/Helpers/TenantHelper.php
@@ -140,6 +140,14 @@ class TenantHelper
      */
     public static function setSelectedApp(?string $appName): void
     {
+        // The selected app becomes a PATH SEGMENT in the config resolution
+        // (app-configs/{app}/…, navigation.yml), so it must never carry
+        // traversal or separator characters — a client-callable openApp() wrote
+        // this value straight through.
+        if ($appName !== null && ! preg_match('/^[A-Za-z0-9_-]+$/', $appName)) {
+            return;
+        }
+
         session(['noerd.selected_app' => $appName]);
     }
 

--- a/src/Repositories/DatabaseSetupCollectionDefinitionRepository.php
+++ b/src/Repositories/DatabaseSetupCollectionDefinitionRepository.php
@@ -26,10 +26,10 @@ class DatabaseSetupCollectionDefinitionRepository implements SetupCollectionDefi
 
     public function all(?int $tenantId = null): Collection
     {
-        $tenantId ??= TenantHelper::getSelectedTenantId();
+        $tenantId = $this->scopeTenantId($tenantId);
 
         return SetupCollectionDefinition::query()
-            ->when($tenantId !== null, fn($q) => $q->where('tenant_id', $tenantId))
+            ->where('tenant_id', $tenantId)
             ->orderBy('title_list')
             ->get()
             ->map(fn(SetupCollectionDefinition $m) => $this->toData($m));
@@ -44,10 +44,10 @@ class DatabaseSetupCollectionDefinitionRepository implements SetupCollectionDefi
 
     public function findByKey(string $key, ?int $tenantId = null): ?SetupCollectionDefinitionData
     {
-        $tenantId ??= TenantHelper::getSelectedTenantId();
+        $tenantId = $this->scopeTenantId($tenantId);
 
         $model = SetupCollectionDefinition::query()
-            ->when($tenantId !== null, fn($q) => $q->where('tenant_id', $tenantId))
+            ->where('tenant_id', $tenantId)
             ->where('key', mb_strtoupper($key))
             ->first();
 
@@ -73,7 +73,7 @@ class DatabaseSetupCollectionDefinitionRepository implements SetupCollectionDefi
 
     public function save(SetupCollectionDefinitionData $data, ?string $originalFilename = null, ?int $tenantId = null): string
     {
-        $tenantId ??= TenantHelper::getSelectedTenantId();
+        $tenantId = $this->scopeTenantId($tenantId);
         if ($tenantId === null) {
             throw new RuntimeException('Cannot save a setup collection definition without a tenant context.');
         }
@@ -107,7 +107,7 @@ class DatabaseSetupCollectionDefinitionRepository implements SetupCollectionDefi
 
     public function copy(string $filename, ?int $tenantId = null): string
     {
-        $tenantId ??= TenantHelper::getSelectedTenantId();
+        $tenantId = $this->scopeTenantId($tenantId);
         $source = $this->findModel($filename, $tenantId);
         if (! $source) {
             throw new RuntimeException("Setup collection definition '{$filename}' not found.");
@@ -147,10 +147,21 @@ class DatabaseSetupCollectionDefinitionRepository implements SetupCollectionDefi
         return true;
     }
 
+    /**
+     * The tenant every read is scoped to. SetupCollectionDefinition carries no
+     * BelongsToTenant, so a null tenant used to drop the filter entirely and
+     * expose every tenant's definitions (a public-app guest resolves no
+     * selected tenant at all). Reads now fail closed instead.
+     */
+    private function scopeTenantId(?int $tenantId): ?int
+    {
+        return $tenantId ?? TenantHelper::currentTenantId() ?? TenantHelper::getSelectedTenantId();
+    }
+
     private function resolveFieldsUncached(string $filename, ?int $tenantId): ?array
     {
         $query = SetupCollectionDefinition::query()
-            ->when($tenantId !== null, fn($q) => $q->where('tenant_id', $tenantId));
+            ->where('tenant_id', $tenantId);
 
         $model = (clone $query)->where('filename', $filename)->first();
 
@@ -185,10 +196,10 @@ class DatabaseSetupCollectionDefinitionRepository implements SetupCollectionDefi
 
     private function findModel(string $filename, ?int $tenantId): ?SetupCollectionDefinition
     {
-        $tenantId ??= TenantHelper::getSelectedTenantId();
+        $tenantId = $this->scopeTenantId($tenantId);
 
         return SetupCollectionDefinition::query()
-            ->when($tenantId !== null, fn($q) => $q->where('tenant_id', $tenantId))
+            ->where('tenant_id', $tenantId)
             ->where('filename', $filename)
             ->first();
     }

--- a/src/Repositories/YamlSetupCollectionDefinitionRepository.php
+++ b/src/Repositories/YamlSetupCollectionDefinitionRepository.php
@@ -92,6 +92,14 @@ class YamlSetupCollectionDefinitionRepository implements SetupCollectionDefiniti
 
     private function pathFor(string $filename): string
     {
+        // The filename comes from a client-supplied collection key (?key=…,
+        // mount arguments), so it must be a bare identifier — otherwise it
+        // reads any .yml on the filesystem. Mirrors the guard in
+        // StaticConfigHelper::resolveConfigPath().
+        if (! preg_match('/^[A-Za-z0-9_-]+$/', $filename)) {
+            return $this->basePath . '/__invalid__.yml';
+        }
+
         return $this->basePath . '/' . $filename . '.yml';
     }
 

--- a/src/Support/ComponentAccessGuard.php
+++ b/src/Support/ComponentAccessGuard.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Noerd\Support;
 
+use Illuminate\Support\Str;
 use Noerd\Helpers\NoerdAuth;
 
 /**
@@ -108,15 +109,32 @@ final class ComponentAccessGuard
     }
 
     /**
-     * The comparable identity of a component name: lowercased and stripped of
-     * any Livewire namespace prefix ('noerd::tenants-list' → 'tenants-list').
+     * The comparable identity of a component name — it must collapse EVERY
+     * spelling Livewire resolves to the same component file, or the guard is
+     * bypassable by writing the name differently.
+     *
+     * Livewire's Finder strips the ⚡ marker and rewrites '/' to '.'
+     * (Finder::normalizeName), then builds the view path from the dot segments,
+     * where empty segments simply vanish — so 'x', '.x', '..x' and '/x' all
+     * load the same component. The namespace is dropped as well, because noerd
+     * registers its components both namespaced and bare (Livewire::addLocation).
      */
     private static function normalize(string $componentName): string
     {
-        $name = str_contains($componentName, '::')
-            ? mb_substr($componentName, mb_strpos($componentName, '::') + 2)
-            : $componentName;
+        $name = Str::afterLast($componentName, '::');
 
-        return mb_strtolower(mb_trim($name));
+        // Mirror Finder::normalizeName(): drop the ⚡ marker (with either
+        // variation selector) and treat slashes as dot separators.
+        $name = preg_replace('/\x{26A1}[\x{FE0E}\x{FE0F}]?/u', '', $name) ?? $name;
+        $name = str_replace(['/', '\\'], '.', $name);
+
+        // Empty segments carry no meaning for the resolver — dropping them is
+        // what makes '.tenants-list' and 'tenants-list' compare equal.
+        $segments = array_values(array_filter(
+            array_map(static fn(string $segment): string => mb_trim($segment), explode('.', $name)),
+            static fn(string $segment): bool => $segment !== '',
+        ));
+
+        return mb_strtolower(implode('.', $segments));
     }
 }

--- a/src/Support/LockedPropertiesHook.php
+++ b/src/Support/LockedPropertiesHook.php
@@ -53,16 +53,60 @@ class LockedPropertiesHook extends ComponentHook
         'pageLayout',
     ];
 
+    /**
+     * The subset that must not arrive as MOUNT ARGUMENTS either.
+     *
+     * #[Locked] and this hook's update() only veto the update path — Livewire
+     * assigns mount parameters to matching public properties before any of that
+     * runs (SupportNestingComponents::setParametersToMatchingProperties), and
+     * the modal stack takes those arguments straight from the client. These
+     * three decide WHICH model the generic query reads and WHICH class the
+     * object gates are checked against, and no legitimate caller passes them —
+     * a component declares them itself. Properties like listActionMethod or
+     * context are deliberately NOT here: the relation-field picker passes them.
+     *
+     * @var array<int, string>
+     */
+    private const MOUNT_PROTECTED = [
+        'detailModel',
+        'listModel',
+        'objectPermissionModel',
+    ];
+
+    /**
+     * @param  array<string, mixed>  $params
+     */
+    public function mount($params, $parent = null, $attributes = null): void
+    {
+        if (! $this->guardsComponent()) {
+            return;
+        }
+
+        foreach (self::MOUNT_PROTECTED as $property) {
+            if (array_key_exists($property, $params)) {
+                throw new CannotUpdateLockedPropertyException($property);
+            }
+        }
+    }
+
     public function update($propertyName, $fullPath, $newValue): void
     {
         if (! in_array($propertyName, self::PROTECTED_PROPERTIES, true)) {
             return;
         }
 
-        $traits = class_uses_recursive($this->component);
-
-        if (in_array(NoerdList::class, $traits, true) || in_array(NoerdPage::class, $traits, true)) {
+        if ($this->guardsComponent()) {
             throw new CannotUpdateLockedPropertyException($propertyName);
         }
+    }
+
+    /**
+     * Whether the current component is one this hook protects.
+     */
+    private function guardsComponent(): bool
+    {
+        $traits = class_uses_recursive($this->component);
+
+        return in_array(NoerdList::class, $traits, true) || in_array(NoerdPage::class, $traits, true);
     }
 }

--- a/src/Traits/NoerdList.php
+++ b/src/Traits/NoerdList.php
@@ -1053,7 +1053,15 @@ trait NoerdList
         $this->applyColumnFilters($query, $modelClass);
         $this->eagerLoadRelationColumns($query);
 
-        $sortField = self::tableHasColumn($table, $this->sortField) ? $this->sortField : 'id';
+        // $sortField is client-writable (sortBy() enforces isSortableColumn(),
+        // a raw property update does not). Ordering by a column the model hides
+        // — password, remember_token, api_token — turns the list into an
+        // oracle over that value, so hidden attributes are never sortable.
+        $hidden = $this->resolvedModelInstance()?->getHidden() ?? [];
+        $sortField = self::tableHasColumn($table, $this->sortField)
+            && ! in_array($this->sortField, $hidden, true)
+                ? $this->sortField
+                : 'id';
         $query->orderBy($sortField, $this->sortAsc ? 'asc' : 'desc');
 
         return $query;

--- a/tests/Feature/DynamicMountHardeningTest.php
+++ b/tests/Feature/DynamicMountHardeningTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Component;
+use Livewire\Features\SupportLockedProperties\CannotUpdateLockedPropertyException;
+use Livewire\Livewire;
+use Noerd\Helpers\StaticConfigHelper;
+use Noerd\Helpers\TenantHelper;
+use Noerd\Models\NoerdUser;
+use Noerd\Models\Profile;
+use Noerd\Models\Tenant;
+use Noerd\Support\ComponentAccessGuard;
+use Noerd\Tests\TestCase;
+use Noerd\Traits\NoerdList;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+/*
+ | Second-round hardening of the dynamic mount seams. Each case below was a
+ | working exploit: the component name spelling that slipped past the admin
+ | guard, the model repoint through mount arguments (which #[Locked] cannot
+ | cover), and the app name that became a path segment.
+ */
+
+class ZzMountGuardListComponent extends Component
+{
+    use NoerdList;
+
+    public const COMPONENT = 'zz-mount-guard-list';
+
+    public $listModel = Profile::class;
+
+    // Declared like a real list that opts into an explicit permission model —
+    // Livewire only assigns mount params to properties the class defines.
+    public ?string $objectPermissionModel = Profile::class;
+
+    public function render(): string
+    {
+        return '<div></div>';
+    }
+
+    protected function getListConfig(?string $customName = null): array
+    {
+        return ['title' => 'Guard', 'columns' => [['field' => 'name', 'label' => 'Name']]];
+    }
+}
+
+beforeEach(function (): void {
+    $tenant = Tenant::factory()->create();
+    $user = NoerdUser::factory()->create(['super_admin' => false]);
+    $user->tenants()->attach($tenant->id);
+    TenantHelper::setSelectedTenantId($tenant->id);
+    TenantHelper::setSelectedApp('SETUP');
+    $this->actingAs($user);
+
+    expect($user->isAdmin())->toBeFalse();
+});
+
+it('guards an admin component under every spelling Livewire resolves', function (string $name): void {
+    // Livewire strips the ⚡ marker, rewrites '/' to '.' and drops empty dot
+    // segments when resolving the view — so all of these load the very same
+    // admin component and must all be refused.
+    expect(ComponentAccessGuard::allows($name))->toBeFalse("[{$name}] must stay admin-only");
+})->with([
+    'noerd::setup-languages-list',
+    'noerd::.setup-languages-list',
+    'noerd::..setup-languages-list',
+    'noerd::/setup-languages-list',
+    '.setup-languages-list',
+    './setup-languages-list',
+    'NOERD::.Setup-Languages-List',
+]);
+
+it('does not mount an admin screen through the dot-prefixed alias', function (): void {
+    Livewire::test('noerd::.setup-languages-list')->assertStatus(403);
+});
+
+it('refuses a model repoint through mount arguments', function (): void {
+    // #[Locked] and the update hook only veto updates; Livewire assigns mount
+    // parameters to matching public properties beforehand.
+    // Livewire wraps the refusal in a ViewException — assert on the cause.
+    foreach (['listModel' => NoerdUser::class, 'objectPermissionModel' => Tenant::class] as $property => $value) {
+        try {
+            Livewire::test(ZzMountGuardListComponent::class, [$property => $value]);
+            $thrown = null;
+        } catch (Throwable $e) {
+            $thrown = $e->getPrevious() ?? $e;
+        }
+
+        expect($thrown)->toBeInstanceOf(CannotUpdateLockedPropertyException::class, "[{$property}] must be refused at mount");
+    }
+});
+
+it('still accepts the picker arguments a relation field legitimately passes', function (): void {
+    Livewire::test(ZzMountGuardListComponent::class, [
+        'listActionMethod' => 'selectAction',
+        'context' => 'detailData.owner_id',
+    ])->assertOk();
+});
+
+it('rejects an app name that is not a plain identifier', function (): void {
+    TenantHelper::setSelectedApp('SETUP');
+
+    // The selected app becomes a path segment in the config resolution.
+    TenantHelper::setSelectedApp('../../../../tmp/evil');
+
+    expect(TenantHelper::getSelectedApp())->toBe('SETUP')
+        ->and(StaticConfigHelper::getCurrentApp())->toBe('setup');
+});

--- a/tests/Feature/UserAdministrationScopeTest.php
+++ b/tests/Feature/UserAdministrationScopeTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Noerd\Helpers\NoerdAuth;
+use Noerd\Helpers\TenantHelper;
+use Noerd\Models\NoerdUser;
+use Noerd\Models\Profile;
+use Noerd\Models\Tenant;
+use Noerd\Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+/*
+ | A tenant admin administers THEIR tenants — never the installation. $modelId
+ | is URL-bound and the header filters round-trip through the session, so every
+ | one of these paths is client-steerable and must re-check its target. Each
+ | case was a working exploit.
+ */
+
+function zzTenantAdmin(Tenant $tenant): NoerdUser
+{
+    $user = NoerdUser::factory()->create(['super_admin' => false]);
+    $profile = Profile::create(['tenant_id' => $tenant->id, 'key' => 'ADMIN', 'name' => 'Admin']);
+    $user->tenants()->attach($tenant->id, ['profile_id' => $profile->id]);
+
+    return $user;
+}
+
+beforeEach(function (): void {
+    $this->tenantA = Tenant::factory()->create(['name' => 'A']);
+    $this->admin = zzTenantAdmin($this->tenantA);
+    TenantHelper::setSelectedTenantId($this->tenantA->id);
+    TenantHelper::setSelectedApp('SETUP');
+    $this->actingAs($this->admin);
+});
+
+it('never deletes an account that belongs to no tenant of this admin', function (): void {
+    $orphanSuperAdmin = NoerdUser::factory()->create(['super_admin' => true]);
+
+    try {
+        Livewire::test('noerd::noerd-user-detail', ['modelId' => $orphanSuperAdmin->id])->call('delete');
+    } catch (Throwable) {
+        // A 403 may surface as an exception or a response; survival is the assertion.
+    }
+
+    expect(NoerdUser::find($orphanSuperAdmin->id))->not->toBeNull();
+});
+
+it('never lists the users of a foreign tenant through the header filter', function (): void {
+    $tenantB = Tenant::factory()->create(['name' => 'B']);
+    $foreign = NoerdUser::factory()->create();
+    $foreign->tenants()->attach($tenantB->id);
+
+    // storeActiveListFilters() persists client input into the session, which
+    // rendering() reloads — emulated directly, as one crafted request does.
+    session(['listFilters' => ['tenant_id' => $tenantB->id]]);
+
+    $visible = Livewire::test('noerd::noerd-users-list')->instance()->visibleRowIds();
+
+    expect($visible)->not->toContain($foreign->id);
+});
+
+it('never captures a super admin through the existing-email branch', function (): void {
+    $super = NoerdUser::factory()->create(['super_admin' => true, 'email' => 'super@victim.tld']);
+
+    $component = Livewire::test('noerd::noerd-user-detail');
+    $possible = $component->get('possibleTenants');
+    foreach ($possible as $tenantId => $row) {
+        $possible[$tenantId]['hasAccess'] = true;
+    }
+
+    try {
+        $component->set('detailData.name', 'x')
+            ->set('detailData.email', 'super@victim.tld')
+            ->set('possibleTenants', $possible)
+            ->call('store');
+    } catch (Throwable) {
+    }
+
+    expect($super->fresh()->tenants->contains($this->tenantA->id))->toBeFalse();
+});
+
+it('never impersonates a super admin', function (): void {
+    $super = NoerdUser::factory()->create(['super_admin' => true]);
+    $super->tenants()->attach($this->tenantA->id);
+
+    try {
+        Livewire::test('noerd::noerd-users-list')->call('loginAsUser', $super->id);
+    } catch (Throwable) {
+    }
+
+    expect(NoerdAuth::id())->toBe($this->admin->id);
+});
+
+it('still administers a user of its own tenant', function (): void {
+    $member = NoerdUser::factory()->create();
+    $profile = Profile::where('tenant_id', $this->tenantA->id)->first();
+    $member->tenants()->attach($this->tenantA->id, ['profile_id' => $profile->id]);
+
+    Livewire::test('noerd::noerd-user-detail', ['modelId' => $member->id])
+        ->set('detailData.name', 'Renamed')
+        ->call('store')
+        ->assertHasNoErrors();
+
+    expect($member->fresh()->name)->toBe('Renamed');
+
+    Livewire::test('noerd::noerd-users-list')->call('loginAsUser', $member->id);
+    expect(NoerdAuth::id())->toBe($member->id);
+});


### PR DESCRIPTION
Second, independent security review of the release candidate. Every finding below was **reproduced as a working exploit** before the fix and is covered by a regression test. Stacked on `feature/test-coverage-and-ci` (the branch PR #55 lands in `main`), so it introduces no conflicts.

## Critical

**The admin guard from the first round was bypassable by spelling the component name differently.** `ComponentAccessGuard::normalize()` stripped the namespace, but Livewire's resolver also rewrites `/` to `.` and drops empty dot segments — so `noerd::.setup-languages-list`, `noerd::..setup-languages-list`, `noerd::/setup-languages-list` and the bare `.setup-languages-list` all load the very same admin component while normalizing to a different string.

Verified: as a plain tenant member, `noerd::setup-languages-list` was refused while `noerd::.setup-languages-list` **mounted successfully**. Reachable through the client-dispatchable `noerdModal` event and `GET /noerd/component-page/{component}`; it exposed every admin screen without its own mount guard (languages, collections, collection definitions incl. their delete paths).

Normalization now mirrors `Finder::normalizeName()` — ⚡ marker stripped, `/` and `\` folded to `.`, empty segments dropped, lowercased — and the regression test pins seven spellings.

## High — tenant-admin → super-admin takeover (full chain, reproduced)

1. `noerd-user-detail::store()` returned early on the "existing email" branch, **skipping** the target authorization it applies elsewhere. A tenant admin submitted a super admin's email and attached that account to their own tenant. The branch also never verified that `profile_id` belongs to the tenant it is granted for.
2. `noerd-users-list::loginAsUser()` had **no super-admin exclusion** — any account attached to one of the admin's tenants could be impersonated.

Chained, this was `tenant admin → super admin` knowing only the victim's email address. The exploit test logged in as the victim (`impersonated id: 2`). Now: super admins are neither capturable nor impersonatable, and both store branches share one `attachTenantAccess()` helper so they cannot drift apart again.

## High — cross-tenant user administration

- **`noerd-user-detail::delete()` never re-authorized its target.** `$modelId` is URL-bound and rewritable, so any tenant admin could point it at a foreign account; every account with no remaining tenant assignment was then **hard-deleted**. Reproduced: a tenant admin deleted an orphaned super-admin account. `delete()` now runs the same check as `store()`, and `mount()` no longer loads a foreign record either.
- **`noerd-users-list` trusted a client-supplied `tenant_id` filter.** `listFilters` round-trips through the session, and the query used the submitted value verbatim instead of intersecting it with the admin's own tenants — listing every user (name, email, assignments) of any tenant. Reproduced and fixed; the filter can now only ever narrow.
- **Mount arguments bypassed `LockedPropertiesHook`.** `#[Locked]` and the hook's `update()` only veto the update path; Livewire assigns mount parameters to matching public properties first. `detailModel`, `listModel` and `objectPermissionModel` are now refused as mount arguments — they repoint the generic query and the object-permission check, and no legitimate caller passes them (verified across core and all modules). Deliberately NOT blocked: `listActionMethod`, `context`, `selectListConfig` — the relation-field picker passes those.
- **`openApp()` wrote an unvalidated app name into the session.** The value becomes a path segment in `base_path("app-configs/{$app}")` and in the navigation lookup; `openApp('../../../../tmp/x', …)` was accepted. `TenantHelper::setSelectedApp()` now rejects anything that is not a plain identifier.

## Medium

- **Ordering oracle over hidden columns.** `sortField` is client-writable and was validated only against the physical schema, so `sortField=password` ordered a list by the bcrypt hash — a binary search over `password` / `api_token`, columns that are in `$hidden` and never rendered. Hidden attributes are no longer sortable.
- **Collection-definition reads failed open without a tenant.** `->when($tenantId !== null, …)` dropped the tenant filter entirely when none was resolved (a public-app guest resolves none), exposing every tenant's definitions. Reads now filter unconditionally and yield nothing without a tenant; `save()` keeps throwing.
- **Path traversal in the YAML definition repository.** `pathFor()` interpolated a client-supplied collection key (`?key=…`) straight into the path, so `?key=../../../../etc/foo` read that `.yml`. The filename must now be a bare identifier.
- **`tenant-apps-list`** re-asserts super-admin access on `toggleApp`/`appSort`/`toggleHidden` instead of relying on the mount check alone (hydrate only re-checks `isAdmin`, not `isSuperAdmin`).

## Verified clean (not changed)

A runtime sweep mounted **all 162 components** as a non-admin and checked the response status: every admin screen is refused, and the only components a plain member can mount with write methods are self-scoped user actions (`profile/*`, `dropzone`, sidebar preferences) — the profile forms correctly require the current password / a password confirmation. No remaining SQL injection: every `whereRaw`/`DB::raw` site was traced to a constant or a bound value. `deleteSelected()`, `RelationFormSync`, `setFieldValue`, `resolvePicklistOptions`, `NullMediaResolver`, the login/reset/logout flows and `audit-list` all hold.

## Reported, not fixed here

- **17 components use `Auth::user()` (the host default guard) for authorization**, while `noerd.auth.set_as_default` defaults to `false`. In a host that owns the default guard these decide against the wrong user. The test suite pins `auth.defaults.guard = 'noerd'`, so **no test can currently detect this** — worth a dedicated pass.
- A revoked user keeps their selected tenant for the lifetime of the session (`getSelectedTenantId()` is never re-validated against membership), so access revocation only takes effect on the next login.
- `RelationTitleResolver` resolves badge titles through an unscoped `DB::table()`; a dangling FK renders a foreign record's name.
- `writableDetailDataKeys()` returning `[]` (a `*-page` component or a missing detail YAML) falls back to an unfiltered write. No core component hits it; a module that does would be exposed. Recommend failing closed, as `persistSettings()` already does.

Full package suite: 1013 passed, 1 skipped; `pint --test` green.