### PR TITLE
Separate a list description from the table with a full-bleed rule

### DIFF
--- a/resources/views/components/list/index.blade.php
+++ b/resources/views/components/list/index.blade.php
@@ -150,7 +150,7 @@
                 @keydown.window.enter="if (canHandleListKey()) { $event.preventDefault(); $wire.findListAction(selectedRow{{ $listId }}) }"
             >
                 @if (! $hideHead && ! $compact)
-                    <div>
+                    <div @class(['-mx-6 border-b border-gray-300 px-6' => ! empty($description)])>
                         @include('noerd::components.table.title-search', [
                             'description' => $description ?? '',
                         ])


### PR DESCRIPTION
A list that declares `description:` in its YAML rendered the text directly above the table with no separator, so the description and the first table row read as one block.

The description block now closes with a rule. It breaks out of the page body padding (`-mx-6 … px-6`) so the line spans the full width, lining up with the header rule above it and with the table below, which breaks out the same way. Lists without a description (or with `description: ''`) are unchanged — the classes are bound to `! empty($description)`.

The rule sits in the list renderer rather than in `table/title-search.blade.php`: that partial is also included by components which are not hosted in an `x-noerd::page` body (e.g. `harvester-project::firewood-overview`), where the breakout would escape the layout.

Verified in the browser on a list with a description, and `vendor/bin/pest tests/Feature` passes (761 tests).