### PR TITLE
Move list default sorting to the YAML config and remove setDefaultSort()

### DIFF
--- a/app-configs/setup/lists/noerd-users-list.yml
+++ b/app-configs/setup/lists/noerd-users-list.yml
@@ -1,4 +1,7 @@
 title: Users
+defaultSort:
+  field: name
+  direction: asc
 searchableColumns:
   - name
   - email

--- a/app-configs/setup/lists/tenants-list.yml
+++ b/app-configs/setup/lists/tenants-list.yml
@@ -1,4 +1,7 @@
 title: Tenants
+defaultSort:
+  field: name
+  direction: asc
 columns:
   - field: name
     label: Name

--- a/docs/list-search.md
+++ b/docs/list-search.md
@@ -126,24 +126,20 @@ public function listData(): array
 
 ## Default Sorting
 
-To set a default sort order for a list, use the `setDefaultSort()` method in your `mount()` method:
+Default sorting is configured in the list YAML — never in the component:
 
-```php
-public function mount(): void
-{
-    $this->mountList();
-    $this->setDefaultSort('invoice_date', false);  // Sort by invoice_date descending
-}
+```yaml
+defaultSort:
+  field: invoice_date
+  direction: desc   # optional, desc when omitted
 ```
 
-The method signature is:
+- `field`: The column name to sort by
+- `direction`: `asc` (A-Z, oldest first) or `desc` (Z-A, newest first); omitted means `desc`
 
-```php
-protected function setDefaultSort(string $field, bool $ascending = false): void
-```
-
-- `$field`: The column name to sort by
-- `$ascending`: `true` for ascending (A-Z, oldest first), `false` for descending (Z-A, newest first)
+`mountList()` applies the YAML default whenever the user has not sorted the list yet; a
+user-picked sort is persisted per list in the session and always wins. See
+[List View](list-view.md) ("Default Sorting") for details.
 
 ## Not Sortable Columns
 

--- a/docs/list-view.md
+++ b/docs/list-view.md
@@ -261,21 +261,26 @@ public function with(): array
 
 ## Default Sorting
 
-To set a custom default sort order, use `setDefaultSort()` in your `mount()` method:
+Default sorting is configured in the list YAML — never in the component:
 
-```php
-public function mount(): void
-{
-    $this->mountList();
-    $this->setDefaultSort('created_at', false);  // Sort by created_at descending
-}
+```yaml
+title: Invoices
+defaultSort:
+  field: invoice_date
+  direction: desc   # optional, desc when omitted
 ```
 
-**Parameters:**
-- `$field`: Column name to sort by
-- `$ascending`: `true` for ascending (A-Z), `false` for descending (Z-A)
+**Keys:**
+- `field`: Column name to sort by
+- `direction`: `asc` (A-Z) or `desc` (Z-A); omitted means `desc`
 
-Without `setDefaultSort()`, lists default to `id` descending.
+`mountList()` applies the YAML default whenever the user has not sorted the list yet; a sort the
+user picks in the header is persisted per list in the session and always wins over the YAML
+default. Alternate list views (`--{key}.yml`) are complete standalone configs, so each view may
+bring its own `defaultSort`.
+
+Without a `defaultSort` key, lists sort by `id` descending. There is no component API for default
+sorting: never set `$sortField` / `$sortAsc` directly and never override `mount()` for sorting.
 
 See [List Search](list-search.md) for more details on search and sorting.
 

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -134,7 +134,7 @@ Example for user: users-list.blade.php (plural) and user-detail.blade.php (singu
 - Documentation (README files, docs folders, markdown files) must always be written in English.
 - When writing tests, they must always be in PEST format.
 - YAML files must always use block style formatting. Never use flow/inline style like `{ key: value }` or `[item1, item2]`.
-- When setting default sorting in list components, always use the `setDefaultSort()` method in `mount()`. Never set `$this->sortField` or `$this->sortAsc` directly.
+- Default sorting of a list is CONFIGURATION, never component code: set a top-level `defaultSort:` block in the list YAML (`field:` plus optional `direction: asc|desc`, `desc` when omitted) — in BOTH synced copies. `mountList()` applies it while the user has not sorted the list; a session-saved user sort always wins. There is no component API for it: never set `$this->sortField`/`$this->sortAsc` and never override `mount()` for sorting.
 
 ### Config, noerd:install and noerd:update
 - Configuration keys come from the package config (`vendor/noerd/noerd/config/noerd.php`); the

--- a/resources/boost/skills/noerd-list-development/SKILL.md
+++ b/resources/boost/skills/noerd-list-development/SKILL.md
@@ -51,8 +51,9 @@ new class extends Component {
 
 - Nothing else goes into a slim component. `mount()`, `listAction()`, `listData()`, `rendering()`
   come from the trait.
-- Default sort: `public function mount(): void { $this->mountList(); $this->setDefaultSort('name'); }`
-  — never set `$sortField`/`$sortAsc` directly.
+- Default sort: a `defaultSort:` block in the list YAML (`field:` + optional
+  `direction: asc|desc`, `desc` when omitted) — both synced copies, never component code. A
+  user-picked sort persists in the session and wins; never set `$sortField`/`$sortAsc` directly.
 - Custom query: override `listData()` only —
   `$rows = $this->listQuery($this->listModel)->where(...)->with(...)->paginate($this->perPage); return $this->buildList($rows);`
   Keep extra view data (e.g. a summary) in a slim `with()` that shares the query via a private

--- a/resources/views/components/noerd-users-list.blade.php
+++ b/resources/views/components/noerd-users-list.blade.php
@@ -16,12 +16,6 @@ new class () extends Component {
     public $listModel = NoerdUser::class;
     public ?string $detailRoute = 'noerd.user.detail';
 
-    public function mount(): void
-    {
-        $this->mountList();
-        $this->setDefaultSort('name', true);
-    }
-
     public function loginAsUser($userId)
     {
         if (! NoerdAuth::user()->isAdmin()) {

--- a/resources/views/components/tenants-list.blade.php
+++ b/resources/views/components/tenants-list.blade.php
@@ -14,12 +14,6 @@ new class extends Component {
 
     public $detailComponent = 'noerd::tenant-detail';
 
-    public function mount(): void
-    {
-        $this->mountList();
-        $this->setDefaultSort('name', true);
-    }
-
     public function listData(): array
     {
         $query = $this->listQuery($this->listModel);

--- a/src/Commands/stubs/module/list-yaml.stub
+++ b/src/Commands/stubs/module/list-yaml.stub
@@ -1,4 +1,7 @@
 title: {{ModelsTitle}}
+defaultSort:
+  field: name
+  direction: asc
 actions:
   - label: New {{ModelTitle}}
     action: listAction

--- a/src/Traits/NoerdList.php
+++ b/src/Traits/NoerdList.php
@@ -269,12 +269,6 @@ trait NoerdList
             $this->listColumnFilters = session("listColumnFilters.{$this->componentName()}", []);
         }
 
-        $savedSort = session("listSort.{$this->componentName()}");
-        if ($savedSort) {
-            $this->sortField = $savedSort['field'];
-            $this->sortAsc = $savedSort['asc'];
-        }
-
         $savedView = session("listView.{$this->componentName()}");
 
         // A ?view= URL param (shared link) wins over the session-saved view.
@@ -321,6 +315,17 @@ trait NoerdList
         }
 
         $this->syncListViewParam();
+
+        // The sort restore runs AFTER the view restore on purpose: with no
+        // session-saved sort the default comes from the ACTIVE view's YAML
+        // (`defaultSort:`), so an alternate list view brings its own order.
+        $savedSort = session("listSort.{$this->componentName()}");
+        if ($savedSort) {
+            $this->sortField = $savedSort['field'];
+            $this->sortAsc = $savedSort['asc'];
+        } else {
+            $this->applyDefaultSortFromConfig();
+        }
 
         // Deep-link support: ?{entity}Id=5 opens the record's modal over the
         // list, ?create=1 the create modal. Mount-only BY DESIGN — Livewire
@@ -891,22 +896,6 @@ trait NoerdList
         }
 
         return method_exists($this, 'with') ? ($this->with()['listConfig'] ?? []) : [];
-    }
-
-    /**
-     * Set the default sort field and direction.
-     * Call this in mount() to configure initial sorting.
-     */
-    protected function setDefaultSort(string $field, bool $ascending = false): void
-    {
-        $savedSort = session("listSort.{$this->componentName()}");
-        if ($savedSort) {
-            $this->sortField = $savedSort['field'];
-            $this->sortAsc = $savedSort['asc'];
-        } else {
-            $this->sortField = $field;
-            $this->sortAsc = $ascending;
-        }
     }
 
     protected function getAllowedListFilterColumns(): array
@@ -1775,6 +1764,28 @@ trait NoerdList
         [$app, $viewKey] = StaticConfigHelper::parseListViewKey($key);
         $this->listViewApp = $app;
         $this->listView = $viewKey === 'default' ? null : $viewKey;
+    }
+
+    /**
+     * Default sorting is configured in the list YAML — never in the component:
+     *
+     *   defaultSort:
+     *     field: name
+     *     direction: asc   # optional, desc when omitted
+     *
+     * Applied only while the user has not sorted the list themselves (no
+     * session entry). Without the key, lists sort by id descending.
+     */
+    private function applyDefaultSortFromConfig(): void
+    {
+        $defaultSort = $this->getListConfig()['defaultSort'] ?? null;
+
+        if (!is_array($defaultSort) || empty($defaultSort['field'])) {
+            return;
+        }
+
+        $this->sortField = (string) $defaultSort['field'];
+        $this->sortAsc = ($defaultSort['direction'] ?? 'desc') === 'asc';
     }
 
     /**

--- a/tests/Commands/MakeModuleStubsTest.php
+++ b/tests/Commands/MakeModuleStubsTest.php
@@ -69,6 +69,7 @@ it('generates block-style YAML configs bound to detailData', function (): void {
 
     expect($listYaml)
         ->toContain('title: Widgets')
+        ->toContain("defaultSort:\n  field: name\n  direction: asc")
         ->toContain('action: listAction')
         ->not->toContain('newLabel')
         ->not->toContain('_label_');

--- a/tests/Feature/ListDetailRouteFallbackTest.php
+++ b/tests/Feature/ListDetailRouteFallbackTest.php
@@ -2,12 +2,15 @@
 
 declare(strict_types=1);
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Component;
 use Livewire\Livewire;
 use Noerd\Tests\TestCase;
 use Noerd\Traits\NoerdList;
 
-uses(TestCase::class);
+// RefreshDatabase: mountList() resolves the list config (YAML defaultSort),
+// and the config search roots read the active tenant apps from the database.
+uses(TestCase::class, RefreshDatabase::class);
 
 it('dispatches the route plus the component as fallback when a list declares both', function (): void {
     Livewire::test(ZzRouteFallbackListComponent::class)

--- a/tests/Traits/NoerdListTest.php
+++ b/tests/Traits/NoerdListTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
 use Livewire\Component;
 use Livewire\Livewire;
 use Noerd\Tests\TestCase;
@@ -10,21 +11,62 @@ use Noerd\Traits\NoerdList;
 
 uses(TestCase::class, RefreshDatabase::class);
 
-it('sets default sort field and direction via setDefaultSort', function (): void {
-    $component = Livewire::test(TestableNoerdListComponent::class);
+/**
+ * Default sorting is list YAML configuration (`defaultSort:`), so the sort
+ * tests write a uniquely named fixture YAML into app-configs/setup/lists/
+ * and clean it up afterwards (same pattern as ListViewsTest).
+ */
+beforeEach(function (): void {
+    $this->sortFixtureFile = base_path('app-configs/setup/lists/zz-default-sort-test-list.yml');
 
-    expect($component->get('sortField'))->toBe('created_at');
-    expect($component->get('sortAsc'))->toBe(false);
+    $this->writeSortFixture = function (string $yaml): void {
+        File::ensureDirectoryExists(dirname($this->sortFixtureFile));
+        File::put($this->sortFixtureFile, $yaml);
+    };
 });
 
-it('sets ascending sort when specified', function (): void {
-    $component = Livewire::test(TestableNoerdListAscComponent::class);
+afterEach(function (): void {
+    File::delete($this->sortFixtureFile);
+});
+
+it('applies the YAML defaultSort when the user has not sorted yet', function (): void {
+    ($this->writeSortFixture)("title: Fixture\ndefaultSort:\n  field: name\n  direction: asc");
+
+    $component = Livewire::test(TestableNoerdListYamlSortComponent::class);
 
     expect($component->get('sortField'))->toBe('name');
     expect($component->get('sortAsc'))->toBe(true);
 });
 
-it('uses default sort when no setDefaultSort is called', function (): void {
+it('defaults the YAML defaultSort direction to descending', function (): void {
+    ($this->writeSortFixture)("title: Fixture\ndefaultSort:\n  field: created_at");
+
+    $component = Livewire::test(TestableNoerdListYamlSortComponent::class);
+
+    expect($component->get('sortField'))->toBe('created_at');
+    expect($component->get('sortAsc'))->toBe(false);
+});
+
+it('lets a session-saved sort win over the YAML defaultSort', function (): void {
+    ($this->writeSortFixture)("title: Fixture\ndefaultSort:\n  field: name\n  direction: asc");
+    session(['listSort.zz-default-sort-test-list' => ['field' => 'email', 'asc' => false]]);
+
+    $component = Livewire::test(TestableNoerdListYamlSortComponent::class);
+
+    expect($component->get('sortField'))->toBe('email');
+    expect($component->get('sortAsc'))->toBe(false);
+});
+
+it('ignores a defaultSort without a field', function (): void {
+    ($this->writeSortFixture)("title: Fixture\ndefaultSort:\n  direction: asc");
+
+    $component = Livewire::test(TestableNoerdListYamlSortComponent::class);
+
+    expect($component->get('sortField'))->toBe('id');
+    expect($component->get('sortAsc'))->toBe(false);
+});
+
+it('sorts by id descending without a defaultSort in the YAML', function (): void {
     $component = Livewire::test(TestableNoerdListDefaultComponent::class);
 
     expect($component->get('sortField'))->toBe('id');
@@ -43,7 +85,9 @@ it('treats only undotted, non-action, allowed columns as sortable', function ():
 });
 
 it('sets the sort direction without changing the sort field', function (): void {
-    $component = Livewire::test(TestableNoerdListComponent::class)
+    ($this->writeSortFixture)("title: Fixture\ndefaultSort:\n  field: created_at");
+
+    $component = Livewire::test(TestableNoerdListYamlSortComponent::class)
         ->call('setSortDirection', true);
 
     expect($component->get('sortField'))->toBe('created_at')
@@ -67,12 +111,11 @@ it('sets the sort direction for a field that is no sortable column', function ()
 });
 
 it('persists the sort direction to the session', function (): void {
-    $component = Livewire::test(TestableNoerdListComponent::class)->call('setSortDirection', true);
+    ($this->writeSortFixture)("title: Fixture\ndefaultSort:\n  field: created_at");
 
-    $componentName = new ReflectionMethod($component->instance(), 'componentName');
-    $componentName->setAccessible(true);
+    Livewire::test(TestableNoerdListYamlSortComponent::class)->call('setSortDirection', true);
 
-    expect(session('listSort.' . $componentName->invoke($component->instance())))
+    expect(session('listSort.zz-default-sort-test-list'))
         ->toBe(['field' => 'created_at', 'asc' => true]);
 });
 
@@ -101,17 +144,15 @@ it('derives select event name from dotted namespaced list component', function (
 });
 
 /**
- * Test component with descending sort.
+ * Test component whose list YAML fixture drives the default sort.
  */
-class TestableNoerdListComponent extends Component
+class TestableNoerdListYamlSortComponent extends Component
 {
     use NoerdList;
 
-    public function mount(): void
-    {
-        $this->mountList();
-        $this->setDefaultSort('created_at', false);
-    }
+    public const COMPONENT = 'zz-default-sort-test-list';
+
+    public const DETAIL_COMPONENT = 'zz-default-sort-test-list';
 
     public function render(): string
     {
@@ -120,26 +161,7 @@ class TestableNoerdListComponent extends Component
 }
 
 /**
- * Test component with ascending sort.
- */
-class TestableNoerdListAscComponent extends Component
-{
-    use NoerdList;
-
-    public function mount(): void
-    {
-        $this->mountList();
-        $this->setDefaultSort('name', true);
-    }
-
-    public function render(): string
-    {
-        return '<div></div>';
-    }
-}
-
-/**
- * Test component without setDefaultSort.
+ * Test component without a list YAML.
  */
 class TestableNoerdListDefaultComponent extends Component
 {


### PR DESCRIPTION
## Summary

Default sorting of a list is now **configuration, not component code**. The list YAML gets a top-level `defaultSort:` block; the component-side APIs are gone (`setDefaultSort()` removed — this PR replaces the previously proposed declared-property approach entirely):

```yaml
title: Users
defaultSort:
  field: name
  direction: asc   # optional, desc when omitted
```

`mountList()` applies the YAML default whenever the user has not sorted the list yet; a user-picked sort is persisted per list in the session and always wins. The sort restore now runs AFTER the view restore, so an alternate list view (`--{key}.yml` — a complete standalone config) may bring its own default order. Without a `defaultSort` key, lists sort by `id` descending.

## Changes

- `NoerdList`: new `applyDefaultSortFromConfig()` reads `defaultSort` from the resolved list config (`getListConfig()`, view-aware and memoized); `setDefaultSort()` is removed
- `noerd-users-list` / `tenants-list`: `mount()` overrides removed; their setup YAMLs now carry `defaultSort` (name, asc)
- `noerd:module` scaffolder: `list-yaml.stub` ships a `defaultSort` example
- Docs (`list-view.md`, `list-search.md`), Boost guideline and `noerd-list-development` skill rewritten to the YAML-only rule
- `ListDetailRouteFallbackTest` now uses `RefreshDatabase` (mount resolves the list config; the config search roots read active tenant apps from the DB)

## Breaking change

`setDefaultSort()` no longer exists. Every module list that called it in `mount()` must move the default sort into its list YAML (both synced copies). All in-house modules are converted alongside this PR; module composer constraints must require the noerd release containing this change before their next tag.

## Tests

- `tests/Traits/NoerdListTest.php` rewritten: YAML fixture drives the default (asc, desc-when-omitted, field-less key ignored), session-saved sort wins, id-desc fallback without YAML
- Full package suite: **1024 passed** (`vendor/bin/pest`), `vendor/bin/pint --test` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTXZ43i6M94sUjkktuv73U