### PR TITLE
Make the list header responsive with a filter drawer, drop .bak copies from config publishing and load the global test helpers through HelperLoader

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,9 +2,10 @@
 # at runtime. NOT excluded on purpose:
 # - demo/        -> read at runtime by noerd:demo (NoerdDemoCommand)
 # - dist/        -> the prebuilt frontend bundle published to public/vendor/noerd
-# - tests/TestCase.php, tests/helpers.php, tests/Traits/
+# - tests/TestCase.php, tests/HelperLoader.php, tests/helpers.php, tests/Traits/
 #                -> public test API for module developers
-#                   (`uses(Noerd\Tests\TestCase::class)` in every module test)
+#                   (`uses(Noerd\Tests\TestCase::class)` in every module test,
+#                    `Noerd\Tests\HelperLoader::load()` for suites that don't)
 /.github            export-ignore
 /docs               export-ignore
 /tests/Commands     export-ignore

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -90,9 +90,8 @@ npm run build     # or: npm run dev
 ```
 
 > Installations created before the brand palette became CSS-first still carry a generated
-> `tailwind.config.js` and a `@config` line in `app.css`. `noerd:update` offers to remove both (a
-> `tailwind.config.js.bak` is kept); a config you customised yourself is only reported, never
-> touched. See [Brand](brand.md).
+> `tailwind.config.js` and a `@config` line in `app.css`. `noerd:update` offers to remove both; a
+> config you customised yourself is only reported, never touched. See [Brand](brand.md).
 
 ## Configuration
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -114,10 +114,25 @@ A test that asserts their current content is wrong by definition.
 
 ## Global helpers
 
-`tests/helpers.php` is loaded by `Noerd\Tests\TestCase` (covering every suite that extends it) and
-by the host project's `tests/Pest.php`, so the helpers are available in every host and module test —
-without shipping test functions in the production composer autoload. New global helpers go there,
-guarded with `function_exists`.
+`tests/helpers.php` is **not** part of the production composer autoload — a consumer app must never
+load test functions on every request — and `autoload-dev` does not help either: composer only dumps
+the dev autoload of the ROOT package, never that of a dependency. The file is therefore loaded
+explicitly, through `Noerd\Tests\HelperLoader`:
+
+- Suites binding `Noerd\Tests\TestCase` get the helpers from that class and need no call.
+- Every other suite (a module test bound to the host's `Tests\TestCase`, the host's own `Feature`
+  suite) loads them once from its `tests/Pest.php`:
+
+```php
+\Noerd\Tests\HelperLoader::load();
+```
+
+`HelperLoader` lives in the package's psr-4 map, so it resolves through the autoloader whether noerd
+is installed as a composer package (`vendor/noerd/noerd/`) or as a git submodule
+(`app-modules/noerd/`) — never hard-code either path, and never add `tests/helpers.php` to a
+project's root `composer.json`. Its own file is only read once something calls it, so nothing test
+related reaches a production request. New global helpers go into `tests/helpers.php`, guarded with
+`function_exists`.
 
 | Helper | Purpose |
 |--------|---------|

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -1087,9 +1087,11 @@ Detail components (`*-detail`) build their validation rules at runtime from the 
 test must never assume a specific field is — or is not — required.** Two global helpers support this:
 `validDetailPayload(Model::class, $overrides)` (a complete factory payload) and
 `requiredLayoutFields($component)` (the required field names from the live `pageLayout`). They live in
-the noerd package (`tests/helpers.php`), loaded by `Noerd\Tests\TestCase` and the host's
-`tests/Pest.php`, so they are available to every host and submodule test (not just the host `Feature`
-suite). When adding a new global test helper, put it there (guarded with `function_exists`).
+the noerd package (`tests/helpers.php`). They are deliberately NOT composer-autoloaded (test
+functions must never load in a production request): suites binding `Noerd\Tests\TestCase` get them
+from that class, every other `tests/Pest.php` loads them once with `\Noerd\Tests\HelperLoader::load();`
+— never a hard-coded path and never an entry in the project's root `composer.json`. When adding a new
+global test helper, put it there (guarded with `function_exists`).
 
 **Store-SUCCESS tests** — submit a COMPLETE payload sourced from the model factory and override only
 the fields the test asserts on. Never hand-pick a minimal subset (it breaks the moment a new field

--- a/resources/boost/skills/noerd-testing/SKILL.md
+++ b/resources/boost/skills/noerd-testing/SKILL.md
@@ -24,7 +24,11 @@ content is wrong by definition:
 - ✓ Architecture guardrails are fine (a detail YAML has no `widgets:`/`relations:`; a page blade
   embeds the `detail:` its YAML names).
 
-## 2. Global helpers (`vendor/noerd/noerd/tests/helpers.php`, autoloaded everywhere)
+## 2. Global helpers (`tests/helpers.php` in the noerd package)
+
+Not composer-autoloaded (test code must never load in production). Suites binding
+`Noerd\Tests\TestCase` get them for free; every other `tests/Pest.php` loads them once with
+`\Noerd\Tests\HelperLoader::load();` — never a hard-coded path, never a root `composer.json` entry.
 
 | Helper | Use |
 |---|---|

--- a/resources/views/components/filters/date-dropdown.blade.php
+++ b/resources/views/components/filters/date-dropdown.blade.php
@@ -1,4 +1,5 @@
-@props(['filter', 'value' => ''])
+{{-- `full` switches the control to the stacked full-width layout of the filter drawer. --}}
+@props(['filter', 'value' => '', 'full' => false])
 
 @php
     $label = $value ? ($filter['options'][$value] ?? $value) : '';
@@ -6,11 +7,13 @@
     $isCustomDate = $active && !isset($filter['options'][$value]);
 @endphp
 
+{{-- The panels are anchored with `position: fixed` so they escape a horizontally scrolling
+     filter bar (an `overflow-x` ancestor clips absolutely positioned children vertically too). --}}
 <div x-data="{ open: false, showDatePicker: false, customDate: '{{ $isCustomDate ? $value : '' }}' }"
      @click.outside="open = false; showDatePicker = false"
-     class="relative mr-4">
-    <button @click="open = !open; showDatePicker = false" type="button"
-            class="{{ $active ? '!border-brand-primary !border-solid !border-2' : 'border border-dashed border-zinc-300' }} flex items-center gap-1 rounded-md px-3 h-8 py-1 text-sm leading-[1.375rem] focus:outline-none focus:ring-2 focus:ring-brand-border whitespace-nowrap">
+     class="relative {{ $full ? 'w-full' : 'mr-4 shrink-0' }}">
+    <button x-ref="trigger_{{ $filter['column'] }}" @click="open = !open; showDatePicker = false" type="button"
+            class="{{ $active ? '!border-brand-primary !border-solid !border-2' : 'border border-dashed border-zinc-300' }} {{ $full ? 'w-full' : '' }} flex items-center gap-1 rounded-md px-3 h-8 py-1 text-sm leading-[1.375rem] focus:outline-none focus:ring-2 focus:ring-brand-border whitespace-nowrap">
         <span>{{ $filter['label'] }}</span>
         @if($active)
             <span class="text-gray-400 mx-0.5">|</span>
@@ -22,7 +25,8 @@
     </button>
     {{-- Main dropdown --}}
     <div x-show="open" x-cloak x-transition
-         class="absolute left-0 z-50 mt-1 w-48 origin-top-left rounded-md bg-white py-1 shadow-lg ring-1 ring-black/5 focus:outline-hidden">
+         x-anchor.fixed.bottom-start.offset.4="$refs.trigger_{{ $filter['column'] }}"
+         class="z-50 w-48 origin-top-left rounded-md bg-white py-1 shadow-lg ring-1 ring-black/5 focus:outline-hidden">
         @foreach($filter['options'] ?? [] as $key => $option)
             <button type="button"
                     wire:click="$set('listFilters.{{ $filter['column'] }}', '{{ $key }}')"
@@ -43,7 +47,7 @@
         </div>
     </div>
     {{-- Date picker sub-panel --}}
-    <div x-show="open && showDatePicker" x-cloak x-transition x-anchor.right-start="$refs.dateBtn_{{ $filter['column'] }}"
+    <div x-show="open && showDatePicker" x-cloak x-transition x-anchor.fixed.right-start="$refs.dateBtn_{{ $filter['column'] }}"
          class="z-50 ml-1 w-56 rounded-md bg-white p-4 shadow-lg ring-1 ring-black/5 focus:outline-hidden">
         <input type="date" x-model="customDate"
                class="w-full rounded-md border border-zinc-300 px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-brand-border" />

--- a/resources/views/components/filters/picklist.blade.php
+++ b/resources/views/components/filters/picklist.blade.php
@@ -1,8 +1,9 @@
-@props(['filter', 'value' => ''])
+{{-- `full` switches the control to the stacked full-width layout of the filter drawer. --}}
+@props(['filter', 'value' => '', 'full' => false])
 
 <select wire:change="storeActiveListFilters"
         wire:model.live="listFilters.{{ $filter['column'] }}"
-        class="@if($value !== '') !border-brand-primary !border-solid !border-2 @endif mr-4 min-w-36 max-w-48 truncate rounded-md border border-dashed border-zinc-300 px-3 h-8 py-1 pr-8 text-sm leading-[1.375rem] focus:outline-none focus:ring-2 focus:ring-brand-border">
+        class="@if($value !== '') !border-brand-primary !border-solid !border-2 @endif {{ $full ? 'w-full' : 'mr-4 min-w-36 max-w-48 shrink-0' }} truncate rounded-md border border-dashed border-zinc-300 px-3 h-8 py-1 pr-8 text-sm leading-[1.375rem] focus:outline-none focus:ring-2 focus:ring-brand-border">
     <option value="">{{ $filter['label'] }}</option>
     @foreach($filter['options'] ?? [] as $key => $option)
         <option value="{{ $key }}">{{ $option }}</option>

--- a/resources/views/components/table/list-filters.blade.php
+++ b/resources/views/components/table/list-filters.blade.php
@@ -1,0 +1,71 @@
+{{-- The list header's filter controls, rendered twice from list-header: once inline in the
+     header row and once inside the filter drawer that takes over when the header row runs out
+     of space. Both copies bind to the same `listFilters` properties, so either one drives the
+     list. `$keyPrefix` keeps the wire:key of the chips unique between the two copies, `$stacked`
+     switches the controls to the full-width drawer layout. --}}
+@php
+    $stacked ??= false;
+    $keyPrefix ??= '';
+@endphp
+
+@foreach ($tableFilters as $tableFilter)
+    @if (in_array($tableFilter['type'] ?? 'Picklist', ['ShowFrom', 'ShowUntil']))
+        <x-noerd::filters.date-dropdown
+            :filter="$tableFilter"
+            :value="$listFilters[$tableFilter['column']] ?? ''"
+            :full="$stacked"
+        />
+    @else
+        <x-noerd::filters.picklist
+            :filter="$tableFilter"
+            :value="$listFilters[$tableFilter['column']] ?? ''"
+            :full="$stacked"
+        />
+    @endif
+@endforeach
+
+@foreach ($chips as $filterChip)
+    <span
+        wire:key="{{ $keyPrefix }}column-filter-chip-{{ $filterChip['field'] }}"
+        @class([
+            'flex shrink-0 items-center gap-1 rounded-full bg-gray-100 py-0.5 pr-1 pl-2.5 text-xs font-normal whitespace-nowrap text-gray-700',
+            'w-full justify-start' => $stacked,
+        ])
+    >
+        <span class="font-medium">{{ $filterChip['label'] }}:</span>
+        <span class="{{ $stacked ? 'truncate' : '' }}">{{ $filterChip['value'] }}</span>
+        <button
+            type="button"
+            wire:click="clearColumnFilter('{{ $filterChip['field'] }}')"
+            title="{{ __('Clear filter') }}"
+            class="ml-auto rounded-full p-0.5 text-gray-500 hover:bg-gray-200 hover:text-gray-700"
+        >
+            <x-dynamic-component component="heroicons::mini.solid.x-mark" class="size-3" />
+        </button>
+    </span>
+@endforeach
+
+@if ($hasClearAll)
+    @if ($stacked)
+        <x-noerd::button
+            variant="secondary"
+            size="sm"
+            icon="x-mark"
+            type="button"
+            class="w-full"
+            wire:click="clearAllListFilters"
+        >
+            {{ __('Clear all filters') }}
+        </x-noerd::button>
+    @else
+        <x-noerd::button
+            class="shrink-0"
+            variant="icon"
+            size="sm"
+            icon="x-mark"
+            type="button"
+            wire:click="clearAllListFilters"
+            :title="__('Clear all filters')"
+        />
+    @endif
+@endif

--- a/resources/views/components/table/list-header.blade.php
+++ b/resources/views/components/table/list-header.blade.php
@@ -4,102 +4,182 @@
          this file only contributes the title, count, view switcher and the
          filter chips. Relations are forwarded for YAML `action:` buttons. --}}
     <x-noerd::modal-title :listRelations="$relations ?? []">
-        <div class="pb-3 lg:pb-0">
-            @if (count($listViews ?? []) > 1)
-                {{-- List-view switcher: pick one of several YAML views for this list --}}
-                <div x-data="{ open: false }" class="relative">
-                    <button
-                        type="button"
-                        x-on:click="open = ! open"
-                        x-on:click.outside="open = false"
-                        class="flex items-center gap-1 rounded focus:outline-hidden"
-                        :aria-expanded="open"
-                        aria-haspopup="true"
-                        title="{{ __('Switch list view') }}"
-                    >
-                        {{ $title }}
-                        @if (isset($rows) && ! is_array($rows))
-                            <span class="font-light">({{ $rows->total() }})</span>
-                        @endif
-                        <x-noerd::icons.chevron-down class="my-auto text-gray-500" />
-                    </button>
-                    <div
-                        x-show="open"
-                        x-transition
-                        x-cloak
-                        class="absolute left-0 z-90 mt-2 w-56 origin-top-left rounded-md bg-white py-1 shadow-lg ring-1 ring-black/5 focus:outline-hidden"
-                        role="menu"
-                        aria-orientation="vertical"
-                    >
-                        @foreach ($listViews as $viewKey => $view)
-                            <button
-                                type="button"
-                                role="menuitem"
-                                wire:click="switchListView('{{ $viewKey }}')"
-                                x-on:click="open = false"
-                                class="block w-full px-4 py-2 text-left text-sm {{ $viewKey === $activeListView ? 'font-semibold text-gray-900' : 'font-normal text-gray-700' }} hover:bg-gray-50"
-                            >
-                                {{ __($view['title']) }}
-                                <span class="opacity-50">({{ $view['appLabel'] }})</span>
-                            </button>
-                        @endforeach
-                    </div>
-                </div>
-            @else
-                {{ $title }}
-                @if (isset($rows) && ! is_array($rows))
-                    <span class="font-light"> ({{ $rows->total() }}) </span>
-                @endif
-            @endif
-        </div>
-
         @php
             $activeColumnFilterChips = $this->activeColumnFilterChips;
+            $hasListFilters = (bool) $this->tableFilters || $activeColumnFilterChips !== [];
+            $hasClearAllFilters = collect($this->listFilters)->filter()->isNotEmpty() || count($activeColumnFilterChips) > 1;
+            $activeFilterCount = collect($this->listFilters)->filter()->count() + count($activeColumnFilterChips);
         @endphp
-        @if ($this->tableFilters || $activeColumnFilterChips !== [])
-            <div class="ml-4 flex flex-wrap items-center gap-1">
-                @foreach ($this->tableFilters as $tableFilter)
-                    @if (in_array($tableFilter['type'] ?? 'Picklist', ['ShowFrom', 'ShowUntil']))
-                        <x-noerd::filters.date-dropdown
-                            :filter="$tableFilter"
-                            :value="$this->listFilters[$tableFilter['column']] ?? ''"
-                        />
+
+        {{-- Title + filters share one flex track so the filters can claim the leftover width;
+             the list controls injected by modal-title keep their ml-auto to the right of it. --}}
+        <div
+            class="min-w-0 lg:flex lg:flex-1 lg:items-center"
+            @if ($hasListFilters)
+                {{-- The filters never wrap onto a second line. `filterRow` is clipped to the
+                     space it gets, so `scrollWidth > clientWidth` tells us the filters no longer
+                     fit — the row then goes invisible (it keeps its box so it stays measurable)
+                     and the funnel button next to the title opens them in a right-hand drawer.
+                     Collapsing only ever frees width (the button is narrower than the row), so
+                     the two states cannot oscillate. --}}
+                x-data="{
+                    collapsed: false,
+                    drawerOpen: false,
+                    measure() {
+                        const row = this.$refs.filterRow;
+                        if (! row) { return; }
+                        this.collapsed = row.scrollWidth > row.clientWidth + 1;
+                        if (! this.collapsed) { this.drawerOpen = false; }
+                    },
+                    init() {
+                        this.$nextTick(() => this.measure());
+                        new ResizeObserver(() => this.measure()).observe(this.$refs.filterRow);
+                        new MutationObserver(() => this.measure()).observe(this.$refs.filterRow, {
+                            childList: true,
+                            subtree: true,
+                            characterData: true,
+                        });
+                    },
+                }"
+            @endif
+        >
+            <div class="flex min-w-0 shrink-0 items-center gap-2 pb-3 lg:pb-0">
+                <div class="min-w-0">
+                    @if (count($listViews ?? []) > 1)
+                        {{-- List-view switcher: pick one of several YAML views for this list --}}
+                        <div x-data="{ open: false }" class="relative">
+                            <button
+                                type="button"
+                                x-on:click="open = ! open"
+                                x-on:click.outside="open = false"
+                                class="flex items-center gap-1 rounded focus:outline-hidden"
+                                :aria-expanded="open"
+                                aria-haspopup="true"
+                                title="{{ __('Switch list view') }}"
+                            >
+                                {{ $title }}
+                                @if (isset($rows) && ! is_array($rows))
+                                    <span class="font-light">({{ $rows->total() }})</span>
+                                @endif
+                                <x-noerd::icons.chevron-down class="my-auto text-gray-500" />
+                            </button>
+                            <div
+                                x-show="open"
+                                x-transition
+                                x-cloak
+                                class="absolute left-0 z-90 mt-2 w-56 origin-top-left rounded-md bg-white py-1 shadow-lg ring-1 ring-black/5 focus:outline-hidden"
+                                role="menu"
+                                aria-orientation="vertical"
+                            >
+                                @foreach ($listViews as $viewKey => $view)
+                                    <button
+                                        type="button"
+                                        role="menuitem"
+                                        wire:click="switchListView('{{ $viewKey }}')"
+                                        x-on:click="open = false"
+                                        class="block w-full px-4 py-2 text-left text-sm {{ $viewKey === $activeListView ? 'font-semibold text-gray-900' : 'font-normal text-gray-700' }} hover:bg-gray-50"
+                                    >
+                                        {{ __($view['title']) }}
+                                        <span class="opacity-50">({{ $view['appLabel'] }})</span>
+                                    </button>
+                                @endforeach
+                            </div>
+                        </div>
                     @else
-                        <x-noerd::filters.picklist
-                            :filter="$tableFilter"
-                            :value="$this->listFilters[$tableFilter['column']] ?? ''"
-                        />
+                        {{ $title }}
+                        @if (isset($rows) && ! is_array($rows))
+                            <span class="font-light"> ({{ $rows->total() }}) </span>
+                        @endif
                     @endif
-                @endforeach
-                @foreach ($activeColumnFilterChips as $filterChip)
-                    <span
-                        wire:key="column-filter-chip-{{ $filterChip['field'] }}"
-                        class="flex items-center gap-1 rounded-full bg-gray-100 py-0.5 pr-1 pl-2.5 text-xs font-normal whitespace-nowrap text-gray-700"
-                    >
-                        <span class="font-medium">{{ $filterChip['label'] }}:</span>
-                        {{ $filterChip['value'] }}
-                        <button
-                            type="button"
-                            wire:click="clearColumnFilter('{{ $filterChip['field'] }}')"
-                            title="{{ __('Clear filter') }}"
-                            class="rounded-full p-0.5 text-gray-500 hover:bg-gray-200 hover:text-gray-700"
-                        >
-                            <x-dynamic-component component="heroicons::mini.solid.x-mark" class="size-3" />
-                        </button>
-                    </span>
-                @endforeach
-                @if (collect($this->listFilters)->filter()->isNotEmpty() || count($activeColumnFilterChips) > 1)
-                    <x-noerd::button
-                        variant="icon"
-                        size="sm"
-                        icon="x-mark"
+                </div>
+
+                @if ($hasListFilters)
+                    {{-- Only rendered while the inline row cannot show the filters. --}}
+                    <button
                         type="button"
-                        wire:click="clearAllListFilters"
-                        :title="__('Clear all filters')"
-                    />
+                        x-show="collapsed"
+                        x-cloak
+                        x-on:click="drawerOpen = true"
+                        class="relative inline-flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-sm border border-gray-300 text-gray-700 transition hover:bg-gray-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden"
+                        :aria-expanded="drawerOpen"
+                        title="{{ __('Filters') }}"
+                    >
+                        <span class="sr-only">{{ __('Filters') }}</span>
+                        <x-dynamic-component component="heroicons::outline.funnel" class="size-4" />
+                        @if ($activeFilterCount > 0)
+                            <span class="absolute -top-1.5 -right-1.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-brand-primary px-1 text-[10px] leading-none font-semibold text-brand-primary-text">
+                                {{ $activeFilterCount }}
+                            </span>
+                        @endif
+                    </button>
                 @endif
             </div>
-        @endif
+
+            @if ($hasListFilters)
+                <div
+                    x-ref="filterRow"
+                    class="ml-4 flex min-w-0 flex-1 items-center gap-1 overflow-hidden"
+                    :class="collapsed ? 'invisible pointer-events-none' : ''"
+                >
+                    @include('noerd::components.table.list-filters', [
+                        'tableFilters' => $this->tableFilters,
+                        'listFilters' => $this->listFilters,
+                        'chips' => $activeColumnFilterChips,
+                        'hasClearAll' => $hasClearAllFilters,
+                    ])
+                </div>
+
+                {{-- Filter drawer: the same controls, stacked, sliding in from the right. Sits
+                     above the modal stack (z-50/z-[60]) so a list opened as a modal keeps it. --}}
+                <div x-show="drawerOpen" x-cloak class="fixed inset-0 z-[70]" role="dialog" aria-modal="true">
+                    <div
+                        x-show="drawerOpen"
+                        x-transition:enter="transition ease-out duration-200"
+                        x-transition:enter-start="opacity-0"
+                        x-transition:enter-end="opacity-100"
+                        x-transition:leave="transition ease-in duration-150"
+                        x-transition:leave-start="opacity-100"
+                        x-transition:leave-end="opacity-0"
+                        x-on:click="drawerOpen = false"
+                        class="absolute inset-0 bg-gray-800/50"
+                    ></div>
+                    <div
+                        x-show="drawerOpen"
+                        x-on:keydown.escape.window="drawerOpen = false"
+                        x-transition:enter="transition transform ease-out duration-200"
+                        x-transition:enter-start="translate-x-full"
+                        x-transition:enter-end="translate-x-0"
+                        x-transition:leave="transition transform ease-in duration-150"
+                        x-transition:leave-start="translate-x-0"
+                        x-transition:leave-end="translate-x-full"
+                        class="absolute inset-y-0 right-0 flex w-80 max-w-full flex-col bg-white shadow-xl"
+                    >
+                        <div class="flex items-center border-b border-gray-300 px-6 py-6">
+                            <span class="font-semibold text-slate-900">{{ __('Filters') }}</span>
+                            <button
+                                type="button"
+                                x-on:click="drawerOpen = false"
+                                class="ml-auto inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-sm border border-gray-300 text-gray-700 transition hover:bg-gray-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden"
+                                title="{{ __('Close') }}"
+                            >
+                                <span class="sr-only">{{ __('Close') }}</span>
+                                <x-dynamic-component component="heroicons::mini.solid.x-mark" class="size-4" />
+                            </button>
+                        </div>
+                        <div class="flex flex-1 flex-col items-stretch gap-3 overflow-y-auto px-6 py-6 text-sm font-normal">
+                            @include('noerd::components.table.list-filters', [
+                                'tableFilters' => $this->tableFilters,
+                                'listFilters' => $this->listFilters,
+                                'chips' => $activeColumnFilterChips,
+                                'hasClearAll' => $hasClearAllFilters,
+                                'stacked' => true,
+                                'keyPrefix' => 'drawer-',
+                            ])
+                        </div>
+                    </div>
+                </div>
+            @endif
+        </div>
 
     </x-noerd::modal-title>
 </x-slot:header>

--- a/src/Commands/Concerns/PublishesConfigDirectory.php
+++ b/src/Commands/Concerns/PublishesConfigDirectory.php
@@ -10,9 +10,9 @@ use RecursiveIteratorIterator;
  * The single recursive config-publishing implementation shared by
  * noerd:install/noerd:update and the module install commands — previously two
  * divergent ~65-line copies. Existing files prompt skip/overwrite/overwrite-all
- * (or are overwritten under --force), and every overwrite first writes a
- * one-generation `.bak` next to the file, so an update can never destroy a
- * host customization irrecoverably.
+ * (or are overwritten under --force). Overwrites leave no `.bak` behind: the
+ * published configs live in the host repository, so version control is the
+ * change history.
  */
 trait PublishesConfigDirectory
 {
@@ -88,9 +88,6 @@ trait PublishesConfigDirectory
                         $this->input->setOption('force', true);
                     }
                 }
-
-                // One-generation backup so --force can always be undone.
-                @copy($targetPath, $targetPath . '.bak');
 
                 $this->line("<comment>Overwriting:</comment> {$displayPath}");
                 $results['overwritten_files']++;

--- a/src/Commands/NoerdInstallCommand.php
+++ b/src/Commands/NoerdInstallCommand.php
@@ -278,7 +278,7 @@ class NoerdInstallCommand extends Command
 
         $scaffolder->removeLegacyTailwindBridge();
 
-        $this->line('<info>Removed tailwind.config.js (backed up as tailwind.config.js.bak) and its @config line.</info>');
+        $this->line('<info>Removed tailwind.config.js and its @config line.</info>');
     }
 
     /**
@@ -448,8 +448,9 @@ class NoerdInstallCommand extends Command
      * An existing config/noerd.php belongs to the host — never clobber it
      * silently. The stub is diffed against it: missing top-level keys are
      * reported (the documented contract is that noerd:update carries new keys
-     * into existing installations), and an overwrite — via --force or an
-     * explicit confirmation — first writes a one-generation .bak backup.
+     * into existing installations), and an overwrite happens only via --force
+     * or an explicit confirmation. No .bak is written — the host config is
+     * under version control.
      */
     protected function refreshExistingNoerdConfig(string $sourcePath, string $targetPath): void
     {
@@ -474,15 +475,14 @@ class NoerdInstallCommand extends Command
             $this->warn('config/noerd.php is missing new top-level keys: ' . implode(', ', $missing));
 
             if (!$this->input->isInteractive()
-                || !$this->confirm('Overwrite config/noerd.php with the current stub (a .bak backup is written)?', false)) {
+                || !$this->confirm('Overwrite config/noerd.php with the current stub?', false)) {
                 $this->line('<comment>Skipped config/noerd.php publishing. Add the missing keys manually (see stubs/noerd.php.stub).</comment>');
 
                 return;
             }
         }
 
-        @copy($targetPath, $targetPath . '.bak');
-        $this->line('<comment>Overwriting config/noerd.php (backup: config/noerd.php.bak)...</comment>');
+        $this->line('<comment>Overwriting config/noerd.php...</comment>');
 
         if (copy($sourcePath, $targetPath)) {
             $this->line('<info>Published config/noerd.php successfully.</info>');

--- a/src/Services/FrontendScaffolder.php
+++ b/src/Services/FrontendScaffolder.php
@@ -172,14 +172,14 @@ final class FrontendScaffolder
     }
 
     /**
-     * Remove the obsolete tailwind.config.js bridge, keeping a .bak copy of the config.
+     * Remove the obsolete tailwind.config.js bridge. No .bak copy is kept — the
+     * host project keeps its change history in version control.
      */
     public function removeLegacyTailwindBridge(): void
     {
         $configPath = $this->path('tailwind.config.js');
 
         if (file_exists($configPath)) {
-            copy($configPath, $configPath . '.bak');
             unlink($configPath);
         }
 

--- a/src/Traits/NoerdPage.php
+++ b/src/Traits/NoerdPage.php
@@ -116,6 +116,14 @@ trait NoerdPage
 
     public function initPage(): void
     {
+        // The page YAML (pages/{name}.yml) is OPTIONAL — hand-built pages keep
+        // defining their layout in the component itself. It is loaded even when
+        // the guarded init below bails out (read-denied object, stale record id):
+        // Blade evaluates a page blade's slot content before the page chrome
+        // discards it for the denied state, so a hand-built page reading
+        // $pageLayout['detail'] must always find its layout.
+        $this->pageLayout = StaticConfigHelper::getPageFields($this->getName(), $this->detailModel ?? null);
+
         $this->initNoerdComponent(function (): void {
             // Pages backed by a single Eloquent model declare $detailModel — the
             // record is loaded into $detailData exactly like a detail would.
@@ -125,10 +133,6 @@ trait NoerdPage
                     return;
                 }
             }
-
-            // The page YAML (pages/{name}.yml) is OPTIONAL — hand-built pages keep
-            // defining their layout in the component itself.
-            $this->pageLayout = StaticConfigHelper::getPageFields($this->getName(), $this->detailModel ?? null);
 
             $this->resolveQuickCreate();
         });

--- a/tests/Commands/FrontendScaffolderTest.php
+++ b/tests/Commands/FrontendScaffolderTest.php
@@ -359,7 +359,7 @@ describe('legacy tailwind config migration', function (): void {
             ->and($this->scaffolder->legacyTailwindConfigIsUnmodified())->toBeFalse();
     });
 
-    it('removes every @config occurrence, keeping a backup', function (): void {
+    it('removes every @config occurrence without leaving a backup', function (): void {
         // The old updateAppCss() appended its block at EOF regardless of an existing @config line,
         // so long-lived projects carry the directive twice — and possibly double-quoted.
         writeScaffoldFile('resources/css/app.css', implode(PHP_EOL, [
@@ -374,7 +374,7 @@ describe('legacy tailwind config migration', function (): void {
         $this->scaffolder->removeLegacyTailwindBridge();
 
         expect(File::exists(scaffoldPath('tailwind.config.js')))->toBeFalse()
-            ->and(File::exists(scaffoldPath('tailwind.config.js.bak')))->toBeTrue();
+            ->and(File::exists(scaffoldPath('tailwind.config.js.bak')))->toBeFalse();
 
         $css = File::get(scaffoldPath('resources/css/app.css'));
 

--- a/tests/Commands/NoerdConfigPublishTest.php
+++ b/tests/Commands/NoerdConfigPublishTest.php
@@ -12,7 +12,8 @@ uses(TestCase::class);
 /*
  | publishNoerdConfig() must never clobber a host's config/noerd.php silently:
  | an existing file is diffed against the stub, missing top-level keys are
- | reported, and an overwrite writes a .bak backup first.
+ | reported, and an overwrite leaves no .bak behind (the host config is under
+ | version control).
  */
 
 class ConfigPublishFixtureCommand extends NoerdInstallCommand
@@ -74,13 +75,13 @@ it('reports missing top-level keys and keeps the file without --force', function
     expect(File::get($this->configPath))->toContain("['prefix' => 'noerd']");
 });
 
-it('overwrites with --force and writes a .bak backup', function (): void {
+it('overwrites with --force without writing a .bak backup', function (): void {
     File::put($this->configPath, "<?php\n\nreturn ['routes' => ['prefix' => 'custom']];\n");
 
     $this->artisan('test:config-publish', ['--force' => true, '--no-interaction' => true])
-        ->expectsOutputToContain('backup: config/noerd.php.bak')
+        ->expectsOutputToContain('Published config/noerd.php successfully.')
         ->assertExitCode(0);
 
-    expect(File::get($this->configPath . '.bak'))->toContain("'prefix' => 'custom'")
+    expect(File::exists($this->configPath . '.bak'))->toBeFalse()
         ->and(File::get($this->configPath))->not->toContain("'prefix' => 'custom'");
 });

--- a/tests/Commands/PublishConfigDirectoryTest.php
+++ b/tests/Commands/PublishConfigDirectoryTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Support\Facades\File;
+use Noerd\Commands\Concerns\PublishesConfigDirectory;
+use Noerd\Tests\TestCase;
+
+uses(TestCase::class);
+
+/*
+ | publishConfigDirectory() overwrites an existing host config file in place and
+ | leaves no `.bak` sibling behind — the published YAMLs live in the host
+ | repository, so version control is the change history.
+ */
+
+class PublishConfigDirectoryFixtureCommand extends Command
+{
+    use PublishesConfigDirectory;
+
+    public static string $sourceDir = '';
+    public static string $targetDir = '';
+    protected $signature = 'test:publish-config-directory {--force : Overwrite existing files}';
+
+    public function handle(): int
+    {
+        $this->publishConfigDirectory(static::$sourceDir, static::$targetDir);
+
+        return 0;
+    }
+}
+
+beforeEach(function (): void {
+    $this->app[Kernel::class]->registerCommand(new PublishConfigDirectoryFixtureCommand());
+
+    $base = base_path('storage/framework/testing/publish-config-directory');
+    File::deleteDirectory($base);
+
+    PublishConfigDirectoryFixtureCommand::$sourceDir = $base . '/source';
+    PublishConfigDirectoryFixtureCommand::$targetDir = $base . '/target';
+
+    File::ensureDirectoryExists(PublishConfigDirectoryFixtureCommand::$sourceDir . '/lists');
+    File::put(PublishConfigDirectoryFixtureCommand::$sourceDir . '/lists/accounts-list.yml', "title: Accounts\n");
+});
+
+afterEach(function (): void {
+    File::deleteDirectory(base_path('storage/framework/testing/publish-config-directory'));
+});
+
+it('copies a new config file', function (): void {
+    $this->artisan('test:publish-config-directory', ['--no-interaction' => true])
+        ->assertExitCode(0);
+
+    expect(File::get(PublishConfigDirectoryFixtureCommand::$targetDir . '/lists/accounts-list.yml'))
+        ->toBe("title: Accounts\n");
+});
+
+it('overwrites an existing config file without writing a .bak backup', function (): void {
+    $target = PublishConfigDirectoryFixtureCommand::$targetDir . '/lists/accounts-list.yml';
+    File::ensureDirectoryExists(dirname($target));
+    File::put($target, "title: Host customization\n");
+
+    $this->artisan('test:publish-config-directory', ['--force' => true, '--no-interaction' => true])
+        ->assertExitCode(0);
+
+    expect(File::get($target))->toBe("title: Accounts\n")
+        ->and(File::exists($target . '.bak'))->toBeFalse();
+});

--- a/tests/Feature/PageReadBlockedLayoutTest.php
+++ b/tests/Feature/PageReadBlockedLayoutTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Component;
+use Livewire\Livewire;
+use Noerd\Helpers\AccessHelper;
+use Noerd\Models\NoerdUser;
+use Noerd\Models\Tenant;
+use Noerd\Tests\TestCase;
+use Noerd\Traits\NoerdPage;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+/*
+ | Hand-built page blades read the embedded detail name unguarded from the page
+ | layout ($pageLayout['detail']) — and Blade evaluates that slot content even
+ | when the page chrome discards it for the object-access-denied state. The page
+ | layout therefore must be loaded even when the guarded init bails out
+ | (read-denied object, stale record id) instead of crashing the render with
+ | "Undefined array key 'detail'".
+ */
+
+class ZzReadBlockedPage extends Component
+{
+    use NoerdPage;
+
+    public $detailModel = Tenant::class;
+
+    public ?string $detailPrimary = 'tenantId';
+
+    public function render(): string
+    {
+        // Mirrors the hand-built page blades: the detail name is read UNGUARDED.
+        return '<div>{{ $pageLayout[\'detail\'] }}</div>';
+    }
+}
+
+beforeEach(function (): void {
+    $this->actingAs(NoerdUser::factory()->adminUser()->withSelectedApp('setup')->create());
+
+    Livewire::component('zz-read-blocked-page', ZzReadBlockedPage::class);
+
+    File::ensureDirectoryExists(base_path('app-configs/setup/pages'));
+    File::put(
+        base_path('app-configs/setup/pages/zz-read-blocked-page.yml'),
+        "title: Fixture Page\ndetail: noerd::zz-read-blocked-detail\n",
+    );
+});
+
+afterEach(function (): void {
+    File::delete(base_path('app-configs/setup/pages/zz-read-blocked-page.yml'));
+});
+
+it('keeps the page layout loaded when the object read gate denies', function (): void {
+    Gate::define(AccessHelper::OBJECT_READ_GATE, fn(?NoerdUser $user, string $modelClass): bool => false);
+
+    Livewire::test('zz-read-blocked-page')
+        ->assertSet('objectReadBlocked', true)
+        ->assertSee('noerd::zz-read-blocked-detail');
+});
+
+it('keeps the page layout loaded when the record id no longer resolves', function (): void {
+    Livewire::test('zz-read-blocked-page', ['modelId' => 999999])
+        ->assertSet('modelId', null)
+        ->assertSee('noerd::zz-read-blocked-detail');
+});
+
+it('loads the record and the page layout when reading is allowed', function (): void {
+    $tenant = Tenant::factory()->create(['name' => 'Readable Tenant']);
+
+    Livewire::test('zz-read-blocked-page', ['modelId' => $tenant->id])
+        ->assertSet('objectReadBlocked', false)
+        ->assertSet('detailData.name', 'Readable Tenant')
+        ->assertSee('noerd::zz-read-blocked-detail');
+});

--- a/tests/HelperLoader.php
+++ b/tests/HelperLoader.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noerd\Tests;
+
+/**
+ * Loads the global test helpers from `tests/helpers.php`.
+ *
+ * The helpers are deliberately NOT part of the production composer autoload —
+ * a consumer application must never load test functions on every request — and
+ * `autoload-dev` does not help either, because composer only ever dumps the
+ * dev autoload of the ROOT package, not of a dependency. Consumers therefore
+ * need an explicit load, and the path differs per installation
+ * (`vendor/noerd/noerd/tests/` vs. `app-modules/noerd/tests/` for a submodule).
+ *
+ * This class lives in the package's regular psr-4 map (`Noerd\Tests\`), so it
+ * resolves through the autoloader in both layouts while its file — and with it
+ * `helpers.php` — is only ever read once something asks for it:
+ *
+ *     // tests/Pest.php of the host application or of any module
+ *     \Noerd\Tests\HelperLoader::load();
+ *
+ * Suites that bind `Noerd\Tests\TestCase` get the helpers through that class
+ * and need no call of their own.
+ */
+final class HelperLoader
+{
+    /**
+     * Make the global test helpers available. Safe to call repeatedly — the
+     * file is included once and every helper is `function_exists`-guarded.
+     */
+    public static function load(): void
+    {
+        require_once __DIR__ . '/helpers.php';
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,13 +4,6 @@ declare(strict_types=1);
 
 namespace Noerd\Tests;
 
-// The global test helpers ship with the package but are NOT in the production
-// autoload (a consumer app must never load test functions per request). Loading
-// them here covers every context that runs noerd-based tests: the package's own
-// suite, host-root runs and submodule testbench suites — they all extend this
-// TestCase. Each helper is function_exists-guarded, so double-loading is safe.
-require_once __DIR__ . '/helpers.php';
-
 use Illuminate\Foundation\Testing\RefreshDatabaseState;
 use Illuminate\Support\Facades\File;
 use Livewire\Livewire;
@@ -22,6 +15,14 @@ use Orchestra\Testbench\TestCase as BaseTestCase;
 use PDO;
 use Throwable;
 use WireUi\Heroicons\HeroiconsServiceProvider;
+
+// The global test helpers ship with the package but are NOT in the production
+// autoload (a consumer app must never load test functions per request). Loading
+// them here covers every context that runs noerd-based tests through this
+// TestCase: the package's own suite, host-root runs and submodule testbench
+// suites. Suites that bind a different TestCase call HelperLoader::load()
+// themselves from their tests/Pest.php.
+HelperLoader::load();
 
 abstract class TestCase extends BaseTestCase
 {

--- a/tests/Traits/NoerdListColumnFilterTest.php
+++ b/tests/Traits/NoerdListColumnFilterTest.php
@@ -526,6 +526,43 @@ it('renders active column filter chips in the list header', function (): void {
         ->toContain('clearColumnFilter');
 });
 
+it('renders the header filters in a clipped single-line row that collapses into a drawer', function (): void {
+    $tenant = Tenant::factory()->create();
+    $user = NoerdUser::factory()->create();
+    TenantHelper::setSelectedTenantId($tenant->id);
+    TenantHelper::setSelectedApp('SETUP');
+    test()->actingAs($user);
+
+    $html = Livewire::test(TestableColumnFilterPageRenderComponent::class)
+        ->call('setColumnFilter', 'name', 'rot')
+        ->html();
+
+    preg_match('/<div\s+x-ref="filterRow"\s+class="([^"]*)"/', $html, $row);
+
+    expect($row[1] ?? '')->toContain('overflow-hidden')
+        ->not->toContain('flex-wrap');
+
+    // Collapsing is measured on the row and toggles the funnel button + drawer copy.
+    expect($html)->toContain('row.scrollWidth > row.clientWidth')
+        ->toContain('x-show="collapsed"')
+        ->toContain('drawerOpen = true');
+});
+
+it('renders every header filter a second time inside the drawer with distinct keys', function (): void {
+    $tenant = Tenant::factory()->create();
+    $user = NoerdUser::factory()->create();
+    TenantHelper::setSelectedTenantId($tenant->id);
+    TenantHelper::setSelectedApp('SETUP');
+    test()->actingAs($user);
+
+    $html = Livewire::test(TestableColumnFilterPageRenderComponent::class)
+        ->call('setColumnFilter', 'name', 'rot')
+        ->html();
+
+    expect(mb_substr_count($html, 'column-filter-chip-name'))->toBe(2);
+    expect($html)->toContain('drawer-column-filter-chip-name');
+});
+
 /**
  * List component with an inline YAML config over the noerd_users table.
  */

--- a/tests/Unit/TestHelperLoaderTest.php
+++ b/tests/Unit/TestHelperLoaderTest.php
@@ -45,11 +45,11 @@ it('ships the loader and the helpers in dist archives', function (): void {
 
     $ignored = [];
     foreach ($lines as $line) {
-        $line = trim($line);
+        $line = mb_trim($line);
         if (str_starts_with($line, '#') || ! str_contains($line, 'export-ignore')) {
             continue;
         }
-        $ignored[] = ltrim((string) strtok($line, " \t"), '/');
+        $ignored[] = mb_ltrim((string) strtok($line, " \t"), '/');
     }
 
     foreach (['tests/HelperLoader.php', 'tests/helpers.php', 'tests/TestCase.php'] as $path) {

--- a/tests/Unit/TestHelperLoaderTest.php
+++ b/tests/Unit/TestHelperLoaderTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use Noerd\Tests\HelperLoader;
+
+/*
+ | The global test helpers must stay out of the production autoload, but must
+ | still be reachable from a consuming project regardless of how noerd is
+ | installed (composer package vs. git submodule). HelperLoader is that single
+ | entry point — these tests pin both halves of the contract.
+ */
+
+it('exposes the global test helpers', function (): void {
+    HelperLoader::load();
+
+    expect(function_exists('validDetailPayload'))->toBeTrue()
+        ->and(function_exists('requiredLayoutFields'))->toBeTrue()
+        ->and(function_exists('registerTestLivewireRoute'))->toBeTrue();
+});
+
+it('is idempotent', function (): void {
+    HelperLoader::load();
+    HelperLoader::load();
+
+    expect(function_exists('validDetailPayload'))->toBeTrue();
+});
+
+it('resolves the helper file through the autoloader, not through a fixed path', function (): void {
+    $loaderFile = (new ReflectionClass(HelperLoader::class))->getFileName();
+
+    expect($loaderFile)->not->toBeFalse()
+        ->and(file_exists(dirname((string) $loaderFile) . '/helpers.php'))->toBeTrue();
+});
+
+it('keeps the helpers out of the production composer autoload', function (): void {
+    $composer = json_decode((string) file_get_contents(dirname(__DIR__, 2) . '/composer.json'), true);
+
+    expect($composer['autoload']['files'] ?? [])->toBe([])
+        ->and($composer['autoload']['psr-4']['Noerd\Tests\\'] ?? null)->toBe('tests/');
+});
+
+it('ships the loader and the helpers in dist archives', function (): void {
+    $lines = file(dirname(__DIR__, 2) . '/.gitattributes', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: [];
+
+    $ignored = [];
+    foreach ($lines as $line) {
+        $line = trim($line);
+        if (str_starts_with($line, '#') || ! str_contains($line, 'export-ignore')) {
+            continue;
+        }
+        $ignored[] = ltrim((string) strtok($line, " \t"), '/');
+    }
+
+    foreach (['tests/HelperLoader.php', 'tests/helpers.php', 'tests/TestCase.php'] as $path) {
+        foreach ($ignored as $pattern) {
+            expect($path === $pattern || str_starts_with($path, $pattern . '/'))
+                ->toBeFalse("{$path} must ship in dist archives, but is export-ignored by '{$pattern}'");
+        }
+    }
+});


### PR DESCRIPTION
This restores the commit that was accidentally pushed straight to `main` (`89590c2 "update"`). `main` was reset to `452b195` (v0.13.0) and the identical tree now comes back through this PR with a proper message.

## Responsive list header

- New `resources/views/components/table/list-filters.blade.php` holds the header's filter controls (picklist/date dropdowns, active-filter chips, clear-all button). `list-header.blade.php` renders it twice against the same `listFilters` properties: inline while the row has space, and stacked inside a drawer once it overflows. `$keyPrefix` keeps the chip `wire:key`s unique between both copies, `$stacked` switches to the full-width drawer layout.
- `filters/date-dropdown` and `filters/picklist` take a `full` prop for the stacked variant.

## No more `.bak` copies when publishing configs

`PublishesConfigDirectory`, `NoerdInstallCommand::refreshExistingNoerdConfig()` and `FrontendScaffolder::removeLegacyTailwindBridge()` no longer write a one-generation `.bak` next to the file. The published configs live in the host repository, so version control is the change history. Prompts, docs and the install output were adjusted accordingly.

## Page layout is loaded before the guarded init

`NoerdPage::initPage()` now assigns `$pageLayout` before `initNoerdComponent()`. Blade evaluates a page blade's slot content before the page chrome discards it for a denied state, so a hand-built page reading `$pageLayout['detail']` must always find its layout — even when the guarded init bails out on a read-denied object or a stale record id. Covered by `PageReadBlockedLayoutTest`.

## `Noerd\Tests\HelperLoader`

`tests/helpers.php` is deliberately not composer-autoloaded (test functions must never load in a production request), and `autoload-dev` does not help either — composer only dumps the dev autoload of the root package. The new `HelperLoader` lives in the package's psr-4 map, so suites that do not bind `Noerd\Tests\TestCase` load the helpers with `\Noerd\Tests\HelperLoader::load();` from their `tests/Pest.php`, without hard-coding `vendor/noerd/noerd/` vs. `app-modules/noerd/`. `TestCase` uses it too, `.gitattributes` keeps the file in the distributed package, and the docs, Boost guideline and `noerd-testing` skill document the new call.

## Tests

Added: `PublishConfigDirectoryTest`, `PageReadBlockedLayoutTest`, `TestHelperLoaderTest`, plus cases in `NoerdListColumnFilterTest`. Updated: `FrontendScaffolderTest`, `NoerdConfigPublishTest` for the dropped backups.
