### PR TITLE
Follow up the route renaming and apply Pint formatting

### DIFF
--- a/database/migrations/2026_08_28_000000_rename_core_route_names_in_tenant_apps.php
+++ b/database/migrations/2026_08_28_000000_rename_core_route_names_in_tenant_apps.php
@@ -10,8 +10,7 @@ use Illuminate\Support\Facades\Schema;
  * a host application may own. `tenant_apps.route` stores route names, so any
  * row still pointing at an old core name is mapped to its namespaced successor.
  */
-return new class extends Migration
-{
+return new class extends Migration {
     /** @var array<string, string> */
     private array $renames = [
         'setup' => 'noerd.setup',

--- a/resources/views/components/layout/app-bar.blade.php
+++ b/resources/views/components/layout/app-bar.blade.php
@@ -27,7 +27,7 @@ new class extends Component {
             @endphp
             <div class="text-xs text-center overflow-y-auto flex-1 pb-6">
                 {{-- Home --}}
-                <a wire:click="openApp('noerd-apps', 'noerd-apps')" class="cursor-pointer">
+                <a wire:click="openApp('noerd-apps', 'noerd.apps')" class="cursor-pointer">
                     <div @class([
                         '!bg-brand-primary/5 border-brand-primary!' => $selectedApp === 'noerd-apps',
                         'hover:bg-brand-navi-hover flex mt-2 h-[40px] w-[40px] rounded-full mx-auto',

--- a/src/Commands/NoerdUpdateAllCommand.php
+++ b/src/Commands/NoerdUpdateAllCommand.php
@@ -10,13 +10,6 @@ class NoerdUpdateAllCommand extends Command
 {
     use RequiresNoerdInstallation;
 
-    protected $signature = 'noerd:update-all
-        {--force : Overwrite existing files without asking}
-        {--build : Run npm build after the core noerd:update}
-        {--except=* : Skip a command; module key or full name (--except=cms, --except=noerd:update)}';
-
-    protected $description = 'Run noerd:update and every installed module\'s noerd:update-{module} command';
-
     private const CORE = 'noerd:update';
 
     /**
@@ -24,6 +17,13 @@ class NoerdUpdateAllCommand extends Command
      * that a preceding `noerd:update --force` overwrites with the core template.
      */
     private const RUN_LAST = ['noerd:update-plus'];
+
+    protected $signature = 'noerd:update-all
+        {--force : Overwrite existing files without asking}
+        {--build : Run npm build after the core noerd:update}
+        {--except=* : Skip a command; module key or full name (--except=cms, --except=noerd:update)}';
+
+    protected $description = 'Run noerd:update and every installed module\'s noerd:update-{module} command';
 
     /**
      * Only the modules whose service provider is loaded register an update command,
@@ -118,7 +118,7 @@ class NoerdUpdateAllCommand extends Command
     private function partition(array $names): array
     {
         $except = array_map(
-            static fn (string $value): string => str_contains($value, ':') ? $value : 'noerd:update-' . $value,
+            static fn(string $value): string => str_contains($value, ':') ? $value : 'noerd:update-' . $value,
             (array) $this->option('except'),
         );
 
@@ -193,7 +193,7 @@ class NoerdUpdateAllCommand extends Command
             $rows[] = [$name, '<comment>skipped</comment>', '--except'];
         }
 
-        $failed = array_filter($results, static fn (array $result): bool => $result['status'] === 'failed');
+        $failed = array_filter($results, static fn(array $result): bool => $result['status'] === 'failed');
 
         $this->newLine();
         $this->info('Update summary:');

--- a/src/Helpers/SetupCollectionHelper.php
+++ b/src/Helpers/SetupCollectionHelper.php
@@ -39,6 +39,40 @@ class SetupCollectionHelper
     }
 
     /**
+     * Build select options from a setup collection's entries for the current
+     * tenant: value = `data[valueField]` (or the entry id when no valueField is
+     * given), label = `data[displayField]` resolved to the active language.
+     * Shared by the `setupCollectionSelect` form element and the list picklist
+     * badges, so both always agree on values and labels.
+     *
+     * @return array<int, array{value: mixed, label: string}>
+     */
+    public static function selectOptions(string $collectionKey, string $displayField = 'name', ?string $valueField = null): array
+    {
+        $collection = SetupCollection::where('collection_key', $collectionKey)->first();
+        if (! $collection) {
+            return [];
+        }
+
+        $locale = session('selectedLanguage') ?? 'de';
+        $options = [];
+
+        foreach ($collection->entries as $entry) {
+            $label = $entry->data[$displayField] ?? '';
+            if (is_array($label)) {
+                $label = $label[$locale] ?? $label['de'] ?? reset($label) ?: '';
+            }
+
+            $options[] = [
+                'value' => $valueField ? ($entry->data[$valueField] ?? '') : $entry->id,
+                'label' => (string) $label,
+            ];
+        }
+
+        return $options;
+    }
+
+    /**
      * Instance method: resolve collection fields via the repository.
      */
     public function resolveCollectionFields(?string $collection): ?array
@@ -92,40 +126,6 @@ class SetupCollectionHelper
         }
 
         return $table;
-    }
-
-    /**
-     * Build select options from a setup collection's entries for the current
-     * tenant: value = `data[valueField]` (or the entry id when no valueField is
-     * given), label = `data[displayField]` resolved to the active language.
-     * Shared by the `setupCollectionSelect` form element and the list picklist
-     * badges, so both always agree on values and labels.
-     *
-     * @return array<int, array{value: mixed, label: string}>
-     */
-    public static function selectOptions(string $collectionKey, string $displayField = 'name', ?string $valueField = null): array
-    {
-        $collection = SetupCollection::where('collection_key', $collectionKey)->first();
-        if (! $collection) {
-            return [];
-        }
-
-        $locale = session('selectedLanguage') ?? 'de';
-        $options = [];
-
-        foreach ($collection->entries as $entry) {
-            $label = $entry->data[$displayField] ?? '';
-            if (is_array($label)) {
-                $label = $label[$locale] ?? $label['de'] ?? reset($label) ?: '';
-            }
-
-            $options[] = [
-                'value' => $valueField ? ($entry->data[$valueField] ?? '') : $entry->id,
-                'label' => (string) $label,
-            ];
-        }
-
-        return $options;
     }
 
     /**

--- a/src/Helpers/StaticConfigHelper.php
+++ b/src/Helpers/StaticConfigHelper.php
@@ -279,27 +279,6 @@ class StaticConfigHelper
         return self::$runtimeCache[$cacheKey] = self::buildNavigationStructure($currentApp);
     }
 
-    /**
-     * @see getNavigationStructure()
-     */
-    private static function buildNavigationStructure(string $currentApp): ?array
-    {
-        $yamlPath = base_path("app-configs/{$currentApp}/navigation.yml");
-
-        if (!file_exists($yamlPath)) {
-            return null;
-        }
-
-        $navigationStructure = self::parseYamlFile($yamlPath);
-
-        // Process dynamic navigation blocks
-        if ($navigationStructure) {
-            $navigationStructure = self::processDynamicNavigation($navigationStructure);
-        }
-
-        return $navigationStructure;
-    }
-
     public static function getCurrentApp(): ?string
     {
         $selectedApp = TenantHelper::getSelectedApp();
@@ -490,6 +469,27 @@ class StaticConfigHelper
         self::$yamlCache[$path] = [$version, $parsed];
 
         return $parsed;
+    }
+
+    /**
+     * @see getNavigationStructure()
+     */
+    private static function buildNavigationStructure(string $currentApp): ?array
+    {
+        $yamlPath = base_path("app-configs/{$currentApp}/navigation.yml");
+
+        if (!file_exists($yamlPath)) {
+            return null;
+        }
+
+        $navigationStructure = self::parseYamlFile($yamlPath);
+
+        // Process dynamic navigation blocks
+        if ($navigationStructure) {
+            $navigationStructure = self::processDynamicNavigation($navigationStructure);
+        }
+
+        return $navigationStructure;
     }
 
     /**

--- a/src/Support/DetailSaveHook.php
+++ b/src/Support/DetailSaveHook.php
@@ -32,6 +32,8 @@ abstract class DetailSaveHook extends ComponentHook
 {
     private const SAVE_ACTIONS = ['store', 'save', 'update'];
 
+    abstract protected function afterSave(Component $component, Model $record): void;
+
     public function call($method, $params, $returnEarly, $metadata, $componentContext): callable
     {
         $effective = $method;
@@ -78,6 +80,4 @@ abstract class DetailSaveHook extends ComponentHook
             $this->afterSave($component, $record);
         };
     }
-
-    abstract protected function afterSave(Component $component, Model $record): void;
 }

--- a/src/Support/RelationFormSync.php
+++ b/src/Support/RelationFormSync.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Support\Str;
+use LogicException;
 use Noerd\Contracts\DeclaresRelationForms;
 
 /**
@@ -142,7 +143,7 @@ final class RelationFormSync
         }
 
         foreach ($data as $value) {
-            if (is_string($value) ? trim($value) !== '' : $value !== null) {
+            if (is_string($value) ? mb_trim($value) !== '' : $value !== null) {
                 return true;
             }
         }
@@ -153,7 +154,7 @@ final class RelationFormSync
     private static function defaultPersist(Model $owner, RelationFormDefinition $definition, array $data): void
     {
         $data = array_map(
-            fn (mixed $value): mixed => is_string($value) && trim($value) === '' ? null : $value,
+            fn(mixed $value): mixed => is_string($value) && mb_trim($value) === '' ? null : $value,
             $data,
         );
 
@@ -179,7 +180,7 @@ final class RelationFormSync
             return;
         }
 
-        throw new \LogicException(sprintf(
+        throw new LogicException(sprintf(
             'Relation form [%s] on [%s] uses an unsupported relation type [%s] — declare a persistUsing closure.',
             $definition->relation,
             $owner::class,

--- a/src/Traits/NoerdList.php
+++ b/src/Traits/NoerdList.php
@@ -845,6 +845,29 @@ trait NoerdList
     }
 
     /**
+     * The table's schema columns keyed by column name, introspected at most once
+     * per table and process. Backs every column-existence check in the trait:
+     * Schema::hasColumn() is NOT cached by Laravel and issues one
+     * information-schema query per call — on an 8-column list that used to mean
+     * a two-digit number of metadata queries per render.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    protected static function tableColumns(string $table): array
+    {
+        return self::$schemaColumnCache[$table]
+            ??= collect(Schema::getColumns($table))->keyBy('name')->all();
+    }
+
+    /**
+     * Cached replacement for Schema::hasColumn() (see tableColumns()).
+     */
+    protected static function tableHasColumn(string $table, string $column): bool
+    {
+        return array_key_exists($column, self::tableColumns($table));
+    }
+
+    /**
      * Keep the client-controlled page size within sane bounds — an unbounded
      * ->paginate($perPage) is a memory-exhaustion vector.
      */
@@ -1320,29 +1343,6 @@ trait NoerdList
     }
 
     /**
-     * The table's schema columns keyed by column name, introspected at most once
-     * per table and process. Backs every column-existence check in the trait:
-     * Schema::hasColumn() is NOT cached by Laravel and issues one
-     * information-schema query per call — on an 8-column list that used to mean
-     * a two-digit number of metadata queries per render.
-     *
-     * @return array<string, array<string, mixed>>
-     */
-    protected static function tableColumns(string $table): array
-    {
-        return self::$schemaColumnCache[$table]
-            ??= collect(Schema::getColumns($table))->keyBy('name')->all();
-    }
-
-    /**
-     * Cached replacement for Schema::hasColumn() (see tableColumns()).
-     */
-    protected static function tableHasColumn(string $table, string $column): bool
-    {
-        return array_key_exists($column, self::tableColumns($table));
-    }
-
-    /**
      * One shared instance of the resolved model class for table-name and cast
      * introspection — the render path asks for it many times per request.
      */
@@ -1616,36 +1616,6 @@ trait NoerdList
     }
 
     /**
-     * @see getListConfig()
-     */
-    private function resolveListConfig(?string $customName): array
-    {
-        if ($customName === null && $this->listActionMethod === 'selectAction' && $this->selectListConfig) {
-            return StaticConfigHelper::getListConfig($this->selectListConfig, $this->listModel ?? null);
-        }
-        $name = $customName ?? $this->getListComponent();
-
-        // An active alternate view only applies to this component's own config,
-        // never to an explicitly requested custom config. A view from another
-        // app resolves via explicit-app lookup; the session app stays untouched.
-        if ($customName === null && ($this->listView !== null || $this->listViewApp !== null)) {
-            $viewName = $this->listView !== null ? "{$name}--{$this->listView}" : $name;
-            $config = $this->listViewApp !== null
-                ? StaticConfigHelper::getListConfigForApp($this->listViewApp, $viewName, $this->listModel ?? null)
-                : StaticConfigHelper::getListConfig($viewName, $this->listModel ?? null);
-            if ($config !== []) {
-                return $config;
-            }
-            // The view's YAML disappeared mid-session — fall back to the default view.
-            $this->listView = null;
-            $this->listViewApp = null;
-            $this->syncListViewParam();
-        }
-
-        return StaticConfigHelper::getListConfig($name, $this->listModel ?? null);
-    }
-
-    /**
      * Override in the component to enable CSV export.
      *
      * @return array{0: Builder, 1: array, 2: string}
@@ -1722,6 +1692,36 @@ trait NoerdList
         }
 
         return $listeners;
+    }
+
+    /**
+     * @see getListConfig()
+     */
+    private function resolveListConfig(?string $customName): array
+    {
+        if ($customName === null && $this->listActionMethod === 'selectAction' && $this->selectListConfig) {
+            return StaticConfigHelper::getListConfig($this->selectListConfig, $this->listModel ?? null);
+        }
+        $name = $customName ?? $this->getListComponent();
+
+        // An active alternate view only applies to this component's own config,
+        // never to an explicitly requested custom config. A view from another
+        // app resolves via explicit-app lookup; the session app stays untouched.
+        if ($customName === null && ($this->listView !== null || $this->listViewApp !== null)) {
+            $viewName = $this->listView !== null ? "{$name}--{$this->listView}" : $name;
+            $config = $this->listViewApp !== null
+                ? StaticConfigHelper::getListConfigForApp($this->listViewApp, $viewName, $this->listModel ?? null)
+                : StaticConfigHelper::getListConfig($viewName, $this->listModel ?? null);
+            if ($config !== []) {
+                return $config;
+            }
+            // The view's YAML disappeared mid-session — fall back to the default view.
+            $this->listView = null;
+            $this->listViewApp = null;
+            $this->syncListViewParam();
+        }
+
+        return StaticConfigHelper::getListConfig($name, $this->listModel ?? null);
     }
 
     /**

--- a/src/Traits/RoutedModal.php
+++ b/src/Traits/RoutedModal.php
@@ -58,10 +58,10 @@ trait RoutedModal
     protected function routedModalArguments(): array
     {
         $parameters = array_map(
-            fn (mixed $value): mixed => $value === 'new' ? null : $value,
+            fn(mixed $value): mixed => $value === 'new' ? null : $value,
             array_filter(
                 request()->route()?->parameters() ?? [],
-                fn (string $name): bool => property_exists($this, $name),
+                fn(string $name): bool => property_exists($this, $name),
                 ARRAY_FILTER_USE_KEY,
             ),
         );

--- a/tests/Commands/NoerdUpdateAllTest.php
+++ b/tests/Commands/NoerdUpdateAllTest.php
@@ -82,8 +82,8 @@ beforeEach(function (): void {
     // Any real update command that happens to be registered is excluded per run, so
     // the assertions hold no matter which modules the host application loads.
     $this->excluded = collect(array_keys(Artisan::all()))
-        ->filter(fn (string $name): bool => $name === 'noerd:update' || str_starts_with($name, 'noerd:update-'))
-        ->reject(fn (string $name): bool => in_array($name, ['noerd:update-all', 'noerd:update', 'noerd:update-plus'], true))
+        ->filter(fn(string $name): bool => $name === 'noerd:update' || str_starts_with($name, 'noerd:update-'))
+        ->reject(fn(string $name): bool => in_array($name, ['noerd:update-all', 'noerd:update', 'noerd:update-plus'], true))
         ->values()
         ->all();
 
@@ -95,7 +95,7 @@ beforeEach(function (): void {
     $kernel->registerCommand(new RecordingUpdateCommand('noerd:update-zz-alpha'));
     $kernel->registerCommand(new RecordingUpdateCommand('noerd:update-plus'));
 
-    $this->run = fn (array $parameters = []) => $this->artisan(
+    $this->run = fn(array $parameters = []) => $this->artisan(
         'noerd:update-all',
         array_merge(['--except' => $this->excluded], $parameters),
     );

--- a/tests/Feature/AppBarTest.php
+++ b/tests/Feature/AppBarTest.php
@@ -36,6 +36,31 @@ it('renders the app bar for an authenticated user', function (): void {
         ->assertSee('AppBar Test App');
 });
 
+it('references only registered route names in the rendered app bar', function (): void {
+    $user = NoerdUser::factory()->adminUser()->create();
+    $tenant = $user->adminTenants()->first();
+
+    $tenantApp = TenantApp::create([
+        'title' => 'AppBar Route App',
+        'name' => 'APP_BAR_ROUTE_APP',
+        'icon' => 'noerd::icons.app',
+        'route' => 'app-bar-test',
+        'is_active' => true,
+    ]);
+
+    $tenant?->tenantApps()->attach($tenantApp->id, ['is_hidden' => false]);
+    $this->actingAs($user);
+
+    $html = Livewire::test('noerd::layout.app-bar')->html();
+
+    preg_match_all("/openApp\\('[^']+', '([^']+)'\\)/", $html, $matches);
+
+    expect($matches[1])->not->toBeEmpty();
+    foreach ($matches[1] as $routeName) {
+        expect(Route::has($routeName))->toBeTrue("Route [{$routeName}] referenced in the app bar is not defined.");
+    }
+});
+
 it('sets selected app and redirects when opening an app', function (): void {
     $user = NoerdUser::factory()->adminUser()->create();
     $tenant = $user->adminTenants()->first();

--- a/tests/Feature/DefaultCountriesTest.php
+++ b/tests/Feature/DefaultCountriesTest.php
@@ -29,7 +29,7 @@ it('seeds the default countries with iso codes for a tenant', function (): void 
 
     expect($entries)->toHaveCount(count(DefaultCountries::COUNTRIES));
 
-    $germany = $entries->first(fn (SetupCollectionEntry $entry): bool => ($entry->data['code'] ?? null) === 'DE');
+    $germany = $entries->first(fn(SetupCollectionEntry $entry): bool => ($entry->data['code'] ?? null) === 'DE');
     expect($germany)->not->toBeNull();
     expect($germany->data['name']['de'])->toBe('Deutschland');
     expect($germany->data['name']['en'])->toBe('Germany');
@@ -42,7 +42,7 @@ it('is idempotent and preserves tenant edits', function (): void {
     $germany = SetupCollectionEntry::withoutGlobalScopes()
         ->where('setup_collection_id', $collection->id)
         ->get()
-        ->first(fn (SetupCollectionEntry $entry): bool => ($entry->data['code'] ?? null) === 'DE');
+        ->first(fn(SetupCollectionEntry $entry): bool => ($entry->data['code'] ?? null) === 'DE');
 
     $germany->update(['data' => array_merge($germany->data, ['name' => ['de' => 'BRD', 'en' => 'Germany']])]);
 
@@ -65,7 +65,7 @@ it('backfills the code onto existing name-only entries instead of duplicating th
     SetupCollectionEntry::withoutGlobalScopes()
         ->where('setup_collection_id', $collection->id)
         ->get()
-        ->each(fn (SetupCollectionEntry $entry) => $entry->update([
+        ->each(fn(SetupCollectionEntry $entry) => $entry->update([
             'data' => ['name' => $entry->data['name']],
         ]));
 
@@ -76,5 +76,5 @@ it('backfills the code onto existing name-only entries instead of duplicating th
         ->get();
 
     expect($entries)->toHaveCount(count(DefaultCountries::COUNTRIES));
-    expect($entries->every(fn (SetupCollectionEntry $entry): bool => ($entry->data['code'] ?? '') !== ''))->toBeTrue();
+    expect($entries->every(fn(SetupCollectionEntry $entry): bool => ($entry->data['code'] ?? '') !== ''))->toBeTrue();
 });

--- a/tests/Feature/DetailActionsTest.php
+++ b/tests/Feature/DetailActionsTest.php
@@ -300,5 +300,5 @@ it('keeps a conditional modal action clickable with a single Alpine scope', func
 
     expect($html)->toContain('$modal(')
         ->toContain('x-show="$wire.hasAccount"')
-        ->and(substr_count($html, 'x-data'))->toBe(1);
+        ->and(mb_substr_count($html, 'x-data'))->toBe(1);
 });

--- a/tests/Feature/PageAutoDetailActionsTest.php
+++ b/tests/Feature/PageAutoDetailActionsTest.php
@@ -81,7 +81,7 @@ it('renders the actions exactly once with the opt-out plus an explicit include',
 
     // The label also appears in the serialized wire:snapshot (pageLayout is a
     // public property), so count the rendered button attribute instead.
-    expect(substr_count($component->html(), 'wire:click="doProbe"'))->toBe(1);
+    expect(mb_substr_count($component->html(), 'wire:click="doProbe"'))->toBe(1);
 });
 
 it('resolves url actions through the detailActionUrls convention', function (): void {

--- a/tests/Feature/RelationFormSyncTest.php
+++ b/tests/Feature/RelationFormSyncTest.php
@@ -73,7 +73,7 @@ class ZzRelationSpyHost extends ZzRelationHost
                 relation: 'zzChild',
                 fields: ['line_1', 'city'],
             )
-                ->persistWhen(fn (array $data): bool => ($data['line_1'] ?? '') !== 'skip-me')
+                ->persistWhen(fn(array $data): bool => ($data['line_1'] ?? '') !== 'skip-me')
                 ->persistUsing(function (Model $owner, array $data): void {
                     self::$spy = ['owner_id' => $owner->id, 'data' => $data];
                 }),

--- a/tests/Feature/TranslatableFieldMarkerTest.php
+++ b/tests/Feature/TranslatableFieldMarkerTest.php
@@ -40,7 +40,7 @@ describe('Translatable field marker in detail forms', function (): void {
         ])->assertSuccessful()->html();
 
         assertElementHasClasses($html, ['border-sky-300', 'rounded-lg']);
-        expect(substr_count($html, 'border-sky-300'))->toBeGreaterThanOrEqual(2);
+        expect(mb_substr_count($html, 'border-sky-300'))->toBeGreaterThanOrEqual(2);
     });
 
     it('frames a translatable field in blue in the compact theme and keeps the compact layout', function (): void {
@@ -92,7 +92,7 @@ describe('Translatable field marker in detail forms', function (): void {
         ])->assertSuccessful()->html();
 
         // One language affordance per translatable field, carrying the explanation.
-        expect(substr_count($html, 'This field is translatable.'))->toBe(4)
+        expect(mb_substr_count($html, 'This field is translatable.'))->toBe(4)
             ->and($html)->toContain('text-sky-500');
     })->with(['default', 'compact', 'numbered']);
 
@@ -204,7 +204,7 @@ YAML);
         expect($html)->toContain('Germany')->toContain('DE');
         // … but only the translatable cell carries the tinted background, and it is a
         // background — never a frame, which would fight the table's own grid lines.
-        expect(substr_count($html, 'bg-sky-50 group-hover:bg-transparent'))->toBe(1)
+        expect(mb_substr_count($html, 'bg-sky-50 group-hover:bg-transparent'))->toBe(1)
             ->and($html)->not->toContain('border-sky-300!');
     });
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -181,7 +181,17 @@ abstract class TestCase extends BaseTestCase
             @symlink(dirname(__DIR__), $moduleTarget);
         }
 
-        if (! file_exists(base_path('app-configs/setup/navigation.yml'))) {
+        // Like the config below, the published app-configs are refreshed when the
+        // skeleton copy no longer matches the package copy — copying only when
+        // missing would pin the suite to stale YAMLs (e.g. old navigation route
+        // names) for the lifetime of the skeleton. navigation.yml is the freshness
+        // marker; content is compared because tests that back up and restore the
+        // published file rewrite it, so mtimes carry no signal here.
+        $navigationSource = dirname(__DIR__) . '/app-configs/setup/navigation.yml';
+        $navigationTarget = base_path('app-configs/setup/navigation.yml');
+
+        if (! file_exists($navigationTarget)
+            || file_get_contents($navigationTarget) !== file_get_contents($navigationSource)) {
             File::copyDirectory(dirname(__DIR__) . '/app-configs', base_path('app-configs'));
         }
 


### PR DESCRIPTION
Working-tree follow-ups to the merged route renaming (#44), plus the formatting Pint now enforces in CI.

- `app-bar`: `openApp('noerd-apps', 'noerd.apps')` — the tile pointed at the pre-rename route name.
- `tests/TestCase.php`: refresh the published `app-configs` in the testbench skeleton when they no longer match the package copy, so the suite cannot pin itself to stale navigation route names.
- Pint formatting across factories, migrations and commands.