### PR TITLE
Bump version to v0.14.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
             "name": "Johannes Brock"
         }
     ],
-    "version": "v0.13.1",
+    "version": "v0.14.0",
     "license": "MIT",
     "require": {
         "php": "^8.3",


### PR DESCRIPTION
Release version bump. The `v0.14.0` tag points at this commit, as Packagist resolves the package version from `composer.json` in the tagged commit.