### PR TITLE
Show the last login of a user in the users list

### DIFF
--- a/app-configs/setup/lists/noerd-users-list.yml
+++ b/app-configs/setup/lists/noerd-users-list.yml
@@ -18,6 +18,9 @@ columns:
   - field: profile_for_tenant
     label: Profile
     type: badge_with_text
+  - field: latestLogin.created_at
+    label: Last Login
+    type: datetime
   - field: action
     actions:
       - label: Login as user

--- a/src/Commands/NoerdInstallCommand.php
+++ b/src/Commands/NoerdInstallCommand.php
@@ -766,11 +766,11 @@ class NoerdInstallCommand extends Command
         callout('Application ready', [
             'You can start your local development using:',
             new NumberedList([
-                'Run: composer run dev',
+                'Run: php artisan dev',
                 'Open: ' . new Link($appsUrl) . ' and log in with your admin user',
             ]),
             'New to noerd? Check out the ' . new Link('https://noerd.dev', 'documentation') . '.',
-            'Build something amazing!',
+            'Now go build an amazing business app!',
         ]);
     }
 

--- a/src/Models/NoerdUser.php
+++ b/src/Models/NoerdUser.php
@@ -56,6 +56,11 @@ class NoerdUser extends Authenticatable implements HasLocalePreference
         return $this->hasMany(NoerdLogin::class, 'user_id');
     }
 
+    public function latestLogin(): HasOne
+    {
+        return $this->hasOne(NoerdLogin::class, 'user_id')->latestOfMany();
+    }
+
     public function adminTenants(): BelongsToMany
     {
         return $this->belongsToMany(Tenant::class, 'users_tenants', 'user_id')

--- a/tests/Feature/LoginRecordingTest.php
+++ b/tests/Feature/LoginRecordingTest.php
@@ -89,3 +89,28 @@ it('removes the login rows when the user is deleted', function (): void {
 
     expect(NoerdLogin::count())->toBe(0);
 });
+
+it('exposes the most recent login through the latestLogin relation', function (): void {
+    $user = NoerdUser::factory()->create();
+
+    NoerdLogin::create(['user_id' => $user->id, 'created_at' => now()->subDays(3)]);
+    $latest = NoerdLogin::create(['user_id' => $user->id, 'created_at' => now()->subHour()]);
+
+    expect($user->latestLogin()->first()->id)->toBe($latest->id);
+});
+
+it('eager-loads the last login so a list column resolves without a per-row query', function (): void {
+    $user = NoerdUser::factory()->create();
+    NoerdLogin::create(['user_id' => $user->id, 'created_at' => now()->subHour()]);
+
+    $loaded = NoerdUser::with('latestLogin')->whereKey($user->id)->sole();
+
+    expect($loaded->relationLoaded('latestLogin'))->toBeTrue();
+    expect(data_get($loaded, 'latestLogin.created_at'))->not->toBeNull();
+});
+
+it('leaves the last login empty for a user who never logged in', function (): void {
+    $user = NoerdUser::factory()->create();
+
+    expect($user->latestLogin()->first())->toBeNull();
+});


### PR DESCRIPTION
## What

Adds a **Last Login** column to the setup users list.

- `NoerdUser::latestLogin()` — a `hasOne(...)->latestOfMany()` relation on the existing `noerd_logins` rows
- `noerd-users-list.yml` gains a `latestLogin.created_at` column (`type: datetime`); the generic dotted-column eager loading in `NoerdList` resolves it without a per-row query
- Install command wording: `composer run dev` → `php artisan dev`, and a friendlier closing line

## Tests

`tests/Feature/LoginRecordingTest.php` covers the relation (latest row wins), the eager-loaded list column, and the empty case for a user who never logged in.

```
vendor/bin/pest tests/Feature/LoginRecordingTest.php  →  9 passed
vendor/bin/pint --dirty                               →  passed
```