### PR TITLE
Bump version to v0.14.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
             "name": "Johannes Brock"
         }
     ],
-    "version": "v0.14.5",
+    "version": "v0.14.6",
     "license": "MIT",
     "require": {
         "php": "^8.3",


### PR DESCRIPTION
Release v0.14.6.

- Separate a list description from the table with a full-bleed rule (#77)