### PR TITLE
Restore hashFiles() and the hashtag demo icon

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: composer-${{ runner.os }}-L${{ matrix.laravel }}-${{ uuidFiles('composer.json') }}
+          key: composer-${{ runner.os }}-L${{ matrix.laravel }}-${{ hashFiles('composer.json') }}
           restore-keys: composer-${{ runner.os }}-L${{ matrix.laravel }}-
 
       - name: Install dependencies

--- a/demo/app-configs/demo/navigation.yml
+++ b/demo/app-configs/demo/navigation.yml
@@ -14,5 +14,5 @@
           newComponent: demo-category-detail
         - title: Demo Tags
           route: demo-tags
-          heroicon: uuidtag
+          heroicon: hashtag
           newComponent: demo-tag-detail


### PR DESCRIPTION
The tenant `hash` → `uuid` rename in v0.14.0 also processed `.yml` files and hit two names that are not the tenant column:

- `.github/workflows/tests.yml` — `hashFiles('composer.json')` became `uuidFiles(...)`. `hashFiles` is a GitHub Actions built-in, so the workflow was rejected with *Unrecognized function: 'uuidFiles'* and CI could not run at all.
- `demo/app-configs/demo/navigation.yml` — the heroicon `hashtag` became `uuidtag`, so that demo navigation entry rendered no icon.

Both are restored to their original names.