### PR TITLE
Bump version to v0.14.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
             "name": "Johannes Brock"
         }
     ],
-    "version": "v0.14.3",
+    "version": "v0.14.4",
     "license": "MIT",
     "require": {
         "php": "^8.3",


### PR DESCRIPTION
Release v0.14.4 — ships the layout-declared field defaults from #74.