### PR TITLE
Bump version to v0.13.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
             "name": "Johannes Brock"
         }
     ],
-    "version": "v0.13.0",
+    "version": "v0.13.1",
     "license": "MIT",
     "require": {
         "php": "^8.3",


### PR DESCRIPTION
Release version bump for the v0.13.1 tag. Sets `composer.json` `version` to `v0.13.1` so the tagged commit carries the version it is tagged with.