### PR TITLE
Bump version to v0.14.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
             "name": "Johannes Brock"
         }
     ],
-    "version": "v0.14.1",
+    "version": "v0.14.2",
     "license": "MIT",
     "require": {
         "php": "^8.3",


### PR DESCRIPTION
Releases the tabs actions slot (#70), which is on main but unreleased: `<x-slot:actions>` handed to `x-noerd::tabs` was silently discarded, so document action menus never rendered.

Version bump only, no code changes.