### PR TITLE
Bump version to v0.14.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
             "name": "Johannes Brock"
         }
     ],
-    "version": "v0.14.0",
+    "version": "v0.14.1",
     "license": "MIT",
     "require": {
         "php": "^8.3",


### PR DESCRIPTION
Patch release. Ships the fix from #68: the tenant `hash` → `uuid` rename in v0.14.0 also processed `.yml` files and renamed two names that are not the tenant column — the GitHub Actions built-in `hashFiles()` (which made the workflow invalid) and the `hashtag` heroicon in the demo navigation (which rendered no icon).