### PR TITLE
Restore the URL-bound list filter property and fix the CSV export delimiter scope

### DIFF
--- a/src/Traits/NoerdList.php
+++ b/src/Traits/NoerdList.php
@@ -93,6 +93,14 @@ trait NoerdList
 
     public string $listId = '';
 
+    /**
+     * Free-form list filter carried in the URL (?filter=…). The trait itself
+     * never reads it — consuming lists seed their own listFilters from it in
+     * mount(), which makes it part of the public API of this trait.
+     */
+    #[Url]
+    public ?string $filter = null;
+
     public array $listFilters = [];
 
     /**
@@ -785,7 +793,7 @@ trait NoerdList
                 $columns,
             ), $delimiter);
 
-            $query->lazy(200)->each(function ($row) use ($handle, $columns): void {
+            $query->lazy(200)->each(function ($row) use ($handle, $columns, $delimiter): void {
                 $this->prepareExportRow($row);
                 $line = [];
                 foreach ($columns as $column) {


### PR DESCRIPTION
Two regressions introduced by #46 and shipped in v0.12.0, both caught by the host module suites.

- **`NoerdList::$filter` was removed as dead code.** Nothing inside the package read it, but it is URL-bound (`?filter=…`) and consuming lists seed their own `listFilters` from it in `mount()` — liefertool's orders list does exactly that and now fails with `PropertyNotFoundException`. Restored, with a docblock stating that it is public API of the trait even though the trait itself never reads it.
- **CSV export threw `Undefined variable $delimiter`.** When the hardcoded `';'` became `FormatHelper::csvDelimiter()`, the variable was not passed into the row closure, so every export failed at the first data row (booking-members' membership-fee export).

Verified: liefertool component tests and the booking-members CSV export test pass again; noerd suite 1032 passed, Pint clean.