### PR TITLE
Declare field defaults in the layout

### DIFF
--- a/docs/detail-view.md
+++ b/docs/detail-view.md
@@ -550,8 +550,11 @@ new class extends Component {
 };
 ```
 
-The same applies to `mount()`: override it only for extra logic (e.g. `setPreselect()`, defaults
-for new records, relation titles) and call `$this->initDetail()` first.
+The same applies to `mount()`: override it only for extra logic (e.g. `setPreselect()`, relation
+titles) and call `$this->initDetail()` first. Initial field values are **not** such a case: they are
+configuration and belong in the YAML (`default:`, or the first option of a select) — see
+[Default Values](field-types.md#default-values). The trait applies them generically, also to a
+custom `mount()` that replaces `$detailData` wholesale.
 
 ## Key Concepts
 

--- a/docs/field-types.md
+++ b/docs/field-types.md
@@ -335,6 +335,7 @@ These options are available for most field types:
 | `helpText` | string | - | Explanation shown as a tooltip behind a question-mark icon next to the label (translation key) |
 | `type` | string | `text` | Field type |
 | `colspan` | int | `3` | Width in grid columns (1-12) |
+| `default` | mixed | - | Value the form starts with while the field is null (see [Default Values](#default-values)) |
 | `required` | bool | `false` | Show required indicator on label |
 | `readonly` | bool | `false` | Make field read-only |
 | `live` | bool | `false` | Enable real-time updates (`wire:model.live.debounce`) |
@@ -360,6 +361,70 @@ field type in every theme (`default`, `compact`, `numbered`).
 ```
 
 > Not to be confused with the block-level `description` (on `type: block`), which is a visible sub-heading.
+
+
+### Default Values
+
+A form must never display a value it does not hold. A `<select>` bound to a null property has no
+matching `<option>`, so the browser shows the first one by pure HTML fallback — the user sees
+"Created", the component holds `null`, and `null` is what gets saved. Defaults therefore belong to
+the layout, not to a component's `mount()`.
+
+Two rules apply, in this order:
+
+1. **`default:`** — any field may declare its initial value. It is used while the bound value is
+   `null` (a missing key counts as null); `''`, `0` and `false` are answers and are never replaced.
+2. **First option of a select** — a `type: select` whose `options` are written in the YAML starts on
+   its first option. This is what makes the displayed value real, so it is persisted on save.
+
+```yaml
+- name: detailData.invoice_status
+  label: Status
+  type: select
+  options:
+    - value: created      # <- the default: shown AND saved
+
+      label: Created
+    - value: paid
+      label: Paid
+
+- name: detailData.priority
+  label: Priority
+  type: select
+  default: normal         # <- an explicit default wins over the first option
+
+  options:
+    - value: low
+      label: Low
+    - value: normal
+      label: Normal
+
+- name: detailData.size_class
+  label: Size Class
+  type: select
+  placeholder: '—'        # <- empty is a valid answer: no implicit default
+
+  options:
+    - value: micro
+      label: Micro
+    - value: large
+      label: Large
+```
+
+The implicit first-option rule deliberately does **not** apply to:
+
+- selects using `optionsMethod:`, where the list is built from data at runtime and "the first row
+  wins" would be arbitrary (a staff list, a person picker),
+- selects declaring `placeholder:`, which renders a leading empty option and states that no
+  selection is a valid state.
+
+Defaults are applied on mount and re-applied before every render, so they also fill an **existing**
+record whose column is `NULL` — such a record adopts the default the next time it is saved. Never
+re-implement this per component (`$this->detailData['status'] ??= …` in a custom `mount()`); it is
+generic in `NoerdDetail::applyLayoutDefaults()`.
+
+A select whose stored value matches none of its options renders that value as its own leading
+option, so a list that has drifted out of sync with the data never disguises one status as another.
 
 ---
 
@@ -628,8 +693,13 @@ method.
 | `optionsMethod` | string | - | Alternative to `options`: name of a component method returning the options array |
 | `live` | bool | `false` | Enable real-time updates |
 | `required` | bool | `false` | Show required indicator |
+| `placeholder` | string | - | Label of the leading empty option — declares that "nothing selected" is a valid answer |
 
 *Either `options` or `optionsMethod` must be set.
+
+**Defaults:** a select whose options are written in the YAML starts on its **first option**, and that
+value is persisted on the first save. Declare `placeholder:` when empty is a legitimate answer, or
+`default:` to start on a different option. See [Default Values](#default-values).
 
 **Option Format:**
 ```yaml

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -998,6 +998,44 @@ is an unrelated concept).
 - Keep both synced copies of the detail YAML in sync (`app-configs/` and the module's `app-configs/`)
 - Reference: `docs/themes.md`
 
+### Field Defaults Are Configuration, Never `mount()` Code
+
+A form must never display a value it does not hold. A `<select>` bound to a null property has no
+matching `<option>`, so the browser shows the FIRST one by pure HTML fallback — the user sees a
+status, the component holds `null`, and `null` is what gets saved. Initial values are therefore
+declared in the YAML and applied generically by `NoerdDetail::applyLayoutDefaults()`.
+
+- **Any field** may declare `default: <value>`. It is applied while the bound value is `null` (a
+  missing key counts as null); `''`, `0` and `false` are answers and are never replaced.
+- **A `type: select` whose `options` are written in the YAML starts on its FIRST option** and
+  persists it on save — that is what makes the displayed value real. An explicit `default:` wins.
+- **Opt out with `placeholder:`** when nothing-selected is a legitimate answer: the select renders a
+  leading empty option and gets no implicit default.
+- The implicit rule never applies to `optionsMethod:` selects — the list is built from data at
+  runtime, where "the first row wins" would be arbitrary (a staff list, a person picker).
+- Defaults are re-applied before every render, so they also fill an EXISTING record whose column is
+  `NULL`, and they survive a custom `mount()` that replaces `$detailData` wholesale.
+- **NEVER hand-roll this per component** (`$this->detailData['status'] ??= 'created';` in a custom
+  `mount()`) — adding a default is a YAML change, in BOTH synced copies.
+```yaml
+- name: detailData.invoice_status
+  label: Status
+  type: select
+  options:
+    - value: created      # the default: shown AND saved
+      label: Created
+    - value: paid
+      label: Paid
+- name: detailData.size_class
+  label: Size Class
+  type: select
+  placeholder: '—'        # empty is a valid answer: no implicit default
+  options:
+    - value: micro
+      label: Micro
+```
+- Reference: `docs/field-types.md` ("Default Values")
+
 ### Empty Spacer Columns in Detail/Block Layouts
 Fields in a detail/block layout flow into a 12-column grid via auto-placement, so removing a field makes
 the following field move up into the freed slot. To keep a deliberate empty column (e.g. leave the right

--- a/resources/views/components/forms/select-options.blade.php
+++ b/resources/views/components/forms/select-options.blade.php
@@ -1,0 +1,31 @@
+{{-- Shared <option> list for every theme's input-select: a select must never
+     display a value the component does not hold. Without a matching option the
+     browser falls back to showing the first one, so a null value silently reads
+     as "the first option is selected" and is then lost on save. --}}
+@php
+    $selectedValue = data_get($this, $name);
+    $isEmptySelection = $selectedValue === null || $selectedValue === '';
+
+    $optionValues = [];
+    foreach ($options as $option) {
+        $optionValues[] = (string) (is_array($option) ? ($option['value'] ?? '') : $option);
+    }
+
+    $hasUnlistedValue = !$isEmptySelection && !in_array((string) $selectedValue, $optionValues, true);
+@endphp
+
+@if ($isEmptySelection || $placeholder)
+    <option value="">{{ $placeholder ? __($placeholder) : '' }}</option>
+@endif
+
+@if ($hasUnlistedValue)
+    <option value="{{ $selectedValue }}">{{ __((string) $selectedValue) }}</option>
+@endif
+
+@foreach ($options as $option)
+    @isset($option['value'])
+        <option value="{{ $option['value'] }}">{{ __($option['label']) }}</option>
+    @else
+        <option>{{ __($option) }}</option>
+    @endisset
+@endforeach

--- a/resources/views/components/forms/tiptap.blade.php
+++ b/resources/views/components/forms/tiptap.blade.php
@@ -24,7 +24,7 @@
                 editable: {{ $readonly ? 'false' : 'true' }},
                 editorProps: {
                     attributes: {
-                        class: 'rich-text focus:outline-none min-h-[150px] p-3',
+                        class: 'rich-text focus:outline-none min-h-[150px] p-3 text-base sm:text-sm',
                     },
                 },
                 onUpdate: ({ editor }) => {

--- a/resources/views/themes/compact/input-select.blade.php
+++ b/resources/views/themes/compact/input-select.blade.php
@@ -4,6 +4,7 @@
     'name' => '',
     'label' => '',
     'options' => [],
+    'placeholder' => null,
     'live' => false,
     'readonly' => false,
     'required' => false,
@@ -13,6 +14,7 @@
     $name = $field['name'] ?? $name;
     $label = $field['label'] ?? $label;
     $options = $field['options'] ?? $options;
+    $placeholder = $field['placeholder'] ?? $placeholder;
     $live = $field['live'] ?? $live;
     $readonly = $field['readonly'] ?? $readonly;
     $required = $field['required'] ?? $required;
@@ -37,13 +39,11 @@
             @if ($readonly) disabled @endif
             id="{{ $name }}"
         >
-            @foreach ($options as $option)
-                @isset($option['value'])
-                    <option value="{{ $option['value'] }}">{{ __($option['label']) }}</option>
-                @else
-                    <option>{{ __($option) }}</option>
-                @endisset
-            @endforeach
+            @include('noerd::components.forms.select-options', [
+                'options' => $options,
+                'name' => $name,
+                'placeholder' => $placeholder,
+            ])
         </select>
         <x-noerd::input-error :messages="$errors->get($name)" class="mt-2" />
     </div>

--- a/resources/views/themes/default/input-select.blade.php
+++ b/resources/views/themes/default/input-select.blade.php
@@ -3,6 +3,7 @@
     'name' => '',
     'label' => '',
     'options' => [],
+    'placeholder' => null,
     'live' => false,
     'readonly' => false,
     'required' => false,
@@ -12,6 +13,7 @@
     $name = $field['name'] ?? $name;
     $label = $field['label'] ?? $label;
     $options = $field['options'] ?? $options;
+    $placeholder = $field['placeholder'] ?? $placeholder;
     $live = $field['live'] ?? $live;
     $readonly = $field['readonly'] ?? $readonly;
     $required = $field['required'] ?? $required;
@@ -29,13 +31,11 @@
         @if ($readonly) disabled @endif
         id="{{ $name }}"
     >
-        @foreach ($options as $option)
-            @isset($option['value'])
-                <option value="{{ $option['value'] }}">{{ __($option['label']) }}</option>
-            @else
-                <option>{{ __($option) }}</option>
-            @endisset
-        @endforeach
+        @include('noerd::components.forms.select-options', [
+            'options' => $options,
+            'name' => $name,
+            'placeholder' => $placeholder,
+        ])
     </select>
     <x-noerd::input-error :messages="$errors->get($name)" class="mt-2" />
 </div>

--- a/resources/views/themes/numbered/input-select.blade.php
+++ b/resources/views/themes/numbered/input-select.blade.php
@@ -3,6 +3,7 @@
     'field' => null,
     'name' => '',
     'options' => [],
+    'placeholder' => null,
     'live' => false,
     'readonly' => false,
 ])
@@ -10,6 +11,7 @@
 @php
     $name = $field['name'] ?? $name;
     $options = $field['options'] ?? $options;
+    $placeholder = $field['placeholder'] ?? $placeholder;
     $live = $field['live'] ?? $live;
     $readonly = $field['readonly'] ?? $readonly;
 @endphp
@@ -25,12 +27,10 @@
         @if ($readonly) disabled @endif
         id="{{ $name }}"
     >
-        @foreach ($options as $option)
-            @isset($option['value'])
-                <option value="{{ $option['value'] }}">{{ __($option['label']) }}</option>
-            @else
-                <option>{{ __($option) }}</option>
-            @endisset
-        @endforeach
+        @include('noerd::components.forms.select-options', [
+            'options' => $options,
+            'name' => $name,
+            'placeholder' => $placeholder,
+        ])
     </select>
 </x-noerd::detail.numbered-row>

--- a/src/Support/LayoutDefaults.php
+++ b/src/Support/LayoutDefaults.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Noerd\Support;
+
+/**
+ * Resolves the initial values a YAML field layout declares for the form bucket.
+ *
+ * A detail form must never display a value it does not hold: a `<select>` whose
+ * bound property is null shows its first option purely by HTML fallback, and
+ * that phantom value is lost on save. The layout therefore owns the defaults —
+ * an explicit `default:` on any field, or, for a select whose options are
+ * written in the YAML, the first option.
+ */
+final class LayoutDefaults
+{
+    /**
+     * Default values a layout declares, keyed by the dot path relative to the
+     * `detailData.` form bucket (e.g. `invoice_status`).
+     *
+     * @param  array<int, array<string, mixed>>  $fields
+     * @return array<string, mixed>
+     */
+    public static function resolve(array $fields): array
+    {
+        $defaults = [];
+
+        LayoutFields::walk($fields, function (array $field) use (&$defaults): void {
+            $name = $field['name'] ?? null;
+            if (!is_string($name) || !str_starts_with($name, 'detailData.')) {
+                return;
+            }
+
+            $key = mb_substr($name, mb_strlen('detailData.'));
+            if ($key === '') {
+                return;
+            }
+
+            if (array_key_exists('default', $field)) {
+                $defaults[$key] = $field['default'];
+
+                return;
+            }
+
+            $implicit = self::firstSelectOption($field);
+            if ($implicit !== null) {
+                $defaults[$key] = $implicit;
+            }
+        });
+
+        return $defaults;
+    }
+
+    /**
+     * The implicit default of a select: its first option. Only applies to
+     * options written in the YAML — a `placeholder:` marks empty as a valid
+     * state, and `optionsMethod:` builds the list from data at runtime, where
+     * "the first row wins" would be arbitrary.
+     *
+     * @param  array<string, mixed>  $field
+     */
+    private static function firstSelectOption(array $field): string|int|float|null
+    {
+        if (($field['type'] ?? null) !== 'select') {
+            return null;
+        }
+
+        if (($field['placeholder'] ?? null) || ($field['optionsMethod'] ?? null)) {
+            return null;
+        }
+
+        $options = $field['options'] ?? null;
+        if (!is_array($options) || $options === []) {
+            return null;
+        }
+
+        $first = reset($options);
+
+        // Options come in two shapes: `- value: x / label: X` and the simple
+        // `- 'X'` form, where the label doubles as the value.
+        $value = is_array($first) ? ($first['value'] ?? null) : $first;
+
+        return is_string($value) || is_int($value) || is_float($value) ? $value : null;
+    }
+}

--- a/src/Traits/NoerdDetail.php
+++ b/src/Traits/NoerdDetail.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Str;
 use Livewire\Attributes\On;
 use Noerd\Helpers\StaticConfigHelper;
 use Noerd\Services\PicklistRegistry;
+use Noerd\Support\LayoutDefaults;
 use Noerd\Support\LayoutFields;
 use Noerd\Support\RelationFormSync;
 use ReflectionMethod;
@@ -194,6 +195,7 @@ trait NoerdDetail
             $this->detailData = [];
         }
 
+        $this->applyLayoutDefaults();
         $this->ensureCustomAttributesArray();
         $this->ensureRelationFormsHydrated();
     }
@@ -319,8 +321,38 @@ trait NoerdDetail
             $this->pageLayout = StaticConfigHelper::getComponentFields($detailComponent, $modelClass);
         }
 
+        $this->applyLayoutDefaults();
         $this->ensureCustomAttributesArray();
         $this->ensureRelationFormsHydrated();
+    }
+
+    /**
+     * Seed $detailData with the initial values the layout declares (an explicit
+     * `default:` on a field, or the first option of a YAML-listed select). Only
+     * null values are filled — '' , 0 and false are answers, not gaps — so the
+     * method is idempotent and never overwrites what the record or the user
+     * holds. It runs from mountDetailComponent() AND renderingNoerdDetail(),
+     * because components may replace $detailData wholesale in a custom mount().
+     */
+    protected function applyLayoutDefaults(): void
+    {
+        if ($this->objectReadBlocked) {
+            return;
+        }
+
+        $defaults = LayoutDefaults::resolve($this->pageLayout['fields'] ?? []);
+        if ($defaults === []) {
+            return;
+        }
+
+        $detailData = $this->detailData;
+        foreach ($defaults as $key => $value) {
+            if (data_get($detailData, $key) === null) {
+                data_set($detailData, $key, $value);
+            }
+        }
+
+        $this->detailData = $detailData;
     }
 
     /**

--- a/tests/Feature/LayoutDefaultsTest.php
+++ b/tests/Feature/LayoutDefaultsTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Livewire\Component;
+use Livewire\Livewire;
+use Noerd\Models\NoerdUser;
+use Noerd\Models\Tenant;
+use Noerd\Tests\TestCase;
+use Noerd\Traits\NoerdDetail;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+/*
+ | Layout-declared defaults: a detail form must never display a value it does
+ | not hold. A select whose bound property is null shows its first option by
+ | pure HTML fallback and loses it on save, so the layout owns the initial
+ | value — an explicit `default:` on any field, or the first option of a select
+ | whose options are written in the YAML. The layout comes from a runtime
+ | fixture YAML, never from a shipped config.
+ */
+
+class ZzLayoutDefaultsComponent extends Component
+{
+    use NoerdDetail;
+
+    public const COMPONENT = 'zz-layout-defaults-detail';
+
+    public $detailModel = Tenant::class;
+
+    public ?string $detailPrimary = 'tenantId';
+
+    public function zzDynamicOptions(): array
+    {
+        return ['first' => 'First', 'second' => 'Second'];
+    }
+
+    public function render(): string
+    {
+        return '<div></div>';
+    }
+}
+
+beforeEach(function (): void {
+    $this->actingAs(NoerdUser::factory()->adminUser()->withSelectedApp('setup')->create());
+
+    Livewire::component('zz-layout-defaults-detail', ZzLayoutDefaultsComponent::class);
+
+    File::put(base_path('app-configs/setup/details/zz-layout-defaults-detail.yml'), implode("\n", [
+        'title: Zz Layout Defaults',
+        'fields:',
+        '  - name: detailData.name',
+        '    label: Name',
+        '    type: select',
+        '    options:',
+        '      - value: alpha',
+        '        label: Alpha',
+        '      - value: beta',
+        '        label: Beta',
+        '  - name: detailData.zz_explicit',
+        '    label: Explicit',
+        '    type: select',
+        '    default: beta',
+        '    options:',
+        '      - value: alpha',
+        '        label: Alpha',
+        '      - value: beta',
+        '        label: Beta',
+        '  - name: detailData.zz_text',
+        '    label: Text',
+        '    type: text',
+        '    default: seeded',
+        '  - name: detailData.zz_placeholder',
+        '    label: Placeholder',
+        '    type: select',
+        '    placeholder: Please choose',
+        '    options:',
+        '      - value: alpha',
+        '        label: Alpha',
+        '  - name: detailData.zz_dynamic',
+        '    label: Dynamic',
+        '    type: select',
+        '    optionsMethod: zzDynamicOptions',
+        '  - name: detailData.uuid',
+        '    label: Uuid',
+        '    type: text',
+        '  - name: detailData.zz_plain',
+        '    label: Plain',
+        '    type: text',
+        '  - type: block',
+        '    fields:',
+        '      - name: detailData.zz_nested',
+        '        label: Nested',
+        '        type: select',
+        '        options:',
+        '          - value: nested-first',
+        '            label: Nested First',
+        '          - value: nested-second',
+        '            label: Nested Second',
+    ]));
+});
+
+afterEach(function (): void {
+    File::delete(base_path('app-configs/setup/details/zz-layout-defaults-detail.yml'));
+});
+
+it('seeds a new record with the first option of a select whose options are in the YAML', function (): void {
+    Livewire::test('zz-layout-defaults-detail')
+        ->assertSet('detailData.name', 'alpha');
+});
+
+it('persists the seeded default on the first save', function (): void {
+    Livewire::test('zz-layout-defaults-detail')
+        ->set('detailData.uuid', 'zz-layout-defaults')
+        ->call('store');
+
+    expect(Tenant::query()->where('name', 'alpha')->exists())->toBeTrue();
+});
+
+it('prefers an explicit default over the first option and seeds non-select fields too', function (): void {
+    Livewire::test('zz-layout-defaults-detail')
+        ->assertSet('detailData.zz_explicit', 'beta')
+        ->assertSet('detailData.zz_text', 'seeded');
+});
+
+it('leaves a select with a placeholder empty, because empty is a valid answer there', function (): void {
+    Livewire::test('zz-layout-defaults-detail')
+        ->assertSet('detailData.zz_placeholder', null);
+});
+
+it('never seeds a select whose options are built from data at runtime', function (): void {
+    Livewire::test('zz-layout-defaults-detail')
+        ->assertSet('detailData.zz_dynamic', null);
+});
+
+it('seeds a select nested in a block field', function (): void {
+    Livewire::test('zz-layout-defaults-detail')
+        ->assertSet('detailData.zz_nested', 'nested-first');
+});
+
+it('leaves fields without a declared default untouched', function (): void {
+    Livewire::test('zz-layout-defaults-detail')
+        ->assertSet('detailData.zz_plain', null);
+});
+
+it('seeds an existing record too, not only a new one', function (): void {
+    $tenant = Tenant::factory()->create(['name' => 'beta']);
+
+    // zz_explicit is not a column of the record, so it arrives null from the
+    // database — exactly the state an existing row with a NULL picklist has.
+    Livewire::test('zz-layout-defaults-detail', ['modelId' => $tenant->id])
+        ->assertSet('detailData.zz_explicit', 'beta');
+});
+
+it('never overwrites a value the record already holds', function (): void {
+    $tenant = Tenant::factory()->create(['name' => 'beta']);
+
+    Livewire::test('zz-layout-defaults-detail', ['modelId' => $tenant->id])
+        ->assertSet('detailData.name', 'beta');
+});
+
+it('treats an empty string as an answer and does not re-seed it', function (): void {
+    Livewire::test('zz-layout-defaults-detail')
+        ->set('detailData.name', '')
+        ->assertSet('detailData.name', '');
+});

--- a/tests/Feature/SelectOptionsRenderTest.php
+++ b/tests/Feature/SelectOptionsRenderTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Noerd\Models\NoerdUser;
+use Noerd\Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+/*
+ | A rendered <select> must show what the component actually holds. Without a
+ | matching <option> the browser falls back to displaying the first one, which
+ | is how a null value used to read as "the first option is selected" and was
+ | then lost on save. The layout comes from a synthetic fixture, never from a
+ | shipped config.
+ */
+
+beforeEach(function (): void {
+    $this->actingAs(NoerdUser::factory()->adminUser()->withSelectedApp('setup')->create());
+});
+
+function zzSelectField(array $overrides = []): array
+{
+    return array_merge([
+        'name' => 'model.status',
+        'label' => 'Status',
+        'type' => 'select',
+        'colspan' => 6,
+        'options' => [
+            ['value' => 'alpha', 'label' => 'Alpha'],
+            ['value' => 'beta', 'label' => 'Beta'],
+        ],
+    ], $overrides);
+}
+
+it('renders an empty leading option when the bound value is null', function (): void {
+    Livewire::test('noerd::theme-test', [
+        'initialModel' => [],
+        'fields' => [zzSelectField()],
+    ])
+        ->assertSeeHtml('<option value=""></option>');
+});
+
+it('renders no empty option once the value matches an option', function (): void {
+    Livewire::test('noerd::theme-test', [
+        'initialModel' => ['status' => 'beta'],
+        'fields' => [zzSelectField()],
+    ])
+        ->assertDontSeeHtml('<option value=""></option>');
+});
+
+it('renders the placeholder as the empty option', function (): void {
+    Livewire::test('noerd::theme-test', [
+        'initialModel' => [],
+        'fields' => [zzSelectField(['placeholder' => 'Please choose'])],
+    ])
+        ->assertSeeHtml('<option value="">Please choose</option>');
+});
+
+it('renders a value that matches no option instead of silently showing the first one', function (): void {
+    Livewire::test('noerd::theme-test', [
+        'initialModel' => ['status' => 'gamma'],
+        'fields' => [zzSelectField()],
+    ])
+        ->assertSeeHtml('<option value="gamma">gamma</option>');
+});
+
+it('applies the same option handling in every theme', function (string $theme): void {
+    Livewire::test('noerd::theme-test', [
+        'initialModel' => [],
+        'theme' => $theme,
+        'fields' => [zzSelectField()],
+    ])
+        ->assertSeeHtml('<option value=""></option>');
+})->with(['default', 'compact', 'numbered']);

--- a/tests/helpers.php
+++ b/tests/helpers.php
@@ -14,13 +14,24 @@ if (!function_exists('requiredLayoutFields')) {
      * required: true) so validation tests assert against whatever the YAML
      * currently declares required instead of hard-coding a field name.
      *
+     * Fields the layout always fills (an explicit `default:`, or the first
+     * option of a select whose options are in the YAML) are left out: the trait
+     * seeds them before every render, so they can never reach store() empty and
+     * would never produce a required error.
+     *
      * @return array<int, string>
      */
     function requiredLayoutFields($component): array
     {
         $layout = $component->get('pageLayout') ?? [];
+        $fields = $layout['fields'] ?? [];
 
-        return extractRequiredLayoutFields($layout['fields'] ?? []);
+        $defaulted = array_map(
+            static fn(string $key): string => 'detailData.' . $key,
+            array_keys(\Noerd\Support\LayoutDefaults::resolve($fields)),
+        );
+
+        return array_values(array_diff(extractRequiredLayoutFields($fields), $defaulted));
     }
 }
 


### PR DESCRIPTION
## Problem

A `<select>` bound to a null property has no matching `<option>`, so the browser shows the **first** one by pure HTML fallback. The user sees a status, the component holds `null`, and `null` is what gets saved.

## Change

Initial field values become configuration and are applied generically by `NoerdDetail::applyLayoutDefaults()`:

- **`default:`** on any field — applied while the bound value is `null`; `''`, `0` and `false` are answers and are never replaced.
- **A `type: select` whose `options` are written in the YAML starts on its first option** and persists it on save. An explicit `default:` wins.
- **Opt out with `placeholder:`** when nothing-selected is a legitimate answer — the select renders a leading empty option and gets no implicit default.
- The implicit rule never applies to `optionsMethod:` selects, where "the first row wins" would be arbitrary.

Defaults are re-applied before every render, so they also fill an existing record whose column is `NULL`, and they survive a custom `mount()` that replaces `$detailData` wholesale.

The shared `select-options` partial (used by all three themes) additionally renders a stored value that matches none of the options as its own leading option, so a drifted option list never disguises one status as another.

`requiredLayoutFields()` skips fields the layout always fills — they can never reach `store()` empty.

Also: the tiptap editor keeps a 16px base font on mobile so iOS stops zooming on focus.

## Docs

`docs/field-types.md` ("Default Values"), `docs/detail-view.md` and the Boost guideline.

## Tests

`LayoutDefaultsTest`, `SelectOptionsRenderTest`; full suite green (1128 passed).