### PR TITLE
Add module dependency guard and update-command test helpers

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -188,6 +188,22 @@ it('opens the detail by route when the route exists', function (): void {
 The list dispatches the route together with the component as fallback; a list without a
 `$detailRoute` dispatches only `modalComponent` (see `ListDetailRouteFallbackTest`).
 
+## Module dependency guard
+
+Every business module ships a `ModuleBoundaryTest` calling the global helper
+`assertModuleDependenciesDeclared(dirname(__DIR__, 2))` (from `tests/helpers.php`).
+It derives the known module namespaces from the sibling `app-modules/*/composer.json`
+files and fails when a namespace of another module appears anywhere in the module
+(src, resources, routes, database, config, app-configs **and tests**) without a
+matching `require`/`require-dev` entry. Documented exceptions (e.g. a
+`class_exists()`-guarded optional integration) are passed as the second argument:
+
+```php
+assertModuleDependenciesDeclared(dirname(__DIR__, 2), ['nywerk/liefertool-shop']);
+```
+
+Add a short comment above every allowance explaining why it is legitimate.
+
 ## Factories
 
 A factory's `definition()` must produce a fully valid, persistable record: every non-relation scalar

--- a/tests/Feature/AuditListGuardTest.php
+++ b/tests/Feature/AuditListGuardTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Noerd\Models\NoerdUser;
+use Noerd\Models\Tenant;
+use Noerd\Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $user = NoerdUser::factory()->withExampleTenant()->withSelectedApp('setup')->create();
+
+    $this->actingAs($user);
+});
+
+it('rejects a model class that is not auditable', function (): void {
+    Livewire::test('noerd::audit-list', ['modelClass' => Tenant::class, 'modelId' => 1])
+        ->assertStatus(404);
+});
+
+it('rejects a class that is not an eloquent model', function (): void {
+    Livewire::test('noerd::audit-list', ['modelClass' => Illuminate\Support\Str::class, 'modelId' => 1])
+        ->assertStatus(404);
+});

--- a/tests/Feature/CompactRelationFieldTest.php
+++ b/tests/Feature/CompactRelationFieldTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Noerd\Models\NoerdUser;
+use Noerd\Services\RelationFieldRegistry;
+use Noerd\Support\RelationFieldDefinition;
+use Noerd\Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->admin = NoerdUser::factory()->adminUser()->withSelectedApp('setup')->create();
+    $this->actingAs($this->admin);
+
+    app(RelationFieldRegistry::class)->register('compactTestRelation', RelationFieldDefinition::model(
+        listComponent: 'compact-tests-list',
+        detailComponent: 'compact-test-detail',
+        modelClass: null,
+        titleResolver: 'name',
+    ));
+});
+
+it('shrinks the relation select button to match the compact input height', function (): void {
+    $component = Livewire::test('noerd-relation-field', [
+        'relationType' => 'compactTestRelation',
+        'fieldName' => 'detailData.compact_test_id',
+        'label' => 'Compact Test',
+        'theme' => 'compact',
+    ])->assertOk();
+
+    assertElementHasClasses($component->html(), ['!h-7', '!px-2']);
+});

--- a/tests/helpers.php
+++ b/tests/helpers.php
@@ -150,3 +150,134 @@ if (!function_exists('assertNoElementHasClasses')) {
         Assert::assertTrue(true);
     }
 }
+
+if (!function_exists('assertModuleDependenciesDeclared')) {
+    /**
+     * Module-independence guard: every OTHER app module whose PSR-4 namespace
+     * appears anywhere in this module (src, resources, routes, database,
+     * config, app-configs and tests) must be declared in the module's
+     * composer.json require or require-dev. The known module namespaces are
+     * derived from the sibling app-modules' composer.json files, so the guard
+     * needs no hand-maintained mapping and also catches test-only leaks.
+     *
+     * @param  string  $moduleDir  absolute path of the module under test
+     * @param  array<int, string>  $allowedPackages  extra packages to tolerate
+     */
+    function assertModuleDependenciesDeclared(string $moduleDir, array $allowedPackages = []): void
+    {
+        $modulesRoot = dirname($moduleDir);
+        $composer = json_decode((string) file_get_contents($moduleDir . '/composer.json'), true) ?? [];
+        $declared = array_merge(
+            array_keys($composer['require'] ?? []),
+            array_keys($composer['require-dev'] ?? []),
+            $allowedPackages,
+            [$composer['name'] ?? ''],
+        );
+
+        // prefix (e.g. "Noerd\\Cms\\") => package name (e.g. "noerd/cms")
+        $prefixes = [];
+        foreach (glob($modulesRoot . '/*/composer.json') as $file) {
+            $data = json_decode((string) file_get_contents($file), true) ?? [];
+            foreach (array_keys($data['autoload']['psr-4'] ?? []) as $prefix) {
+                // Sub-namespaces (Database\Factories, Tests, ...) map to the same package.
+                $root = implode('\\', array_slice(explode('\\', mb_trim($prefix, '\\')), 0, 2)) . '\\';
+                $prefixes[$root] ??= $data['name'] ?? '';
+            }
+        }
+
+        $violations = [];
+        foreach (['src', 'resources', 'routes', 'database', 'config', 'app-configs', 'tests'] as $dir) {
+            $path = $moduleDir . '/' . $dir;
+            if (!is_dir($path)) {
+                continue;
+            }
+
+            $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS));
+            foreach ($iterator as $file) {
+                if (!in_array($file->getExtension(), ['php', 'yml', 'yaml', 'json', 'stub'], true)) {
+                    continue;
+                }
+                // The boundary tests themselves name foreign namespaces as needles.
+                if (str_contains($file->getFilename(), 'ModuleBoundaryTest')) {
+                    continue;
+                }
+                $content = (string) file_get_contents($file->getPathname());
+
+                foreach ($prefixes as $prefix => $package) {
+                    if ($package === '' || in_array($package, $declared, true)) {
+                        continue;
+                    }
+                    if (str_contains($content, $prefix) || str_contains($content, str_replace('\\', '\\\\', $prefix))) {
+                        $violations[$package][] = mb_substr($file->getPathname(), mb_strlen($moduleDir) + 1);
+                    }
+                }
+            }
+        }
+
+        Assert::assertSame(
+            [],
+            $violations,
+            'Undeclared module dependencies found — add them to composer.json (require or require-dev) or remove the usage: '
+            . json_encode(array_map(fn(array $files) => array_values(array_unique($files)), $violations), JSON_PRETTY_PRINT),
+        );
+    }
+}
+
+if (!function_exists('assertModuleUpdateCommandPublishesConfigs')) {
+    /**
+     * Standard proof for a module's noerd:update-{module} command: publishes
+     * every YAML the module ships into app-configs/{key} (self-heal branch),
+     * exits cleanly, and --force restores a locally modified copy. The target
+     * directory is snapshotted and restored exactly, so the host project's
+     * installed configuration is never left altered.
+     */
+    function assertModuleUpdateCommandPublishesConfigs(string $command, string $moduleDir, string $moduleKey): void
+    {
+        $source = $moduleDir . '/app-configs/' . $moduleKey;
+        $target = base_path('app-configs/' . $moduleKey);
+        $scratch = storage_path('framework/testing/zz-update-cmd-' . $moduleKey . '-' . getmypid());
+
+        Assert::assertDirectoryExists($source, "Module ships no app-configs/{$moduleKey} directory.");
+
+        $existed = is_dir($target);
+        if ($existed) {
+            \Illuminate\Support\Facades\File::copyDirectory($target, $scratch);
+        }
+
+        try {
+            \Illuminate\Support\Facades\File::deleteDirectory($target);
+
+            $exit = \Illuminate\Support\Facades\Artisan::call($command, ['--no-interaction' => true]);
+            Assert::assertSame(0, $exit, "{$command} did not exit cleanly: " . \Illuminate\Support\Facades\Artisan::output());
+
+            // The update contract publishes the config SUBDIRECTORIES plus
+            // navigation.yml — extra root-level files are module-specific and
+            // outside the generic mechanism.
+            $published = null;
+            $shipped = array_merge(
+                glob($source . '/*/*.yml') ?: [],
+                glob($source . '/*/*/*.yml') ?: [],
+                array_filter([is_file($source . '/navigation.yml') ? $source . '/navigation.yml' : null]),
+            );
+            foreach ($shipped as $file) {
+                $relative = mb_substr($file, mb_strlen($source) + 1);
+                Assert::assertFileExists($target . '/' . $relative, "update did not publish {$relative}");
+                $published ??= $target . '/' . $relative;
+            }
+
+            Assert::assertNotNull($published, 'module ships no yml files to publish');
+
+            // --force refreshes a locally modified copy back to the shipped content.
+            file_put_contents($published, "title: Zz Local Change\n");
+            $exit = \Illuminate\Support\Facades\Artisan::call($command, ['--force' => true, '--no-interaction' => true]);
+            Assert::assertSame(0, $exit, "{$command} --force did not exit cleanly");
+            Assert::assertStringNotContainsString('Zz Local Change', (string) file_get_contents($published));
+        } finally {
+            \Illuminate\Support\Facades\File::deleteDirectory($target);
+            if ($existed) {
+                \Illuminate\Support\Facades\File::copyDirectory($scratch, $target);
+                \Illuminate\Support\Facades\File::deleteDirectory($scratch);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Audit follow-ups for the module test standardization:

- **`assertModuleDependenciesDeclared()`** (tests/helpers.php): derives module namespaces from the sibling app-modules' composer.json files and fails when a namespace of another module is used anywhere in a module without a matching require/require-dev entry; documented exceptions via `allowedPackages`. Rolled out as `ModuleBoundaryTest` across all business modules.
- **`assertModuleUpdateCommandPublishesConfigs()`**: standard proof for `noerd:update-{module}` — publishes every shipped YAML (self-heal), exits cleanly, `--force` restores modified copies; target directory snapshot/restore included.
- **`AuditListGuardTest`**: the audit-list guard tests moved here from pdm (non-auditable model and non-model classes are rejected).
- **`CompactRelationFieldTest`**: compact-theme relation field sizing moved here from crm, asserted via `assertElementHasClasses`.
- `docs/testing.md` documents the shared-skeleton rules and the new dependency guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lv3A8ngemswtQtjpHLs6HV