### PR TITLE
Bump version to v0.14.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
             "name": "Johannes Brock"
         }
     ],
-    "version": "v0.14.4",
+    "version": "v0.14.5",
     "license": "MIT",
     "require": {
         "php": "^8.3",


### PR DESCRIPTION
Re-release of v0.14.4.

The v0.14.4 tag was briefly pushed onto the version-bump commit before the release PR was merged, so Packagist published `bf76d89` and then rejected the move to the merge commit `da75456` — stable versions are immutable. Both commits carry an identical tree; only the hash differed.

The v0.14.4 tag has been restored to `bf76d89` to match what Packagist shows. This PR ships the same code as v0.14.5 so the current `main` is installable.