### PR TITLE
Stop the list header from clipping the search field's focus ring

### DIFF
--- a/resources/views/components/table/list-header.blade.php
+++ b/resources/views/components/table/list-header.blade.php
@@ -130,8 +130,16 @@
                      Visibility below `xl` is driven by opacity/visibility (not
                      `display`), so the panel can transition without a translate that
                      would push the page into horizontal overflow. --}}
+                {{-- `xl:overflow-x-auto` makes the row scroll instead of wrap, but a
+                     scroll container clips BOTH axes (CSS forces `overflow-y` to
+                     `auto` as soon as one axis is not `visible`), and the row's box
+                     is exactly as tall as its 32px controls. Without room the focus
+                     ring of the search field (`ring-2` + `ring-offset-2`) is cut down
+                     to a bare sliver on its left. `xl:p-1.5` opens 6px on every side
+                     for it; the negative margins (and the reduced `xl:ml-2.5`) cancel
+                     that padding again, so the row sits exactly where it did. --}}
                 <div
-                    class="xl:ml-4 xl:flex xl:min-w-0 xl:flex-1 xl:flex-row xl:items-center xl:gap-1 xl:overflow-x-auto
+                    class="xl:-my-1.5 xl:-mr-1.5 xl:ml-2.5 xl:flex xl:min-w-0 xl:flex-1 xl:flex-row xl:items-center xl:gap-1 xl:overflow-x-auto xl:p-1.5
                            max-xl:fixed max-xl:inset-y-0 max-xl:right-0 max-xl:z-[70] max-xl:flex max-xl:w-80 max-xl:max-w-[85vw] max-xl:flex-col max-xl:items-stretch max-xl:gap-3 max-xl:overflow-y-auto max-xl:bg-white max-xl:p-6 max-xl:text-sm max-xl:font-normal max-xl:shadow-xl max-xl:transition max-xl:duration-200"
                     x-bind:class="drawer
                         ? 'max-xl:visible max-xl:translate-x-0 max-xl:opacity-100'

--- a/tests/Components/ListControlsInjectionTest.php
+++ b/tests/Components/ListControlsInjectionTest.php
@@ -76,6 +76,21 @@ it('wraps the injected controls in the listControlsShow expression', function ()
         ->toContain('wire:model.live.debounce.300ms="search"');
 });
 
+it('keeps room for the focus ring inside the scrolling controls row', function (): void {
+    // `xl:overflow-x-auto` makes the header row scroll rather than wrap, and a scroll
+    // container clips BOTH axes. Without padding the row is exactly as tall as its
+    // 32px controls, so the search field's focus ring is cut down to a black sliver.
+    $html = Livewire::test(StandardHeaderListComponent::class)->assertOk()->html();
+
+    preg_match_all('/class="([^"]*xl:overflow-x-auto[^"]*)"/', $html, $matches);
+
+    expect($matches[1])->not->toBeEmpty();
+
+    foreach ($matches[1] as $classAttribute) {
+        expect($classAttribute)->toContain('xl:p-1.5');
+    }
+});
+
 /**
  * List host with its OWN header slot (the tab-panel/object-manager pattern): the
  * generic list-header never renders, so every control must come from the


### PR DESCRIPTION
## Problem

Focusing the search field in a list header painted a bare **2px black bar to its left** instead of a focus ring.

`text-input` focuses with `ring-2 ring-brand-border ring-offset-2` — with a black brand colour that is `box-shadow: 0 0 0 2px #fff, 0 0 0 4px #000`. The header's controls row carries `xl:overflow-x-auto` so the controls scroll instead of wrapping, and CSS promotes `overflow-y` to `auto` as soon as one axis is not `visible` — so the row clips both axes. Its box is exactly as tall as the 32px controls, so the ring was clipped away on top, bottom and right; only the left segment survived inside the search field's `pl-2`.

## Fix

`xl:p-1.5` opens 6px on every side of the scroll container for the 4px ring, and `xl:-my-1.5 xl:-mr-1.5` plus the reduced `xl:ml-2.5` cancel that padding again, so the row renders in exactly the same place. Verified in the browser: the full ring renders, header layout unchanged.

## Test

`tests/Components/ListControlsInjectionTest.php` pins the invariant — every `xl:overflow-x-auto` row in a rendered list header must carry the ring padding.

```
vendor/bin/pest tests/Components/ListControlsInjectionTest.php  →  7 passed
vendor/bin/pint --dirty                                         →  passed
```