### PR TITLE
Add NoerdDetail trait and write-denied relation-form coverage

### DIFF
--- a/src/Services/ColumnFilterParser.php
+++ b/src/Services/ColumnFilterParser.php
@@ -52,6 +52,22 @@ final class ColumnFilterParser
         };
     }
 
+    /**
+     * Contains match via LIKE with an EXPLICIT escape character, so a literal
+     * % or _ in the input matches literally on every driver: sqlite has no
+     * default LIKE escape character (a backslash-escaped pattern silently
+     * matches nothing there), and a backslash escape literal is not portable
+     * into MySQL string literals — `!` is literal in both. The column name is
+     * grammar-wrapped (JSON `->` paths included); the value stays a binding.
+     */
+    public static function applyLikeContains(Builder $query, string $field, string $value, string $boolean = 'and'): void
+    {
+        $wrapped = $query->getQuery()->getGrammar()->wrap($field);
+        $escaped = str_replace(['!', '%', '_'], ['!!', '!%', '!_'], $value);
+
+        $query->whereRaw("{$wrapped} like ? escape '!'", ['%' . $escaped . '%'], $boolean);
+    }
+
     private static function applyBool(Builder $query, string $field, string $raw): void
     {
         $value = mb_trim($raw);
@@ -105,22 +121,6 @@ final class ColumnFilterParser
         }
 
         $query->where($field, $op, $value);
-    }
-
-    /**
-     * Contains match via LIKE with an EXPLICIT escape character, so a literal
-     * % or _ in the input matches literally on every driver: sqlite has no
-     * default LIKE escape character (a backslash-escaped pattern silently
-     * matches nothing there), and a backslash escape literal is not portable
-     * into MySQL string literals — `!` is literal in both. The column name is
-     * grammar-wrapped (JSON `->` paths included); the value stays a binding.
-     */
-    public static function applyLikeContains(Builder $query, string $field, string $value, string $boolean = 'and'): void
-    {
-        $wrapped = $query->getQuery()->getGrammar()->wrap($field);
-        $escaped = str_replace(['!', '%', '_'], ['!!', '!%', '!_'], $value);
-
-        $query->whereRaw("{$wrapped} like ? escape '!'", ['%' . $escaped . '%'], $boolean);
     }
 
     private static function parseDate(string $value): ?Carbon

--- a/tests/Commands/NoerdDemoCommandTest.php
+++ b/tests/Commands/NoerdDemoCommandTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 use Illuminate\Console\Command;
 use Noerd\Commands\NoerdDemoCommand;
 use Noerd\Tests\TestCase;
-use Noerd\Traits\RequiresNoerdInstallation;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 

--- a/tests/Feature/GenericComponentPageTest.php
+++ b/tests/Feature/GenericComponentPageTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Route;
 use Noerd\Models\NoerdUser;
 use Noerd\Tests\TestCase;
 

--- a/tests/Feature/NoerdDetailTraitTest.php
+++ b/tests/Feature/NoerdDetailTraitTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Livewire\Component;
+use Livewire\Livewire;
+use Noerd\Models\NoerdUser;
+use Noerd\Models\Tenant;
+use Noerd\Tests\TestCase;
+use Noerd\Traits\NoerdDetail;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+/*
+ | Core NoerdDetail mechanics not covered by the store roundtrip suite
+ | (NoerdDetailStoreRoundtripTest): layout hydration on mount, the recursion of
+ | validateFromLayout() into `type: block` fields, the setFieldValue event
+ | (relation title adoption and dotted writes — its detailData allowlist is
+ | proven in SecurityHighFixesTest) and clearRelation(). The layout comes from a
+ | runtime fixture YAML, never from a shipped config.
+ */
+
+class ZzDetailTraitComponent extends Component
+{
+    use NoerdDetail;
+
+    public const COMPONENT = 'zz-detail-trait-detail';
+
+    public $detailModel = Tenant::class;
+
+    public ?string $detailPrimary = 'tenantId';
+
+    public function render(): string
+    {
+        return '<div></div>';
+    }
+}
+
+beforeEach(function (): void {
+    $this->actingAs(NoerdUser::factory()->adminUser()->withSelectedApp('setup')->create());
+
+    Livewire::component('zz-detail-trait-detail', ZzDetailTraitComponent::class);
+
+    File::put(base_path('app-configs/setup/details/zz-detail-trait-detail.yml'), implode("\n", [
+        'title: Zz Detail Trait',
+        'fields:',
+        '  - name: detailData.name',
+        '    label: Name',
+        '    type: text',
+        '    required: true',
+        '  - type: block',
+        '    fields:',
+        '      - name: detailData.zz_nested',
+        '        label: Nested',
+        '        type: text',
+        '        required: true',
+    ]));
+});
+
+afterEach(function (): void {
+    File::delete(base_path('app-configs/setup/details/zz-detail-trait-detail.yml'));
+});
+
+it('hydrates detailData from the mounted record and the layout from the YAML', function (): void {
+    $tenant = Tenant::factory()->create(['name' => 'Hydrated Tenant']);
+
+    $component = Livewire::test('zz-detail-trait-detail', ['modelId' => $tenant->id]);
+
+    expect($component->get('detailData.name'))->toBe('Hydrated Tenant')
+        ->and($component->get('pageLayout.title'))->toBe('Zz Detail Trait');
+});
+
+it('derives required rules from the layout, recursing into block fields', function (): void {
+    $component = Livewire::test('zz-detail-trait-detail')
+        ->set('detailData', [])
+        ->call('store');
+
+    $required = requiredLayoutFields($component);
+
+    expect($required)->toContain('detailData.zz_nested');
+
+    $component->assertHasErrors($required);
+});
+
+it('adopts a setFieldValue event into detailData with its relation title', function (): void {
+    $component = Livewire::test('zz-detail-trait-detail')
+        ->dispatch('setFieldValue', field: 'detailData.customer_id', value: 5, relationTitle: 'Acme');
+
+    expect($component->get('detailData.customer_id'))->toBe(5)
+        ->and($component->get('relationTitles.customer_id'))->toBe('Acme');
+
+    // Dotted fields write into the nested payload.
+    $component->dispatch('setFieldValue', field: 'detailData.address.city', value: 'Berlin');
+
+    expect($component->get('detailData.address.city'))->toBe('Berlin');
+});
+
+it('clears a relation value and its title for plain and dotted fields', function (): void {
+    $component = Livewire::test('zz-detail-trait-detail')
+        ->dispatch('setFieldValue', field: 'detailData.customer_id', value: 5, relationTitle: 'Acme')
+        ->dispatch('setFieldValue', field: 'detailData.invoice.contact_id', value: 7, relationTitle: 'Jane')
+        ->call('clearRelation', 'detailData.customer_id')
+        ->call('clearRelation', 'detailData.invoice.contact_id');
+
+    expect($component->get('detailData.customer_id'))->toBeNull()
+        ->and($component->get('relationTitles.customer_id'))->toBe('')
+        ->and($component->get('detailData.invoice.contact_id'))->toBeNull()
+        ->and($component->get('relationTitles.contact_id'))->toBe('');
+});

--- a/tests/Feature/RelationFormSyncTest.php
+++ b/tests/Feature/RelationFormSyncTest.php
@@ -6,10 +6,12 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Schema;
 use Livewire\Component;
 use Livewire\Livewire;
 use Noerd\Contracts\DeclaresRelationForms;
+use Noerd\Helpers\AccessHelper;
 use Noerd\Models\NoerdUser;
 use Noerd\Support\RelationFormDefinition;
 use Noerd\Support\RelationFormSync;
@@ -227,6 +229,23 @@ it('uses a custom persistUsing closure and honors persistWhen', function (): voi
         ->assertHasNoErrors();
 
     expect(ZzRelationSpyHost::$spy)->toBeNull();
+});
+
+it('does not persist the relation form for a write-denied user', function (): void {
+    // Covers the canWriteObject() recheck at the save boundary (DetailSaveHook):
+    // a denied user's store writes neither the host nor the related record.
+    Gate::define(AccessHelper::OBJECT_WRITE_GATE, fn(?NoerdUser $user, string $modelClass): bool => false);
+
+    $host = ZzRelationHost::create(['name' => 'Host']);
+
+    Livewire::test('zz-relation-host-detail', ['modelId' => $host->id])
+        ->set('detailData.name', 'Denied Rename')
+        ->set('detailData.zzAddress.line_1', 'Denied 1')
+        ->call('store');
+
+    expect($host->refresh()->name)->toBe('Host')
+        ->and($host->zz_child_id)->toBeNull()
+        ->and(ZzRelationChild::count())->toBe(0);
 });
 
 it('does not persist when the active layout omits the form', function (): void {


### PR DESCRIPTION
Follow-ups to the test-coverage work merged in #55:

- **`NoerdDetailTraitTest`** (new): layout hydration on mount, `validateFromLayout()` recursion into `type: block` fields, the `setFieldValue` event (relation-title adoption, dotted writes) and `clearRelation()` for plain and dotted fields — against a runtime fixture YAML.
- **`RelationFormSyncTest`**: a write-denied user's store persists neither the host record nor the relation form (covers the `canWriteObject()` recheck at the save boundary).
- **Pint follow-ups**: unused imports left by the test cleanup in `NoerdDemoCommandTest` / `GenericComponentPageTest`, method ordering in `ColumnFilterParser` — `composer lint` is green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lv3A8ngemswtQtjpHLs6HV