### PR TITLE
Scaffold a dashboard for every new app in noerd:create-app

### DIFF
--- a/docs/artisan-commands.md
+++ b/docs/artisan-commands.md
@@ -27,7 +27,7 @@ of them at once.
 | `noerd:create-admin` | Create a new user and make them an admin |
 | `noerd:make-admin` | Make an existing user an admin on all their tenants |
 | `noerd:create-tenant` | Create a new tenant with default profiles |
-| `noerd:create-app` | Create a new app (TenantApp) that can be assigned to tenants |
+| `noerd:create-app` | Create a new app (TenantApp) with its own dashboard that can be assigned to tenants |
 | `noerd:assign-apps-to-tenant` | Assign apps to a tenant with interactive selection |
 
 ### Scaffolding
@@ -190,7 +190,9 @@ php artisan noerd:create-tenant
 ## noerd:create-app
 
 Creates a new app (TenantApp) that can be assigned to tenants. Without options the command runs as
-an interactive wizard.
+an interactive wizard. Every app comes with its own dashboard: the command runs
+`noerd:make-dashboard` for the new app and stores the generated `{app}.dashboard` route as the
+app's main route (see [Create an App](create-app.md)).
 
 ```bash
 php artisan noerd:create-app
@@ -201,7 +203,7 @@ php artisan noerd:create-app
 | `--title=` | The display title of the app |
 | `--name=` | The unique name identifier of the app (uppercase) |
 | `--icon=` | The icon identifier for the app (Heroicon, searchable in the wizard) |
-| `--route=` | The main route name for the app (e.g. `crm.index`) |
+| `--route=` | Open an existing route (e.g. `crm.index`) instead of generating a dashboard |
 | `--active=1` | Whether the app is active (`1` or `0`) |
 
 ## noerd:assign-apps-to-tenant
@@ -326,7 +328,10 @@ php artisan noerd:make-page sent-mails --app=crm
 
 ## noerd:make-dashboard
 
-Generates a dashboard Blade file for an app.
+Generates a dashboard Blade file for an app (`resources/views/components/{app}-dashboard.blade.php`),
+adds the `{app}.dashboard` route to `routes/web.php` (inside the `noerd` + `app-access:{app}`
+middleware group) and links it from the app's `navigation.yml` — creating the navigation file when
+the app has none yet. `noerd:create-app` runs this command automatically for every new app.
 
 ```bash
 php artisan noerd:make-dashboard --app=crm

--- a/docs/create-app.md
+++ b/docs/create-app.md
@@ -12,13 +12,30 @@ The command asks for:
 1. **App Title** - Display name (e.g., "Customer Management")
 2. **App Name** - Unique identifier, uppercase (e.g., "CRM")
 3. **Icon** - Heroicon name (searchable)
-4. **Route** - Main route name (e.g., "crm.index")
+
+Every app ships with its own dashboard, so there is nothing to ask about the app's route: the
+command runs `noerd:make-dashboard` for the new app and stores the generated route
+(`{app}.dashboard`, e.g. `crm.dashboard`) as the app's main route. The scaffold consists of
+
+- `resources/views/components/{app}-dashboard.blade.php` — the dashboard page (`NoerdPage`)
+- a `Route::livewire('{app}', '{app}-dashboard')->name('{app}.dashboard')` entry in `routes/web.php`,
+  wrapped in the `noerd` + `app-access:{app}` middleware group
+- `app-configs/{app}/navigation.yml` with a first block that links the dashboard (an existing
+  navigation only gets the dashboard entry inserted)
 
 For non-interactive use (e.g. in install scripts), every prompt has an option:
 
 ```bash
 php artisan noerd:create-app --title="Customer Management" --name=CRM \
-    --icon=users --route=crm.index --active=1
+    --icon=users --active=1
+```
+
+Pass `--route=` only when the app tile should open an existing route instead — no dashboard is
+generated then:
+
+```bash
+php artisan noerd:create-app --title="Customer Management" --name=CRM \
+    --icon=users --route=crm.index
 ```
 
 Within that command, you can assign that app to one or more tenants. You can also do that later with another Artisan command:
@@ -29,8 +46,10 @@ php artisan noerd:assign-apps-to-tenant
 php artisan noerd:assign-apps-to-tenant --tenant-id=1
 ```
 
-If you visit /noerd-apps again, you should now see your created app in the sidebar.
+If you visit /noerd-apps again, you should now see your created app in the sidebar; opening it
+shows the generated dashboard.
 
 ## Next Steps
 
-Continue with [Create Navigation](navigation.md) to define your app's navigation structure.
+Continue with [Create Navigation](navigation.md) to extend the generated navigation with your
+app's lists and pages.

--- a/src/Commands/Concerns/GeneratesResourceFiles.php
+++ b/src/Commands/Concerns/GeneratesResourceFiles.php
@@ -415,6 +415,19 @@ trait GeneratesResourceFiles
         return $path;
     }
 
+    /**
+     * Generated routes always sit behind the noerd auth/tenant middleware and
+     * the app gate — exactly like the routes of a shipped module.
+     */
+    protected function appendRoute(string $route): void
+    {
+        $routeFile = base_path('routes/web.php');
+        $group = "Route::middleware(['noerd', 'app-access:{$this->appConfigName}'])->group(function (): void {\n    {$route}\n});";
+
+        $this->filesystem->append($routeFile, "\n{$group}\n");
+        $this->line("<info>Route added:</info> {$route}");
+    }
+
     protected function addPageRoute(): void
     {
         $routeFile = base_path('routes/web.php');

--- a/src/Commands/CreateTenantApp.php
+++ b/src/Commands/CreateTenantApp.php
@@ -4,6 +4,7 @@ namespace Noerd\Commands;
 
 use Exception;
 use Illuminate\Console\Command;
+use Illuminate\Support\Str;
 
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\multiselect;
@@ -23,7 +24,7 @@ class CreateTenantApp extends Command
                             {--title= : The display title of the app}
                             {--name= : The unique name identifier of the app}
                             {--icon= : The icon identifier for the app}
-                            {--route= : The main route name for the app}
+                            {--route= : An existing route to open instead of the generated dashboard}
                             {--active=1 : Whether the app is active (1 or 0)}';
 
     /**
@@ -31,7 +32,7 @@ class CreateTenantApp extends Command
      *
      * @var string
      */
-    protected $description = 'Create a new app that can be assigned to tenants';
+    protected $description = 'Create a new app with its own dashboard that can be assigned to tenants';
 
     /**
      * Execute the console command.
@@ -45,14 +46,13 @@ class CreateTenantApp extends Command
         $active = (bool) $this->option('active');
 
         // Interactive mode if no options provided and not in test environment
-        if ((!$title || !$name || !$icon || !$route) && !app()->runningUnitTests()) {
+        if ((!$title || !$name || !$icon) && !app()->runningUnitTests()) {
             $this->info('Creating a new tenant app...');
             $this->newLine();
 
             $title = $title ?: $this->ask('App Title (display name)');
             $name = $this->normalizeAppName($name ?: $this->ask('App Name (unique identifier, e.g., CMS, MEDIA)'));
             $icon = $icon ?: $this->askForIcon();
-            $route = $route ?: $this->ask('App Route (main route name, e.g., cms.pages, media.dashboard)');
         }
 
         // Normalize name if provided via option
@@ -61,8 +61,8 @@ class CreateTenantApp extends Command
         }
 
         // Validate required fields
-        if (!$title || !$name || !$icon || !$route) {
-            $this->error('All fields (title, name, icon, route) are required.');
+        if (!$title || !$name || !$icon) {
+            $this->error('All fields (title, name, icon) are required.');
             return self::FAILURE;
         }
 
@@ -78,6 +78,11 @@ class CreateTenantApp extends Command
             return self::FAILURE;
         }
 
+        // Every app ships its own dashboard: the app tile opens the generated
+        // dashboard route unless the caller points it at an existing route.
+        $generateDashboard = !$route;
+        $route = $route ?: MakeDashboardCommand::routeNameFor($name);
+
         // Create the tenant app
         try {
             $tenantApp = TenantApp::create([
@@ -87,6 +92,14 @@ class CreateTenantApp extends Command
                 'route' => $route,
                 'is_active' => $active,
             ]);
+
+            if ($generateDashboard) {
+                $this->newLine();
+                $this->call('noerd:make-dashboard', [
+                    '--app' => Str::lower($name),
+                    '--no-interaction' => true,
+                ]);
+            }
 
             $this->newLine();
             $this->info("✅ Tenant app created successfully!");

--- a/src/Commands/MakeDashboardCommand.php
+++ b/src/Commands/MakeDashboardCommand.php
@@ -5,7 +5,9 @@ namespace Noerd\Commands;
 use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
 use Noerd\Commands\Concerns\GeneratesResourceFiles;
+use Noerd\Models\TenantApp;
 
 class MakeDashboardCommand extends Command
 {
@@ -23,10 +25,19 @@ class MakeDashboardCommand extends Command
         $this->filesystem = $filesystem;
     }
 
+    /**
+     * The route name of the dashboard generated for the given app — the target
+     * noerd:create-app stores as the app's main route.
+     */
+    public static function routeNameFor(string $app): string
+    {
+        return Str::lower($app) . '.dashboard';
+    }
+
     public function handle(): int
     {
         $result = $this->selectApp($this->option('app'));
-        if ($result !== 0) {
+        if ($result !== self::SUCCESS) {
             return $result;
         }
 
@@ -40,11 +51,11 @@ class MakeDashboardCommand extends Command
             $this->line('');
             $this->info('Dashboard files created successfully!');
 
-            return 0;
+            return self::SUCCESS;
         } catch (Exception $e) {
             $this->error('Error creating dashboard: ' . $e->getMessage());
 
-            return 1;
+            return self::FAILURE;
         }
     }
 
@@ -76,9 +87,15 @@ class MakeDashboardCommand extends Command
     protected function addDashboardRoute(): void
     {
         $routeFile = base_path('routes/web.php');
+
+        if (! $this->filesystem->exists($routeFile)) {
+            $this->filesystem->ensureDirectoryExists(dirname($routeFile));
+            $this->filesystem->put($routeFile, "<?php\n\nuse Illuminate\\Support\\Facades\\Route;\n");
+        }
+
         $content = $this->filesystem->get($routeFile);
 
-        $routeName = "{$this->appConfigName}.dashboard";
+        $routeName = self::routeNameFor($this->appConfigName);
 
         if (str_contains($content, "'{$routeName}'")) {
             $this->warn("Route '{$routeName}' already exists in routes/web.php — skipping.");
@@ -88,37 +105,37 @@ class MakeDashboardCommand extends Command
 
         $route = "Route::livewire('{$this->appConfigName}', '{$this->appConfigName}-dashboard')->name('{$routeName}');";
 
-        if (! $this->confirm("Add dashboard route to routes/web.php?\n  <comment>{$route}</comment>", true)) {
+        if (! $this->confirmStep("Add dashboard route to routes/web.php?\n  <comment>{$route}</comment>")) {
             return;
         }
 
-        $this->filesystem->append($routeFile, "\n{$route}\n");
-        $this->line("<info>Route added:</info> {$route}");
+        $this->appendRoute($route);
     }
 
     protected function addDashboardNavigation(): void
     {
         $navPath = base_path("app-configs/{$this->appConfigName}/navigation.yml");
+        $routeName = self::routeNameFor($this->appConfigName);
 
         if (! $this->filesystem->exists($navPath)) {
-            $this->warn("Navigation file not found: {$navPath} — skipping.");
+            $this->createDashboardNavigation($navPath, $routeName);
 
             return;
         }
 
         $content = $this->filesystem->get($navPath);
 
-        if (str_contains($content, "route: {$this->appConfigName}.dashboard")) {
+        if (str_contains($content, "route: {$routeName}")) {
             $this->warn("Dashboard navigation entry already exists in {$navPath} — skipping.");
 
             return;
         }
 
         $navEntry = "    - title: Dashboard\n"
-            . "      route: {$this->appConfigName}.dashboard\n"
+            . "      route: {$routeName}\n"
             . "      heroicon: home";
 
-        if (! $this->confirm("Add dashboard navigation entry to {$this->appConfigName} navigation.yml?\n<comment>{$navEntry}</comment>", true)) {
+        if (! $this->confirmStep("Add dashboard navigation entry to {$this->appConfigName} navigation.yml?\n<comment>{$navEntry}</comment>")) {
             return;
         }
 
@@ -139,5 +156,49 @@ class MakeDashboardCommand extends Command
         $content = mb_rtrim($content) . "\n" . $navEntry . "\n";
         $this->filesystem->put($navPath, $content);
         $this->line("<info>Dashboard navigation added to:</info> {$navPath}");
+    }
+
+    /**
+     * A freshly created app has no navigation yet: write a minimal navigation.yml
+     * whose first block lists the dashboard, so the app is usable right away and
+     * noerd:make-resource / noerd:make-page can append their entries to that block.
+     */
+    protected function createDashboardNavigation(string $navPath, string $routeName): void
+    {
+        $title = TenantApp::query()
+            ->where('name', mb_strtoupper($this->appConfigName))
+            ->value('title') ?: Str::headline($this->appConfigName);
+
+        $navigation = "- title: '" . str_replace("'", "''", $title) . "'\n"
+            . "  name: {$this->appConfigName}\n"
+            . "  route: {$routeName}\n"
+            . "  block_menus:\n"
+            . "    - title: Overview\n"
+            . "      navigations:\n"
+            . "        - title: Dashboard\n"
+            . "          route: {$routeName}\n"
+            . "          heroicon: home\n";
+
+        if (! $this->confirmStep("Create {$this->appConfigName} navigation.yml with a dashboard entry?\n<comment>{$navigation}</comment>")) {
+            return;
+        }
+
+        $this->filesystem->ensureDirectoryExists(dirname($navPath));
+        $this->filesystem->put($navPath, $navigation);
+        $this->line("<info>Created:</info> {$navPath}");
+    }
+
+    /**
+     * Confirm a scaffolding step, defaulting to yes. A non-interactive run (e.g. the
+     * call from noerd:create-app) never asks: the child command shares the caller's
+     * output style, so the question would otherwise reach the caller's prompt.
+     */
+    protected function confirmStep(string $question): bool
+    {
+        if (! $this->input->isInteractive()) {
+            return true;
+        }
+
+        return $this->confirm($question, true);
     }
 }

--- a/tests/Commands/CreateTenantAppTest.php
+++ b/tests/Commands/CreateTenantAppTest.php
@@ -1,25 +1,61 @@
 <?php
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
 use Noerd\Models\TenantApp;
 use Noerd\Tests\TestCase;
 
 uses(TestCase::class);
 uses(RefreshDatabase::class);
 
+/**
+ * The command scaffolds the app's dashboard into the application root (Blade
+ * component, route, navigation). Snapshot what is there before each test and
+ * remove everything the test generated afterwards.
+ */
+beforeEach(function (): void {
+    $routeFile = base_path('routes/web.php');
+
+    $this->routeFileExisted = File::exists($routeFile);
+    $this->originalRoutes = $this->routeFileExisted ? File::get($routeFile) : null;
+    $this->existingDashboards = File::glob(base_path('resources/views/components/*-dashboard.blade.php'));
+    $this->existingAppConfigs = File::directories(base_path('app-configs'));
+});
+
+afterEach(function (): void {
+    $routeFile = base_path('routes/web.php');
+
+    if ($this->routeFileExisted) {
+        File::put($routeFile, $this->originalRoutes);
+    } else {
+        File::delete($routeFile);
+    }
+
+    foreach (File::glob(base_path('resources/views/components/*-dashboard.blade.php')) as $dashboard) {
+        if (! in_array($dashboard, $this->existingDashboards, true)) {
+            File::delete($dashboard);
+        }
+    }
+
+    foreach (File::directories(base_path('app-configs')) as $appConfig) {
+        if (! in_array($appConfig, $this->existingAppConfigs, true)) {
+            File::deleteDirectory($appConfig);
+        }
+    }
+});
+
 it('successfully creates a app with all parameters', function (): void {
     $this->artisan('noerd:create-app', [
         '--title' => 'Test Application',
         '--name' => 'TEST_APP',
         '--icon' => 'icons.test',
-        '--route' => 'test.dashboard',
         '--active' => '1',
     ])
         ->expectsOutput('✅ Tenant app created successfully!')
         ->expectsOutputToContain('Test Application')
         ->expectsOutputToContain('TEST_APP')
         ->expectsOutputToContain('icons.test')
-        ->expectsOutputToContain('test.dashboard')
+        ->expectsOutputToContain('test_app.dashboard')
         ->expectsOutputToContain('Yes')
         ->expectsOutput('Run "php artisan noerd:assign-apps-to-tenant" to assign this app to a tenant.')
         ->assertExitCode(0);
@@ -30,8 +66,96 @@ it('successfully creates a app with all parameters', function (): void {
     $app = TenantApp::where('name', 'TEST_APP')->first();
     expect($app->title)->toBe('Test Application');
     expect($app->icon)->toBe('icons.test');
-    expect($app->route)->toBe('test.dashboard');
+    expect($app->route)->toBe('test_app.dashboard');
     expect($app->is_active)->toBeTrue();
+});
+
+it('scaffolds a dashboard for the new app and uses its route without asking', function (): void {
+    $this->artisan('noerd:create-app', [
+        '--title' => 'Time Booking',
+        '--name' => 'TB',
+        '--icon' => 'icons.tb',
+    ])
+        ->expectsOutput('Dashboard files created successfully!')
+        ->expectsOutput('✅ Tenant app created successfully!')
+        ->assertExitCode(0);
+
+    expect(TenantApp::where('name', 'TB')->value('route'))->toBe('tb.dashboard');
+
+    $dashboard = base_path('resources/views/components/tb-dashboard.blade.php');
+    $stub = File::get(dirname(__DIR__, 2) . '/src/Commands/stubs/resource/dashboard.blade.stub');
+    expect(File::exists($dashboard))->toBeTrue()
+        ->and(File::get($dashboard))->toBe(str_replace('{{appName}}', 'tb', $stub));
+
+    $routes = File::get(base_path('routes/web.php'));
+    expect($routes)
+        ->toContain("Route::livewire('tb', 'tb-dashboard')->name('tb.dashboard');")
+        ->toContain("Route::middleware(['noerd', 'app-access:tb'])");
+
+    $navigation = base_path('app-configs/tb/navigation.yml');
+    expect(File::exists($navigation))->toBeTrue();
+
+    $parsed = Symfony\Component\Yaml\Yaml::parse(File::get($navigation));
+    expect($parsed[0]['title'])->toBe('Time Booking')
+        ->and($parsed[0]['name'])->toBe('tb')
+        ->and($parsed[0]['route'])->toBe('tb.dashboard')
+        ->and($parsed[0]['block_menus'][0]['navigations'][0]['route'])->toBe('tb.dashboard');
+});
+
+it('creates the routes file when the project has none yet', function (): void {
+    File::delete(base_path('routes/web.php'));
+
+    $this->artisan('noerd:create-app', [
+        '--title' => 'Fresh App',
+        '--name' => 'FRESH',
+        '--icon' => 'icons.fresh',
+    ])->assertExitCode(0);
+
+    $routes = File::get(base_path('routes/web.php'));
+    expect($routes)
+        ->toStartWith("<?php\n")
+        ->toContain("->name('fresh.dashboard');");
+});
+
+it('keeps an existing navigation and only inserts the dashboard entry', function (): void {
+    File::ensureDirectoryExists(base_path('app-configs/existing_nav'));
+    File::put(base_path('app-configs/existing_nav/navigation.yml'), implode("\n", [
+        '- title: Existing',
+        '  name: existing_nav',
+        '  route: existing_nav.dashboard',
+        '  block_menus:',
+        '    - title: Overview',
+        '      navigations:',
+        '        - title: Things',
+        '          route: existing_nav.things',
+        '          heroicon: cube',
+        '',
+    ]));
+
+    $this->artisan('noerd:create-app', [
+        '--title' => 'Existing',
+        '--name' => 'EXISTING_NAV',
+        '--icon' => 'icons.existing',
+    ])->assertExitCode(0);
+
+    $parsed = Symfony\Component\Yaml\Yaml::parse(File::get(base_path('app-configs/existing_nav/navigation.yml')));
+    expect($parsed[0]['block_menus'][0]['navigations'][0]['route'])->toBe('existing_nav.things');
+});
+
+it('points the app at an explicit route and skips the dashboard scaffold', function (): void {
+    $this->artisan('noerd:create-app', [
+        '--title' => 'Custom Route App',
+        '--name' => 'CUSTOM_ROUTE',
+        '--icon' => 'icons.custom',
+        '--route' => 'custom.index',
+    ])
+        ->doesntExpectOutput('Dashboard files created successfully!')
+        ->expectsOutputToContain('custom.index')
+        ->assertExitCode(0);
+
+    expect(TenantApp::where('name', 'CUSTOM_ROUTE')->value('route'))->toBe('custom.index')
+        ->and(File::exists(base_path('resources/views/components/custom_route-dashboard.blade.php')))->toBeFalse()
+        ->and(File::exists(base_path('app-configs/custom_route/navigation.yml')))->toBeFalse();
 });
 
 it('creates an inactive tenant app when active is set to 0', function (): void {
@@ -39,7 +163,6 @@ it('creates an inactive tenant app when active is set to 0', function (): void {
         '--title' => 'Inactive App',
         '--name' => 'INACTIVE_APP',
         '--icon' => 'icons.inactive',
-        '--route' => 'inactive.dashboard',
         '--active' => '0',
     ])
         ->expectsOutputToContain('No')
@@ -54,7 +177,6 @@ it('defaults to active when active parameter is not provided', function (): void
         '--title' => 'Default Active App',
         '--name' => 'DEFAULT_ACTIVE',
         '--icon' => 'icons.default',
-        '--route' => 'default.dashboard',
     ])
         ->expectsOutputToContain('Yes')
         ->assertExitCode(0);
@@ -70,9 +192,8 @@ it('fails when required fields are missing', function (): void {
         '--title' => '',
         '--name' => '',
         '--icon' => '',
-        '--route' => '',
     ])
-        ->expectsOutput('All fields (title, name, icon, route) are required.')
+        ->expectsOutput('All fields (title, name, icon) are required.')
         ->assertExitCode(1);
 
     // Verify no new app was created
@@ -83,10 +204,9 @@ it('fails when only some fields are provided', function (): void {
     $this->artisan('noerd:create-app', [
         '--title' => 'Test Title',
         '--name' => 'MISSING_FIELDS',
-        '--icon' => 'icons.test',
-        '--route' => '', // Missing route
+        '--icon' => '', // Missing icon
     ])
-        ->expectsOutput('All fields (title, name, icon, route) are required.')
+        ->expectsOutput('All fields (title, name, icon) are required.')
         ->assertExitCode(1);
 });
 
@@ -95,7 +215,6 @@ it('normalizes the app name to the uppercase underscore form', function (string 
         '--title' => 'Normalized App',
         '--name' => $input,
         '--icon' => 'icons.test',
-        '--route' => 'test.route',
     ])
         ->expectsOutput('✅ Tenant app created successfully!')
         ->assertExitCode(0);
@@ -114,7 +233,6 @@ it('fails when name contains special characters', function (): void {
         '--title' => 'Special Chars App',
         '--name' => 'SPECIAL-CHARS!',
         '--icon' => 'icons.test',
-        '--route' => 'test.route',
     ])
         ->expectsOutput('App name must contain only uppercase letters and underscores (e.g., CMS, MEDIA, MY_APP).')
         ->assertExitCode(1);
@@ -135,10 +253,11 @@ it('fails when app name already exists', function (): void {
         '--title' => 'Duplicate App',
         '--name' => 'EXISTING_APP',
         '--icon' => 'icons.duplicate',
-        '--route' => 'duplicate.route',
     ])
         ->expectsOutput("App with name 'EXISTING_APP' already exists.")
         ->assertExitCode(1);
+
+    expect(File::exists(base_path('resources/views/components/existing_app-dashboard.blade.php')))->toBeFalse();
 });
 
 it('fails when app name conflicts with seeded data', function (): void {
@@ -156,7 +275,6 @@ it('fails when app name conflicts with seeded data', function (): void {
         '--title' => 'Noerd App A Duplicate',
         '--name' => 'NOERD_APP_A',
         '--icon' => 'icons.noerd-app-a',
-        '--route' => 'noerd-app-a.duplicate',
     ])
         ->expectsOutput("App with name 'NOERD_APP_A' already exists.")
         ->assertExitCode(1);
@@ -167,14 +285,13 @@ it('displays comprehensive app details in output table', function (): void {
         '--title' => 'Complete Details App',
         '--name' => 'DETAILS_APP',
         '--icon' => 'icons.details',
-        '--route' => 'details.dashboard',
     ])
         ->expectsOutput('✅ Tenant app created successfully!')
         ->expectsOutputToContain('| ID      |')
         ->expectsOutputToContain('| Title   | Complete Details App')
         ->expectsOutputToContain('| Name    | DETAILS_APP')
         ->expectsOutputToContain('| Icon    | icons.details')
-        ->expectsOutputToContain('| Route   | details.dashboard')
+        ->expectsOutputToContain('| Route   | details_app.dashboard')
         ->expectsOutputToContain('| Active  | Yes')
         ->expectsOutputToContain('| Created |')
         ->assertExitCode(0);


### PR DESCRIPTION
## Summary

- `noerd:create-app` no longer asks for the app route. Every app ships its own dashboard: the command runs `noerd:make-dashboard` for the new app and stores the generated `{app}.dashboard` route as the app's main route. `--route=` remains as an override for install scripts (an explicit route skips the scaffold).
- `noerd:make-dashboard` creates `routes/web.php` when missing, appends the dashboard route inside the `noerd` + `app-access:{app}` middleware group (it was appended unprotected before), and writes a minimal `app-configs/{app}/navigation.yml` with a dashboard entry when the app has no navigation yet. Its confirmations are skipped in non-interactive runs — a `$this->call()` child shares the caller's output style, so `--no-interaction` alone did not silence them.
- Docs (`create-app.md`, `artisan-commands.md`) updated.

## Tests

`tests/Commands/CreateTenantAppTest.php` covers the generated route, dashboard Blade, routes file creation, navigation creation/insertion and the `--route` override. `vendor/bin/pest tests/Commands` is green.