### PR TITLE
Modernise core services, middleware and commands; drop remaining upgrade shims

### DIFF
--- a/docs/artisan-commands.md
+++ b/docs/artisan-commands.md
@@ -92,11 +92,11 @@ php artisan noerd:update-all --force
 | `--build` | Run npm build — applies to `noerd:update` only, no module command defines it |
 | `--except=` | Skip a command; module key or full name (`--except=cms`, `--except=noerd:update`). Repeatable |
 
-**Run order:** `noerd:update` → the module updates alphabetically → `noerd:update-plus` last.
-The order matters at both ends: `noerd:update --force` republishes `app-configs/setup/navigation.yml`
-from the core template, and `noerd:update-plus` restores the entries it removes (Objects, Layouts,
-User Roles, Object Permissions, App Permissions, Recycle bin). The module updates in between only
-write into their own `app-configs/{module}/` and are sorted purely for a reproducible run.
+**Run order:** `noerd:update` → the module updates alphabetically → commands implementing
+`Noerd\Contracts\RunsAfterModuleUpdates` last. The marker is for a module update that touches what
+the core publishes (e.g. one that re-adds its entries to `app-configs/setup/navigation.yml`, which
+`noerd:update --force` rewrites from the core template). The module updates in between only write
+into their own `app-configs/{module}/` and are sorted purely for a reproducible run.
 
 **Discovery** is dynamic: every command named `noerd:update-{module}` that is registered by a loaded
 service provider takes part — nothing is hardcoded, so a newly installed module is picked up
@@ -108,7 +108,7 @@ are skipped and only missing files are copied — a useful "top up a fresh check
 
 > `noerd:update --force` does more than copy YAML: it also overwrites `config/noerd.php`, scaffolds
 > the missing frontend files (see [Installation](installation.md#frontend)), runs `npm install` for
-> any dependency it added, and removes a legacy `tailwind.config.js` brand bridge without asking.
+> any dependency it added.
 > Use `--except=noerd:update` to leave the core step out.
 
 **Failures do not abort the run.** Every command is executed, a summary table lists each one as
@@ -127,8 +127,11 @@ php artisan noerd:demo
 | Option | Description |
 |--------|-------------|
 | `--force` | Overwrite existing files |
+| `--migrate` | Run the migrations — required to migrate in non-interactive runs (interactive runs ask) |
+| `--seed` | Seed the demo data — required to seed in non-interactive runs (interactive runs ask) |
 
-This command is also offered during `noerd:install`. It can be run independently at any time.
+This command is also offered during `noerd:install` (which forwards its own `--migrate` as
+`--migrate --seed`). It can be run independently at any time.
 
 ## noerd:publish-home
 

--- a/resources/views/components/noerd-user-detail.blade.php
+++ b/resources/views/components/noerd-user-detail.blade.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Str;
 use Livewire\Component;
 use Noerd\Helpers\NoerdAuth;
 use Noerd\Models\NoerdUser;
+use Noerd\Rules\AtLeastOneTrue;
 use Noerd\Enums\Profile;
 use Noerd\Models\SetupLanguage;
 use Noerd\Traits\AdministersNoerdUsers;
@@ -77,7 +78,7 @@ new class extends Component {
                 'email',
                 'max:255',
             ],
-            'tenantAccess' => ['array', 'min:1', new \Noerd\Rules\AtLeastOneTrue()],
+            'tenantAccess' => ['array', 'min:1', new AtLeastOneTrue()],
         ]);
 
         if (! $this->modelId) {

--- a/resources/views/components/tenant-detail.blade.php
+++ b/resources/views/components/tenant-detail.blade.php
@@ -15,7 +15,7 @@ new class extends Component {
     public function mount(): void
     {
         if (! $this->modelId) {
-            $this->modelId = (string) NoerdAuth::user()->selected_tenant_id;
+            $this->modelId = NoerdAuth::user()->selected_tenant_id;
         }
 
         $this->authorizeTenant();

--- a/src/Commands/AssignAppsToTenantCommand.php
+++ b/src/Commands/AssignAppsToTenantCommand.php
@@ -12,7 +12,7 @@ use function Laravel\Prompts\select;
 use Noerd\Models\Tenant;
 use Noerd\Models\TenantApp;
 
-class AssignAppsToTenant extends Command
+class AssignAppsToTenantCommand extends Command
 {
     /**
      * The name and signature of the console command.

--- a/src/Commands/Concerns/RunsNpmBuild.php
+++ b/src/Commands/Concerns/RunsNpmBuild.php
@@ -2,10 +2,11 @@
 
 namespace Noerd\Commands\Concerns;
 
+use Illuminate\Support\Facades\Process;
+
 /**
  * Run `npm run build` in the project root, streaming output to the terminal.
- * Shared by noerd:install, noerd:update and the module install commands —
- * previously three byte-identical proc_open blocks.
+ * Shared by noerd:install, noerd:update and the module install commands.
  */
 trait RunsNpmBuild
 {
@@ -14,27 +15,15 @@ trait RunsNpmBuild
         $this->line('Running npm run build...');
         $this->newLine();
 
-        $process = proc_open(
-            'npm run build',
-            [
-                0 => STDIN,
-                1 => STDOUT,
-                2 => STDERR,
-            ],
-            $pipes,
-            base_path(),
-        );
-
-        if (!is_resource($process)) {
-            $this->warn('Could not execute npm run build. Please run it manually.');
-
-            return;
-        }
-
-        $exitCode = proc_close($process);
+        $result = Process::path(base_path())
+            ->timeout(600)
+            ->tty(false)
+            ->run('npm run build', function (string $type, string $buffer): void {
+                $this->output->write($buffer);
+            });
 
         $this->newLine();
-        if ($exitCode === 0) {
+        if ($result->successful()) {
             $this->info('Frontend assets compiled successfully!');
         } else {
             $this->warn('npm run build finished with errors. You may need to run it manually.');

--- a/src/Commands/ImportSetupCollectionDefinitionsCommand.php
+++ b/src/Commands/ImportSetupCollectionDefinitionsCommand.php
@@ -3,6 +3,9 @@
 namespace Noerd\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\File;
+use Noerd\Helpers\TenantHelper;
 use Noerd\Models\Tenant;
 use Noerd\Support\SetupCollectionDefinitionImport;
 
@@ -54,7 +57,7 @@ class ImportSetupCollectionDefinitionsCommand extends Command
 
         if (! $dryRun && $this->option('delete')) {
             foreach (glob($yamlPath . '/*.yml') ?: [] as $file) {
-                @unlink($file);
+                File::delete($file);
             }
             $this->info('Deleted source YAML files.');
         }
@@ -66,9 +69,9 @@ class ImportSetupCollectionDefinitionsCommand extends Command
     }
 
     /**
-     * @return \Illuminate\Support\Collection<int, Tenant>
+     * @return Collection<int, Tenant>
      */
-    private function resolveTargetTenants(): \Illuminate\Support\Collection
+    private function resolveTargetTenants(): Collection
     {
         if ($this->option('all-tenants')) {
             return Tenant::all();
@@ -78,7 +81,7 @@ class ImportSetupCollectionDefinitionsCommand extends Command
             return Tenant::whereKey((int) $tenantId)->get();
         }
 
-        $current = \Noerd\Helpers\TenantHelper::getSelectedTenantId();
+        $current = TenantHelper::getSelectedTenantId();
         if ($current === null) {
             return collect();
         }

--- a/src/Commands/MakeUserAdminCommand.php
+++ b/src/Commands/MakeUserAdminCommand.php
@@ -7,7 +7,7 @@ use Noerd\Enums\Profile;
 use Noerd\Models\NoerdUser;
 use Noerd\Models\Tenant;
 
-class MakeUserAdmin extends Command
+class MakeUserAdminCommand extends Command
 {
     /**
      * The name and signature of the console command.

--- a/src/Commands/NoerdDemoCommand.php
+++ b/src/Commands/NoerdDemoCommand.php
@@ -15,7 +15,10 @@ class NoerdDemoCommand extends Command
 {
     use RequiresNoerdInstallation;
 
-    protected $signature = 'noerd:demo {--force : Overwrite existing files}';
+    protected $signature = 'noerd:demo
+        {--force : Overwrite existing files}
+        {--migrate : Run the demo migrations (required to migrate in non-interactive runs)}
+        {--seed : Seed the demo data (required to seed in non-interactive runs)}';
 
     protected $description = 'Install demo data (models, migrations, views, configs, routes) directly into the project';
 
@@ -236,7 +239,10 @@ ROUTE;
             return;
         }
 
-        if (! confirm('Would you like to seed demo data (sample customers, categories, tags)?', default: true)) {
+        $shouldSeed = (bool) $this->option('seed')
+            || ($this->input->isInteractive() && confirm('Would you like to seed demo data (sample customers, categories, tags)?', default: true));
+
+        if (! $shouldSeed) {
             $this->line('<comment>Skipping demo seed data. Run manually: php artisan db:seed --class=DemoSeeder</comment>');
 
             return;
@@ -249,7 +255,10 @@ ROUTE;
     {
         $this->newLine();
 
-        if (! confirm('Would you like to run migrations now?', default: true)) {
+        $shouldMigrate = (bool) $this->option('migrate')
+            || ($this->input->isInteractive() && confirm('Would you like to run migrations now?', default: true));
+
+        if (! $shouldMigrate) {
             $this->line('<comment>Skipping migrations. Run manually: php artisan migrate</comment>');
 
             return;

--- a/src/Commands/NoerdInstallCommand.php
+++ b/src/Commands/NoerdInstallCommand.php
@@ -4,12 +4,15 @@ namespace Noerd\Commands;
 
 use Exception;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Process;
 
 use function Laravel\Prompts\callout;
 use function Laravel\Prompts\confirm;
 
 use Laravel\Prompts\Elements\Link;
 use Laravel\Prompts\Elements\NumberedList;
+use Noerd\Commands\Concerns\PublishesConfigDirectory;
+use Noerd\Commands\Concerns\RunsNpmBuild;
 use Noerd\Models\NoerdUser;
 use Noerd\Models\Tenant;
 use Noerd\Models\TenantApp;
@@ -17,8 +20,8 @@ use Noerd\Services\FrontendScaffolder;
 
 class NoerdInstallCommand extends Command
 {
-    use \Noerd\Commands\Concerns\PublishesConfigDirectory;
-    use \Noerd\Commands\Concerns\RunsNpmBuild;
+    use PublishesConfigDirectory;
+    use RunsNpmBuild;
 
     protected $signature = 'noerd:install
                             {--force : Overwrite existing files without asking}
@@ -26,7 +29,7 @@ class NoerdInstallCommand extends Command
                             {--build : Run npm build without asking (required to build in non-interactive runs)}
                             {--demo : Install the demo app without asking (required to install it in non-interactive runs)}';
 
-    protected $description = 'Install noerd content to the local content directory';
+    protected $description = 'Install noerd: publish the setup app configs, config and assets, then migrate and create the first admin';
 
     public function handle(): int
     {
@@ -120,7 +123,11 @@ class NoerdInstallCommand extends Command
             return;
         }
 
-        $this->call('noerd:demo', ['--force' => $this->option('force')]);
+        $this->call('noerd:demo', [
+            '--force' => $this->option('force'),
+            '--migrate' => $this->boolOption('migrate'),
+            '--seed' => $this->boolOption('migrate'),
+        ]);
     }
 
     /**
@@ -169,9 +176,6 @@ class NoerdInstallCommand extends Command
 
             // Install whatever the scaffolder added to package.json
             $this->installNpmPackages($scaffolder->missingNpmPackages());
-
-            // Retire the obsolete tailwind.config.js brand bridge
-            $this->migrateLegacyTailwindConfig($scaffolder);
 
             // Update Livewire component layout
             $this->updateLivewireConfig();
@@ -232,7 +236,7 @@ class NoerdInstallCommand extends Command
         // Process handles the working directory and argument escaping — the
         // previous string-built `cd <path> && npm install ...` broke on paths
         // with spaces and discarded npm's diagnostics on failure.
-        $result = \Illuminate\Support\Facades\Process::path(base_path())
+        $result = Process::path(base_path())
             ->timeout(300)
             ->run(array_merge(['npm', 'install'], $packages, ['--save-dev']));
 
@@ -247,52 +251,17 @@ class NoerdInstallCommand extends Command
     }
 
     /**
-     * Offer to remove the obsolete tailwind.config.js brand bridge
-     *
-     * Brand colors are registered as `--color-brand-*` in the package's noerd.css, so the generated
-     * config and its `@config` line in app.css are obsolete. A host-customised config is
-     * only reported — it is never removed automatically.
-     */
-    protected function migrateLegacyTailwindConfig(FrontendScaffolder $scaffolder): void
-    {
-        if (!$scaffolder->hasLegacyTailwindBridge()) {
-            return;
-        }
-
-        if (!$scaffolder->legacyTailwindConfigIsUnmodified()) {
-            $this->warn('tailwind.config.js looks customised and was left untouched.');
-            $this->warn('Brand colors now ship as --color-brand-* in noerd.css; a `colors` block in your config overrides them at build time. See docs/brand.md.');
-
-            return;
-        }
-
-        $this->line('');
-        $this->line('<comment>Found the legacy noerd tailwind.config.js brand bridge.</comment>');
-        $this->line('Brand colors now ship as --color-brand-* in noerd.css, which lets NOERD_BRAND take effect without a rebuild.');
-
-        if (!$this->option('force') && !$this->confirm('Remove tailwind.config.js and its @config line from app.css?', true)) {
-            $this->line('<comment>Kept tailwind.config.js.</comment>');
-
-            return;
-        }
-
-        $scaffolder->removeLegacyTailwindBridge();
-
-        $this->line('<info>Removed tailwind.config.js and its @config line.</info>');
-    }
-
-    /**
      * Detect the installed Node version so the scaffolder can pin compatible build tooling
      */
     protected function detectNodeVersion(): ?string
     {
-        exec('node -v 2>/dev/null', $output, $returnCode);
+        $result = Process::run('node -v');
 
-        if ($returnCode !== 0 || $output === []) {
+        if (! $result->successful() || mb_trim($result->output()) === '') {
             return null;
         }
 
-        return mb_trim((string) $output[0]);
+        return mb_trim($result->output());
     }
 
     /**

--- a/src/Commands/NoerdUpdateAllCommand.php
+++ b/src/Commands/NoerdUpdateAllCommand.php
@@ -3,6 +3,7 @@
 namespace Noerd\Commands;
 
 use Illuminate\Console\Command;
+use Noerd\Contracts\RunsAfterModuleUpdates;
 use Noerd\Traits\RequiresNoerdInstallation;
 use Throwable;
 
@@ -11,12 +12,6 @@ class NoerdUpdateAllCommand extends Command
     use RequiresNoerdInstallation;
 
     private const CORE = 'noerd:update';
-
-    /**
-     * Runs last: noerd:update-plus re-adds the entries to app-configs/setup/navigation.yml
-     * that a preceding `noerd:update --force` overwrites with the core template.
-     */
-    private const RUN_LAST = ['noerd:update-plus'];
 
     protected $signature = 'noerd:update-all
         {--force : Overwrite existing files without asking}
@@ -82,6 +77,7 @@ class NoerdUpdateAllCommand extends Command
     private function discover(): array
     {
         $names = [];
+        $last = [];
 
         foreach ($this->getApplication()->all() as $name => $command) {
             // all() is keyed by name AND by every alias, both pointing at the same instance.
@@ -99,10 +95,15 @@ class NoerdUpdateAllCommand extends Command
             }
 
             $names[] = $name;
+
+            // A command that touches what other updates publish declares it.
+            if ($command instanceof RunsAfterModuleUpdates) {
+                $last[] = $name;
+            }
         }
 
         $core = in_array(self::CORE, $names, true) ? [self::CORE] : [];
-        $last = array_values(array_intersect(self::RUN_LAST, $names));
+        sort($last);
         // Module updates only write into their own app-configs/{key}/, so they are
         // order-independent — sorted purely for a reproducible run.
         $middle = array_values(array_diff($names, $core, $last));

--- a/src/Commands/NoerdUpdateCommand.php
+++ b/src/Commands/NoerdUpdateCommand.php
@@ -8,7 +8,7 @@ class NoerdUpdateCommand extends NoerdInstallCommand
 {
     protected $signature = 'noerd:update {--force : Overwrite existing files without asking} {--build : Run npm build after update}';
 
-    protected $description = 'Update noerd content files without running installation setup';
+    protected $description = 'Refresh the published setup app configs, config and frontend assets of an existing installation';
 
     public function handle(): int
     {

--- a/src/Contracts/RunsAfterModuleUpdates.php
+++ b/src/Contracts/RunsAfterModuleUpdates.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noerd\Contracts;
+
+/**
+ * Marker for a `noerd:update-{module}` command that `noerd:update-all` must run
+ * AFTER every other update — e.g. a module that re-adds entries to the core's
+ * published navigation, which a preceding `noerd:update --force` rewrites.
+ */
+interface RunsAfterModuleUpdates {}

--- a/src/Helpers/StaticConfigHelper.php
+++ b/src/Helpers/StaticConfigHelper.php
@@ -455,7 +455,9 @@ class StaticConfigHelper
             return $entry[1];
         }
 
-        $parsed = Yaml::parse(file_get_contents($path) ?: '') ?: [];
+        $parsed = Yaml::parse(file_get_contents($path) ?: '');
+        // A scalar or empty document is no config — never let it reach an array-typed reader.
+        $parsed = is_array($parsed) ? $parsed : [];
         self::$yamlCache[$path] = [$version, $parsed];
 
         return $parsed;
@@ -800,49 +802,31 @@ class StaticConfigHelper
     }
 
     /**
-     * Process dynamic navigation blocks based on YAML configuration
+     * Resolve the `dynamic:` block menus of a navigation structure through the
+     * DynamicNavigationRegistry and apply the config/superAdmin/route filters
+     * to every block's entries.
      */
     private static function processDynamicNavigation(array $navigationStructure): array
     {
         $registry = app(DynamicNavigationRegistry::class);
 
-        // Support legacy navigation structure with block_menus at top level
-        if (isset($navigationStructure[0]['block_menus'])) {
-            foreach ($navigationStructure as $i => $appBlock) {
-                $blockMenus = $appBlock['block_menus'] ?? [];
-                foreach ($blockMenus as $j => $menu) {
-                    $dynamicType = $menu['dynamic'] ?? null;
-                    if ($dynamicType) {
-                        $provider = $registry->resolve($dynamicType);
-                        if ($provider) {
-                            $navigationStructure[$i]['block_menus'][$j]['navigations'] = $provider->items();
-                        }
-                        unset($navigationStructure[$i]['block_menus'][$j]['dynamic']);
-                    }
-
-                    // Filter navigation items by config attribute
-                    $navigations = $navigationStructure[$i]['block_menus'][$j]['navigations'] ?? [];
-                    $navigationStructure[$i]['block_menus'][$j]['navigations'] = self::filterNavigationByConfig($navigations);
-                }
+        foreach ($navigationStructure as $i => $appBlock) {
+            if (! is_array($appBlock)) {
+                continue;
             }
 
-            return $navigationStructure;
-        }
-
-        $items = $navigationStructure['items'] ?? [];
-        if (is_array($items)) {
-            foreach ($items as $index => $item) {
-                $dynamicType = $item['dynamic'] ?? ($item['collection'] ?? null);
-                if (($item['type'] ?? null) === 'dynamic' && $dynamicType) {
+            foreach ($appBlock['block_menus'] ?? [] as $j => $menu) {
+                $dynamicType = $menu['dynamic'] ?? null;
+                if ($dynamicType) {
                     $provider = $registry->resolve($dynamicType);
                     if ($provider) {
-                        $children = $item['children'] ?? [];
-                        if (!is_array($children)) {
-                            $children = [];
-                        }
-                        $navigationStructure['items'][$index]['children'] = array_merge($children, $provider->items());
+                        $navigationStructure[$i]['block_menus'][$j]['navigations'] = $provider->items();
                     }
+                    unset($navigationStructure[$i]['block_menus'][$j]['dynamic']);
                 }
+
+                $navigations = $navigationStructure[$i]['block_menus'][$j]['navigations'] ?? [];
+                $navigationStructure[$i]['block_menus'][$j]['navigations'] = self::filterNavigationByConfig($navigations);
             }
         }
 
@@ -904,7 +888,7 @@ class StaticConfigHelper
 
         $paths = [];
         foreach ($mapping[$appKey] ?? [] as $module) {
-            $sourcePath = base_path("app-modules/{$module}/app-configs/{$appKey}");
+            $sourcePath = base_path(config('noerd.generators.modules_path', 'app-modules') . "/{$module}/app-configs/{$appKey}");
             if (is_dir($sourcePath)) {
                 $paths[] = $sourcePath;
             }
@@ -928,7 +912,7 @@ class StaticConfigHelper
         }
 
         $mappings = [];
-        $appModulesPath = base_path('app-modules');
+        $appModulesPath = base_path(config('noerd.generators.modules_path', 'app-modules'));
 
         if (!is_dir($appModulesPath)) {
             return self::$moduleSourceMappingCache[$basePath] = $mappings;

--- a/src/Helpers/TenantHelper.php
+++ b/src/Helpers/TenantHelper.php
@@ -17,6 +17,9 @@ class TenantHelper
      */
     private static array $tenantMemo = [];
 
+    /** Request memo of the single-tenant fallback (false = looked up, none). */
+    private static int|false|null $singleTenantId = null;
+
     /**
      * The tenant the current request operates in — the SINGLE source both the
      * tenant scope and the tenant stamp read, so a record is never written with a
@@ -32,17 +35,18 @@ class TenantHelper
     }
 
     /**
-     * Get the selected tenant ID from session.
+     * The tenant selected in the session. A single-tenant installation has
+     * exactly one tenant, which is the answer whenever nothing is selected —
+     * resolved read-only (memoized per request), the session is only written
+     * by setSelectedTenantId().
      */
     public static function getSelectedTenantId(): ?int
     {
         $id = session('noerd.selected_tenant_id');
 
         if (! $id && ! config('noerd.features.multi_tenant')) {
-            $id = Tenant::first()?->id;
-            if ($id) {
-                session(['noerd.selected_tenant_id' => $id]);
-            }
+            self::$singleTenantId ??= (Tenant::query()->value('id') ?? false);
+            $id = self::$singleTenantId ?: null;
         }
 
         return $id;
@@ -85,6 +89,7 @@ class TenantHelper
     public static function clearCache(): void
     {
         self::$tenantMemo = [];
+        self::$singleTenantId = null;
     }
 
     /**

--- a/src/Livewire/RelationFieldComponent.php
+++ b/src/Livewire/RelationFieldComponent.php
@@ -2,6 +2,7 @@
 
 namespace Noerd\Livewire;
 
+use Illuminate\Database\Eloquent\Model;
 use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
@@ -184,7 +185,7 @@ abstract class RelationFieldComponent extends Component
      * The related Eloquent model behind the current value — for custom renderer
      * components (fieldComponent) that display more than the title.
      */
-    public function relatedModel(): mixed
+    public function relatedModel(): ?Model
     {
         if (!$this->value) {
             return null;

--- a/src/Mail/EmailPreviewTestMail.php
+++ b/src/Mail/EmailPreviewTestMail.php
@@ -5,6 +5,8 @@ namespace Noerd\Mail;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
 
 /**
@@ -22,8 +24,13 @@ class EmailPreviewTestMail extends Mailable implements ShouldQueue
         private readonly string $subjectLine,
     ) {}
 
-    public function build(): self
+    public function envelope(): Envelope
     {
-        return $this->subject($this->subjectLine)->html($this->htmlContent);
+        return new Envelope(subject: $this->subjectLine);
+    }
+
+    public function content(): Content
+    {
+        return new Content(htmlString: $this->htmlContent);
     }
 }

--- a/src/Middleware/ActionPermissionMiddleware.php
+++ b/src/Middleware/ActionPermissionMiddleware.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Guards a route behind a named action permission, e.g.
- * `->middleware('action-permission:production.start-run')`. The decision is
+ * `->middleware('action-permission:production_start_run')`. The decision is
  * AccessHelper::canPerformAction() — an undefined action gate falls back to
  * the profile baseline (see AccessHelper).
  */

--- a/src/Middleware/AppAccessMiddleware.php
+++ b/src/Middleware/AppAccessMiddleware.php
@@ -10,6 +10,12 @@ use Noerd\Helpers\NoerdAuth;
 use Noerd\Helpers\TenantHelper;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * Guards the routes of a tenant app (`app-access:crm` or `app-access:crm,sales`
+ * for routes shared by several apps): the tenant must run one of the apps and
+ * the user must be allowed to access it. The matching app becomes the selected
+ * app, so the navigation always shows the app the route belongs to.
+ */
 class AppAccessMiddleware
 {
     /**
@@ -19,7 +25,6 @@ class AppAccessMiddleware
      */
     public function handle(Request $request, Closure $next, string ...$appNames): Response
     {
-        $appName = implode(',', $appNames);
         $user = NoerdAuth::user();
 
         if (!$user) {
@@ -29,44 +34,25 @@ class AppAccessMiddleware
         $tenant = TenantHelper::getSelectedTenant();
 
         if (!$tenant) {
-            return redirect('/');
+            return redirect()->route('noerd.no-tenant');
         }
 
-        // In single-tenant mode, every app is assigned — but the per-app
-        // authorization gate (see AccessHelper) still applies.
-        if (!config('noerd.features.multi_tenant')) {
-            $accessible = array_filter(
-                $appNames,
-                fn(string $candidate): bool => AccessHelper::canAccessApp(mb_trim($candidate)),
-            );
-            if ($accessible === []) {
-                throw new NoerdException(
-                    NoerdException::TYPE_APP_ACCESS_DENIED,
-                    appName: mb_strtoupper(mb_trim($appNames[0])),
-                );
-            }
-
-            TenantHelper::setSelectedAppFromRoute();
-
-            return $next($request);
-        }
-
-        $appNames = array_map(
+        $appNames = array_values(array_filter(array_map(
             fn(string $name): string => mb_strtolower(mb_trim($name)),
-            explode(',', $appName),
-        );
+            $appNames,
+        )));
 
-        // ONE query for all candidates; the first candidate in route order wins,
-        // matching the old per-candidate loop (which cost one query each).
-        $assignedByLower = $tenant->tenantApps()
-            ->namedAny($appNames)
-            ->pluck('name')
-            ->keyBy(fn(string $name): string => mb_strtolower($name));
+        // In single-tenant mode every app is assigned — only the per-app
+        // authorization gate (see AccessHelper) applies.
+        $assigned = config('noerd.features.multi_tenant')
+            ? $tenant->tenantApps()->namedAny($appNames)->pluck('name')->map(fn(string $name): string => mb_strtolower($name))->all()
+            : $appNames;
 
+        // The first candidate in route order wins.
         $matchingApp = null;
         foreach ($appNames as $candidate) {
-            if ($assignedByLower->has($candidate)) {
-                $matchingApp = $assignedByLower[$candidate];
+            if (in_array($candidate, $assigned, true)) {
+                $matchingApp = $candidate;
                 break;
             }
         }
@@ -74,7 +60,7 @@ class AppAccessMiddleware
         if (!$matchingApp) {
             throw new NoerdException(
                 NoerdException::TYPE_APP_NOT_ASSIGNED,
-                appName: mb_strtoupper($appNames[0]),
+                appName: mb_strtoupper($appNames[0] ?? ''),
             );
         }
 
@@ -85,8 +71,7 @@ class AppAccessMiddleware
             );
         }
 
-        // Only select the app when the session carries no selection yet
-        if (!TenantHelper::getSelectedApp()) {
+        if (TenantHelper::getSelectedApp() !== mb_strtoupper($matchingApp)) {
             TenantHelper::setSelectedApp(mb_strtoupper($matchingApp));
         }
 

--- a/src/Models/SetupCollectionDefinition.php
+++ b/src/Models/SetupCollectionDefinition.php
@@ -5,17 +5,15 @@ namespace Noerd\Models;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Noerd\Traits\BelongsToTenant;
 
 class SetupCollectionDefinition extends Model
 {
+    use BelongsToTenant;
+
     protected $table = 'setup_collection_definitions';
 
     protected $guarded = [];
-
-    public function tenant(): BelongsTo
-    {
-        return $this->belongsTo(Tenant::class);
-    }
 
     public function creator(): BelongsTo
     {

--- a/src/Models/SetupCollectionEntry.php
+++ b/src/Models/SetupCollectionEntry.php
@@ -24,10 +24,8 @@ class SetupCollectionEntry extends Model
     /**
      * Boot method to add model event listeners
      */
-    protected static function boot(): void
+    protected static function booted(): void
     {
-        parent::boot();
-
         // Apply field type conversion before saving
         static::saving(function (SetupCollectionEntry $entry): void {
             if ($entry->collection) {

--- a/src/Models/SetupLanguage.php
+++ b/src/Models/SetupLanguage.php
@@ -95,10 +95,8 @@ class SetupLanguage extends Model
         return SetupLanguageFactory::new();
     }
 
-    protected static function boot(): void
+    protected static function booted(): void
     {
-        parent::boot();
-
         // After saving, ensure only one default per tenant
         static::saved(function (SetupLanguage $language): void {
             if ($language->is_default) {

--- a/src/Providers/NoerdServiceProvider.php
+++ b/src/Providers/NoerdServiceProvider.php
@@ -12,7 +12,7 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Livewire\ComponentHookRegistry;
 use Livewire\Livewire;
-use Noerd\Commands\AssignAppsToTenant;
+use Noerd\Commands\AssignAppsToTenantCommand;
 use Noerd\Commands\CreateAdminCommand;
 use Noerd\Commands\CreateTenantApp;
 use Noerd\Commands\CreateTenantCommand;
@@ -26,7 +26,7 @@ use Noerd\Commands\MakeModuleCommand;
 use Noerd\Commands\MakePageCommand;
 use Noerd\Commands\MakeResourceCommand;
 use Noerd\Commands\MakeThemeCommand;
-use Noerd\Commands\MakeUserAdmin;
+use Noerd\Commands\MakeUserAdminCommand;
 use Noerd\Commands\NoerdDemoCommand;
 use Noerd\Commands\NoerdInfoCommand;
 use Noerd\Commands\NoerdInstallCommand;
@@ -385,13 +385,13 @@ class NoerdServiceProvider extends ServiceProvider
             }
 
             $this->commands([
-                MakeUserAdmin::class,
+                MakeUserAdminCommand::class,
                 NoerdInfoCommand::class,
                 NoerdInstallCommand::class,
                 NoerdUpdateCommand::class,
                 NoerdUpdateAllCommand::class,
                 CreateTenantApp::class,
-                AssignAppsToTenant::class,
+                AssignAppsToTenantCommand::class,
                 MakeModuleCommand::class,
                 MakeResourceCommand::class,
                 MakeListCommand::class,

--- a/src/Repositories/DatabaseSetupCollectionDefinitionRepository.php
+++ b/src/Repositories/DatabaseSetupCollectionDefinitionRepository.php
@@ -7,6 +7,7 @@ use Noerd\Contracts\SetupCollectionDefinitionRepositoryContract;
 use Noerd\Helpers\NoerdAuth;
 use Noerd\Helpers\TenantHelper;
 use Noerd\Models\SetupCollectionDefinition;
+use Noerd\Scopes\TenantScope;
 use Noerd\Support\SetupCollectionDefinitionData;
 use RuntimeException;
 
@@ -28,7 +29,7 @@ class DatabaseSetupCollectionDefinitionRepository implements SetupCollectionDefi
     {
         $tenantId = $this->scopeTenantId($tenantId);
 
-        return SetupCollectionDefinition::query()
+        return SetupCollectionDefinition::withoutGlobalScope(TenantScope::class)
             ->where('tenant_id', $tenantId)
             ->orderBy('title_list')
             ->get()
@@ -46,7 +47,7 @@ class DatabaseSetupCollectionDefinitionRepository implements SetupCollectionDefi
     {
         $tenantId = $this->scopeTenantId($tenantId);
 
-        $model = SetupCollectionDefinition::query()
+        $model = SetupCollectionDefinition::withoutGlobalScope(TenantScope::class)
             ->where('tenant_id', $tenantId)
             ->where('key', mb_strtoupper($key))
             ->first();
@@ -148,9 +149,9 @@ class DatabaseSetupCollectionDefinitionRepository implements SetupCollectionDefi
     }
 
     /**
-     * The tenant every read is scoped to. SetupCollectionDefinition carries no
-     * BelongsToTenant, so a null tenant used to drop the filter entirely and
-     * expose every tenant's definitions. Reads now fail closed instead.
+     * The tenant every read is scoped to. The repository filters explicitly
+     * (callers may address another tenant, e.g. the import command), so the
+     * model's tenant scope is bypassed here; a null tenant fails closed.
      */
     private function scopeTenantId(?int $tenantId): ?int
     {
@@ -159,7 +160,7 @@ class DatabaseSetupCollectionDefinitionRepository implements SetupCollectionDefi
 
     private function resolveFieldsUncached(string $filename, ?int $tenantId): ?array
     {
-        $query = SetupCollectionDefinition::query()
+        $query = SetupCollectionDefinition::withoutGlobalScope(TenantScope::class)
             ->where('tenant_id', $tenantId);
 
         $model = (clone $query)->where('filename', $filename)->first();
@@ -197,7 +198,7 @@ class DatabaseSetupCollectionDefinitionRepository implements SetupCollectionDefi
     {
         $tenantId = $this->scopeTenantId($tenantId);
 
-        return SetupCollectionDefinition::query()
+        return SetupCollectionDefinition::withoutGlobalScope(TenantScope::class)
             ->where('tenant_id', $tenantId)
             ->where('filename', $filename)
             ->first();

--- a/src/Rules/AtLeastOneTrue.php
+++ b/src/Rules/AtLeastOneTrue.php
@@ -1,31 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Noerd\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 
-class AtLeastOneTrue implements Rule
+/**
+ * Passes when the value is an array with at least one element that is `true`.
+ */
+class AtLeastOneTrue implements ValidationRule
 {
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @return bool
-     */
-    public function passes($attribute, $value)
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        // Check if the value is an array and at least one element is true
-        return is_array($value) && in_array(true, $value, true);
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string
-     */
-    public function message()
-    {
-        return 'The :attribute must have at least one true value.';
+        if (! is_array($value) || ! in_array(true, $value, true)) {
+            $fail(__('The :attribute must have at least one true value.'));
+        }
     }
 }

--- a/src/Services/DetailSlotsRegistry.php
+++ b/src/Services/DetailSlotsRegistry.php
@@ -2,6 +2,8 @@
 
 namespace Noerd\Services;
 
+use Noerd\Support\SortedRegistrations;
+
 /**
  * Livewire components contributed into named detail slots by optional modules,
  * which register themselves from their service provider's boot(). A hosting
@@ -29,6 +31,6 @@ class DetailSlotsRegistry
     /** @return array<int, string> */
     public function for(string $slot): array
     {
-        return \Noerd\Support\SortedRegistrations::payloads($this->slots[$slot] ?? [], 'component');
+        return SortedRegistrations::payloads($this->slots[$slot] ?? [], 'component');
     }
 }

--- a/src/Services/FrontendScaffolder.php
+++ b/src/Services/FrontendScaffolder.php
@@ -92,11 +92,6 @@ final class FrontendScaffolder
     private const TAILWIND_CSS_IMPORT = "@import 'tailwindcss';";
 
     /**
-     * The Tailwind 3 config bridge noerd used to inject before the brand palette became CSS-first.
-     */
-    private const LEGACY_CONFIG_DIRECTIVE = "@config '../../tailwind.config.js';";
-
-    /**
      * @var array<int, array{file: string, action: string, detail: string}>
      */
     private array $results = [];
@@ -141,63 +136,6 @@ final class FrontendScaffolder
     public function missingNpmPackages(): array
     {
         return $this->missingNpmPackages;
-    }
-
-    /**
-     * Whether a legacy noerd-generated tailwind.config.js is still bridged into app.css.
-     *
-     * Brand colors ship as `--color-brand-*` in the package's noerd.css since the palette became
-     * CSS-first, so the generated config and its `@config` line are obsolete.
-     */
-    public function hasLegacyTailwindBridge(): bool
-    {
-        $css = $this->read(self::CSS_ENTRY);
-
-        return $css !== null
-            && $this->containsDirective($this->splitLines($css), self::LEGACY_CONFIG_DIRECTIVE)
-            && file_exists($this->path('tailwind.config.js'));
-    }
-
-    /**
-     * Whether the host still uses the tailwind.config.js exactly as noerd generated it.
-     *
-     * The `VITE_BRAND_PRIMARY` marker only ever came from noerd's own generator, so a config
-     * without it was customised by the host and must never be removed automatically.
-     */
-    public function legacyTailwindConfigIsUnmodified(): bool
-    {
-        $config = $this->read('tailwind.config.js');
-
-        return $config !== null && str_contains($config, 'VITE_BRAND_PRIMARY');
-    }
-
-    /**
-     * Remove the obsolete tailwind.config.js bridge. No .bak copy is kept — the
-     * host project keeps its change history in version control.
-     */
-    public function removeLegacyTailwindBridge(): void
-    {
-        $configPath = $this->path('tailwind.config.js');
-
-        if (file_exists($configPath)) {
-            unlink($configPath);
-        }
-
-        $css = $this->read(self::CSS_ENTRY);
-
-        if ($css === null) {
-            return;
-        }
-
-        // A project may carry the directive more than once — updateAppCss() used to append its
-        // block at EOF regardless of an existing @config line — so every occurrence is dropped.
-        $needle = $this->normalizeDirective(self::LEGACY_CONFIG_DIRECTIVE);
-        $kept = array_filter(
-            $this->splitLines($css),
-            fn(string $line): bool => $this->normalizeDirective($line) !== $needle,
-        );
-
-        $this->write(self::CSS_ENTRY, implode(PHP_EOL, $this->trimTrailingBlankLines(array_values($kept))) . PHP_EOL);
     }
 
     /**

--- a/src/Services/RelationBoxRegistry.php
+++ b/src/Services/RelationBoxRegistry.php
@@ -2,6 +2,8 @@
 
 namespace Noerd\Services;
 
+use Noerd\Support\SortedRegistrations;
+
 /**
  * Relation-box tiles contributed for a host model by optional modules, which
  * register themselves from their service provider's boot(). The host page's
@@ -52,6 +54,6 @@ class RelationBoxRegistry
             }
         }
 
-        return \Noerd\Support\SortedRegistrations::payloads($entries, 'tile');
+        return SortedRegistrations::payloads($entries, 'tile');
     }
 }

--- a/src/Support/FieldTypeDefinition.php
+++ b/src/Support/FieldTypeDefinition.php
@@ -13,8 +13,8 @@ class FieldTypeDefinition
         public string $kind,
         public string $target,
         public array $props = [],
-        public $resolver = null,
-        public $keyResolver = null,
+        public mixed $resolver = null,
+        public mixed $keyResolver = null,
     ) {}
 
     /**

--- a/src/Support/RelationFieldDefinition.php
+++ b/src/Support/RelationFieldDefinition.php
@@ -23,7 +23,7 @@ class RelationFieldDefinition
         public ?string $detailComponent = null,
         public ?string $detailRoute = null,
         public ?string $modelClass = null,
-        public $titleResolver = null,
+        public mixed $titleResolver = null,
         public ?string $selectEvent = null,
         public ?string $fieldComponent = null,
     ) {}

--- a/src/Traits/BelongsToTenant.php
+++ b/src/Traits/BelongsToTenant.php
@@ -28,15 +28,6 @@ trait BelongsToTenant
         });
     }
 
-    public function initializeBelongsToTenant(): void
-    {
-        // Only add tenant_id to fillable if the model explicitly defines fillable fields
-        // If the model uses $guarded instead, we don't need to modify $fillable
-        if (! empty($this->fillable) && ! in_array('tenant_id', $this->fillable)) {
-            $this->fillable[] = 'tenant_id';
-        }
-    }
-
     public function tenant(): BelongsTo
     {
         return $this->belongsTo(Tenant::class);

--- a/src/Traits/NoerdComponentShared.php
+++ b/src/Traits/NoerdComponentShared.php
@@ -4,10 +4,9 @@ namespace Noerd\Traits;
 
 /**
  * The few members NoerdList and NoerdPage genuinely share. Both traits compose
- * this one; PHP dedupes a method arriving through multiple use-paths of the
- * SAME trait, so a component may use NoerdList and NoerdPage together without
- * a collision — previously the byte-identical copies in each trait made that
- * combination a fatal conflict.
+ * this one, and PHP dedupes a method arriving through multiple use-paths of
+ * the SAME trait — a component composing NoerdList and NoerdPage only has to
+ * resolve the members both traits define themselves (mount(), getListeners()).
  */
 trait NoerdComponentShared
 {

--- a/src/Traits/NoerdDetail.php
+++ b/src/Traits/NoerdDetail.php
@@ -32,20 +32,6 @@ trait NoerdDetail
         $this->initDetail();
     }
 
-    public function initDetail(): void
-    {
-        $this->initNoerdComponent(function (): void {
-            // For detail components declaring $detailModel. Loads the pageLayout
-            // first so the YAML quick-create opt-in below can be read from it.
-            if (isset($this->detailModel)) {
-                $modelClass = $this->detailModel;
-                $this->mountDetailComponent(new $modelClass(), $modelClass);
-            }
-
-            $this->resolveQuickCreate();
-        });
-    }
-
     public function store(): void
     {
         // Server-side guard: the save button is hidden for denied users, but
@@ -192,6 +178,20 @@ trait NoerdDetail
         $this->applyLayoutDefaults();
         $this->ensureCustomAttributesArray();
         $this->ensureRelationFormsHydrated();
+    }
+
+    protected function initDetail(): void
+    {
+        $this->initNoerdComponent(function (): void {
+            // For detail components declaring $detailModel. Loads the pageLayout
+            // first so the YAML quick-create opt-in below can be read from it.
+            if (isset($this->detailModel)) {
+                $modelClass = $this->detailModel;
+                $this->mountDetailComponent(new $modelClass(), $modelClass);
+            }
+
+            $this->resolveQuickCreate();
+        });
     }
 
     /**

--- a/src/Traits/NoerdList.php
+++ b/src/Traits/NoerdList.php
@@ -242,106 +242,6 @@ trait NoerdList
         $this->mountList();
     }
 
-    public function mountList(): void
-    {
-        $this->listId = Str::random();
-
-        // A list that IS a record (opened by route as a modal, e.g. the object of
-        // the custom-attribute manager) reopens as a modal over the previously
-        // visited page when its ?modal=true URL is loaded directly. Plain lists
-        // are never routed that way and fall straight through.
-        if ($this->redirectToRoutedModal()) {
-            return;
-        }
-
-        $this->perPage = session("listPerPage.{$this->componentName()}", 50);
-        $this->loadListFilters();
-
-        // Column filters: a ?cf[...] URL param (shared link) wins over the session
-        // state and is persisted. Embedded lists (compact/picker) never apply it —
-        // the param addresses the page-level list, but Livewire hydrates it on
-        // nested lists too.
-        $urlColumnFilters = (!$this->compact && !$this->returnsSelection)
-            ? array_filter($this->listColumnFilters, fn($value): bool => is_string($value) && mb_trim($value) !== '')
-            : [];
-        if ($urlColumnFilters !== []) {
-            $this->listColumnFilters = $urlColumnFilters;
-            session(["listColumnFilters.{$this->componentName()}" => $urlColumnFilters]);
-        } else {
-            $this->listColumnFilters = session("listColumnFilters.{$this->componentName()}", []);
-        }
-
-        $savedView = session("listView.{$this->componentName()}");
-
-        // A ?view= URL param (shared link) wins over the session-saved view.
-        // Embedded lists (compact/picker) never apply it — the param addresses
-        // the page-level list, but Livewire hydrates it on nested lists too.
-        $urlView = (!$this->compact && !$this->returnsSelection) ? $this->listViewParam : null;
-        if ($urlView !== null && $urlView !== '') {
-            // The URL carries '--' instead of '::' as the app separator (no
-            // '%3A%3A' noise); decode it back to the composite key. A hand-typed
-            // legacy '::' still parses as-is.
-            if (!str_contains($urlView, '::') && str_contains($urlView, '--')) {
-                $urlView = Str::replaceFirst('--', '::', $urlView);
-            }
-            [$urlApp, $urlKey] = StaticConfigHelper::parseListViewKey($urlView);
-            if ($urlApp !== null && $urlApp === StaticConfigHelper::getCurrentApp()) {
-                $urlView = $urlKey;
-            }
-            if ($urlView === 'default' || array_key_exists($urlView, $this->availableListViews)) {
-                $savedView = $urlView;
-                session(["listView.{$this->componentName()}" => $urlView]);
-            }
-        }
-
-        if ($savedView) {
-            // A composite key whose app has become the current app collapses to
-            // its plain form (selected elsewhere, reopened inside that app).
-            [$savedApp, $savedKey] = StaticConfigHelper::parseListViewKey($savedView);
-            if ($savedApp !== null && $savedApp === StaticConfigHelper::getCurrentApp()) {
-                $savedView = $savedKey;
-            }
-            if ($savedView !== 'default' && array_key_exists($savedView, $this->availableListViews)) {
-                $this->applyListViewKey($savedView);
-            }
-        }
-
-        // The base view can be hidden from this user (a restricted 'default')
-        // or exist only in another allowed app: fall to the first
-        // view they are allowed to see. When every view is filtered away, the
-        // base stays — fail open.
-        if ($this->listView === null && $this->listViewApp === null
-            && $this->availableListViews !== []
-            && !array_key_exists('default', $this->availableListViews)) {
-            $this->applyListViewKey(array_key_first($this->availableListViews));
-        }
-
-        $this->syncListViewParam();
-
-        // The sort restore runs AFTER the view restore on purpose: with no
-        // session-saved sort the default comes from the ACTIVE view's YAML
-        // (`defaultSort:`), so an alternate list view brings its own order.
-        $savedSort = session("listSort.{$this->componentName()}");
-        if ($savedSort) {
-            $this->sortField = $savedSort['field'];
-            $this->sortAsc = $savedSort['asc'];
-        } else {
-            $this->applyDefaultSortFromConfig();
-        }
-
-        // Deep-link support: ?{entity}Id=5 opens the record's modal over the
-        // list, ?create=1 the create modal. Mount-only BY DESIGN — Livewire
-        // updates POST to /livewire/update and carry no page query, and the
-        // former `rendering()` hook was both accidental-initial-load-only and
-        // silently disabled by any component defining its own rendering().
-        $deepLinkId = (int) request()->query($this->getDeepLinkParam());
-        if ($deepLinkId) {
-            $this->listAction($deepLinkId);
-        } elseif (request()->query('create')) {
-            $this->listAction();
-        }
-    }
-
     /**
      * All views available for this list across every allowed app: per app the
      * base config ('default') plus every "--{key}" sibling YAML. Current-app
@@ -445,17 +345,6 @@ trait NoerdList
 
         $this->sortAsc = $ascending;
         $this->persistListSort();
-    }
-
-    /**
-     * The header filters live in ONE session bucket shared across lists ON
-     * PURPOSE: NoerdPage::setPreselect() seeds it from detail pages so a
-     * related list opens pre-filtered, and preselect() reads it back. Only
-     * columns whitelisted per list (getAllowedListFilterColumns) ever apply.
-     */
-    public function loadListFilters(): void
-    {
-        $this->listFilters = session('listFilters', []);
     }
 
     public function storeActiveListFilters(): void
@@ -905,6 +794,117 @@ trait NoerdList
     protected static function tableHasColumn(string $table, string $column): bool
     {
         return SchemaColumnCache::hasColumn($table, $column);
+    }
+
+    protected function mountList(): void
+    {
+        $this->listId = Str::random();
+
+        // A list that IS a record (opened by route as a modal, e.g. the object of
+        // the custom-attribute manager) reopens as a modal over the previously
+        // visited page when its ?modal=true URL is loaded directly. Plain lists
+        // are never routed that way and fall straight through.
+        if ($this->redirectToRoutedModal()) {
+            return;
+        }
+
+        $this->perPage = session("listPerPage.{$this->componentName()}", 50);
+        $this->loadListFilters();
+
+        // Column filters: a ?cf[...] URL param (shared link) wins over the session
+        // state and is persisted. Embedded lists (compact/picker) never apply it —
+        // the param addresses the page-level list, but Livewire hydrates it on
+        // nested lists too.
+        $urlColumnFilters = (!$this->compact && !$this->returnsSelection)
+            ? array_filter($this->listColumnFilters, fn($value): bool => is_string($value) && mb_trim($value) !== '')
+            : [];
+        if ($urlColumnFilters !== []) {
+            $this->listColumnFilters = $urlColumnFilters;
+            session(["listColumnFilters.{$this->componentName()}" => $urlColumnFilters]);
+        } else {
+            $this->listColumnFilters = session("listColumnFilters.{$this->componentName()}", []);
+        }
+
+        $savedView = session("listView.{$this->componentName()}");
+
+        // A ?view= URL param (shared link) wins over the session-saved view.
+        // Embedded lists (compact/picker) never apply it — the param addresses
+        // the page-level list, but Livewire hydrates it on nested lists too.
+        $urlView = (!$this->compact && !$this->returnsSelection) ? $this->listViewParam : null;
+        if ($urlView !== null && $urlView !== '') {
+            // The URL carries '--' instead of '::' as the app separator (no
+            // '%3A%3A' noise); decode it back to the composite key. A hand-typed
+            // legacy '::' still parses as-is.
+            if (!str_contains($urlView, '::') && str_contains($urlView, '--')) {
+                $urlView = Str::replaceFirst('--', '::', $urlView);
+            }
+            [$urlApp, $urlKey] = StaticConfigHelper::parseListViewKey($urlView);
+            if ($urlApp !== null && $urlApp === StaticConfigHelper::getCurrentApp()) {
+                $urlView = $urlKey;
+            }
+            if ($urlView === 'default' || array_key_exists($urlView, $this->availableListViews)) {
+                $savedView = $urlView;
+                session(["listView.{$this->componentName()}" => $urlView]);
+            }
+        }
+
+        if ($savedView) {
+            // A composite key whose app has become the current app collapses to
+            // its plain form (selected elsewhere, reopened inside that app).
+            [$savedApp, $savedKey] = StaticConfigHelper::parseListViewKey($savedView);
+            if ($savedApp !== null && $savedApp === StaticConfigHelper::getCurrentApp()) {
+                $savedView = $savedKey;
+            }
+            if ($savedView !== 'default' && array_key_exists($savedView, $this->availableListViews)) {
+                $this->applyListViewKey($savedView);
+            }
+        }
+
+        // The base view can be hidden from this user (a restricted 'default')
+        // or exist only in another allowed app: fall to the first
+        // view they are allowed to see. When every view is filtered away, the
+        // base stays — fail open.
+        if ($this->listView === null && $this->listViewApp === null
+            && $this->availableListViews !== []
+            && !array_key_exists('default', $this->availableListViews)) {
+            $this->applyListViewKey(array_key_first($this->availableListViews));
+        }
+
+        $this->syncListViewParam();
+
+        // The sort restore runs AFTER the view restore on purpose: with no
+        // session-saved sort the default comes from the ACTIVE view's YAML
+        // (`defaultSort:`), so an alternate list view brings its own order.
+        $savedSort = session("listSort.{$this->componentName()}");
+        if ($savedSort) {
+            $this->sortField = $savedSort['field'];
+            $this->sortAsc = $savedSort['asc'];
+        } else {
+            $this->applyDefaultSortFromConfig();
+        }
+
+        // Deep-link support: ?{entity}Id=5 opens the record's modal over the
+        // list, ?create=1 the create modal. Mount-only BY DESIGN — Livewire
+        // updates POST to /livewire/update and carry no page query, and the
+        // former `rendering()` hook was both accidental-initial-load-only and
+        // silently disabled by any component defining its own rendering().
+        $deepLinkId = (int) request()->query($this->getDeepLinkParam());
+        if ($deepLinkId) {
+            $this->listAction($deepLinkId);
+        } elseif (request()->query('create')) {
+            $this->listAction();
+        }
+    }
+
+    /**
+     * The header filters live in ONE session bucket shared across lists ON
+     * PURPOSE: NoerdPage::setPreselect() seeds it from detail pages so a
+     * related list opens pre-filtered, and preselect() reads it back. Only
+     * columns whitelisted per list (getAllowedListFilterColumns) ever apply.
+     */
+    protected function loadListFilters(): void
+    {
+        $this->listFilters = session('listFilters', []);
     }
 
     /**

--- a/src/Traits/NoerdPage.php
+++ b/src/Traits/NoerdPage.php
@@ -25,7 +25,8 @@ trait NoerdPage
 
     public bool $showSuccessIndicator = false;
 
-    public $modelId = null;
+    /** The record id; `'new'` opens an empty record (see RoutedModal). */
+    public int|string|null $modelId = null;
 
     #[Url(as: 'tab', keep: false, except: 1)]
     public int $currentTab = 1;
@@ -114,30 +115,6 @@ trait NoerdPage
         $this->initPage();
     }
 
-    public function initPage(): void
-    {
-        // The page YAML (pages/{name}.yml) is OPTIONAL — hand-built pages keep
-        // defining their layout in the component itself. It is loaded even when
-        // the guarded init below bails out (read-denied object, stale record id):
-        // Blade evaluates a page blade's slot content before the page chrome
-        // discards it for the denied state, so a hand-built page reading
-        // $pageLayout['detail'] must always find its layout.
-        $this->pageLayout = StaticConfigHelper::getPageFields($this->componentName(), $this->detailModel ?? null);
-
-        $this->initNoerdComponent(function (): void {
-            // Pages backed by a single Eloquent model declare $detailModel — the
-            // record is loaded into $detailData exactly like a detail would.
-            if (isset($this->detailModel)) {
-                $modelClass = $this->detailModel;
-                if (!$this->loadDetailModel(new $modelClass(), $modelClass)) {
-                    return;
-                }
-            }
-
-            $this->resolveQuickCreate();
-        });
-    }
-
     public function closeModalProcess(?string $source = null): void
     {
         $this->currentTab = 1;
@@ -167,7 +144,7 @@ trait NoerdPage
     {
         // Server-side guard: the delete button is hidden for delete-denied users,
         // but the method stays reachable via keyboard shortcut and direct calls.
-        if (!$this->canDeleteObject()) {
+        if (!$this->canDeleteObject() || !isset($this->detailModel)) {
             return;
         }
 
@@ -318,6 +295,30 @@ trait NoerdPage
         }
     }
 
+    protected function initPage(): void
+    {
+        // The page YAML (pages/{name}.yml) is OPTIONAL — hand-built pages keep
+        // defining their layout in the component itself. It is loaded even when
+        // the guarded init below bails out (read-denied object, stale record id):
+        // Blade evaluates a page blade's slot content before the page chrome
+        // discards it for the denied state, so a hand-built page reading
+        // $pageLayout['detail'] must always find its layout.
+        $this->pageLayout = StaticConfigHelper::getPageFields($this->componentName(), $this->detailModel ?? null);
+
+        $this->initNoerdComponent(function (): void {
+            // Pages backed by a single Eloquent model declare $detailModel — the
+            // record is loaded into $detailData exactly like a detail would.
+            if (isset($this->detailModel)) {
+                $modelClass = $this->detailModel;
+                if (!$this->loadDetailModel(new $modelClass(), $modelClass)) {
+                    return;
+                }
+            }
+
+            $this->resolveQuickCreate();
+        });
+    }
+
     protected function storeProcess(Model $model): void
     {
         $this->showSuccessIndicator = true;
@@ -416,7 +417,7 @@ trait NoerdPage
      */
     protected function loadDetailModel(Model $model, string $modelClass): bool
     {
-        if (property_exists($this, 'modelId') && $this->modelId) {
+        if ($this->modelId) {
             $model = $modelClass::find($this->modelId);
 
             if (!$model) {
@@ -507,7 +508,9 @@ trait NoerdPage
         $filters = session('listFilters', []);
         if (!empty($filters[$key])) {
             $method = Str::camel(Str::beforeLast($key, '_id')) . 'Selected';
-            $this->{$method}($filters[$key]);
+            if (method_exists($this, $method)) {
+                $this->{$method}($filters[$key]);
+            }
         }
     }
 

--- a/src/Traits/NoerdSettingsPage.php
+++ b/src/Traits/NoerdSettingsPage.php
@@ -35,23 +35,6 @@ trait NoerdSettingsPage
         $this->initSettings();
     }
 
-    public function initSettings(): void
-    {
-        $this->initNoerdComponent(function (): void {
-            $tenantId = TenantHelper::getSelectedTenantId();
-
-            foreach ($this->settingsModelMap() as $property => $modelClass) {
-                $model = $modelClass::firstOrNew(['tenant_id' => $tenantId]);
-
-                $this->{$property} = collect($model->toArray())
-                    ->except(['created_at', 'updated_at'])
-                    ->toArray();
-            }
-
-            $this->pageLayout = StaticConfigHelper::getSettingsFields($this->componentName());
-        });
-    }
-
     public function store(): void
     {
         // Server-side guard, mirroring NoerdDetail::store(): the save button is
@@ -118,6 +101,23 @@ trait NoerdSettingsPage
         }
 
         return true;
+    }
+
+    protected function initSettings(): void
+    {
+        $this->initNoerdComponent(function (): void {
+            $tenantId = TenantHelper::getSelectedTenantId();
+
+            foreach ($this->settingsModelMap() as $property => $modelClass) {
+                $model = $modelClass::firstOrNew(['tenant_id' => $tenantId]);
+
+                $this->{$property} = collect($model->toArray())
+                    ->except(['created_at', 'updated_at'])
+                    ->toArray();
+            }
+
+            $this->pageLayout = StaticConfigHelper::getSettingsFields($this->componentName());
+        });
     }
 
     /**

--- a/tests/Commands/FrontendScaffolderTest.php
+++ b/tests/Commands/FrontendScaffolderTest.php
@@ -335,62 +335,6 @@ describe('node compatibility', function (): void {
     });
 });
 
-describe('legacy tailwind config migration', function (): void {
-    beforeEach(function (): void {
-        writeScaffoldFile(
-            'resources/css/app.css',
-            "@import 'tailwindcss';\n\n@source '../views';\n@config '../../tailwind.config.js';\n",
-        );
-
-        $this->scaffolder = new FrontendScaffolder(scaffoldPath(), 'v22.22.1');
-    });
-
-    it('detects a noerd-generated config as removable', function (): void {
-        writeScaffoldFile('tailwind.config.js', "export default {\n    theme: { extend: { colors: { 'brand-primary': process.env.VITE_BRAND_PRIMARY || '#000' } } },\n}\n");
-
-        expect($this->scaffolder->hasLegacyTailwindBridge())->toBeTrue()
-            ->and($this->scaffolder->legacyTailwindConfigIsUnmodified())->toBeTrue();
-    });
-
-    it('treats a customised config as host-owned', function (): void {
-        writeScaffoldFile('tailwind.config.js', "export default {\n    plugins: [],\n}\n");
-
-        expect($this->scaffolder->hasLegacyTailwindBridge())->toBeTrue()
-            ->and($this->scaffolder->legacyTailwindConfigIsUnmodified())->toBeFalse();
-    });
-
-    it('removes every @config occurrence without leaving a backup', function (): void {
-        // The old updateAppCss() appended its block at EOF regardless of an existing @config line,
-        // so long-lived projects carry the directive twice — and possibly double-quoted.
-        writeScaffoldFile('resources/css/app.css', implode(PHP_EOL, [
-            "@import 'tailwindcss';",
-            '@config "../../tailwind.config.js";',
-            '',
-            "@source '../views';",
-            "@config '../../tailwind.config.js';",
-        ]) . PHP_EOL);
-        writeScaffoldFile('tailwind.config.js', "export default { /* VITE_BRAND_PRIMARY */ }\n");
-
-        $this->scaffolder->removeLegacyTailwindBridge();
-
-        expect(File::exists(scaffoldPath('tailwind.config.js')))->toBeFalse()
-            ->and(File::exists(scaffoldPath('tailwind.config.js.bak')))->toBeFalse();
-
-        $css = File::get(scaffoldPath('resources/css/app.css'));
-
-        expect($css)->not->toContain('@config')
-            ->and($css)->toContain("@source '../views';")
-            ->and($css)->toContain("@import 'tailwindcss';");
-    });
-
-    it('reports no bridge when the @config line is absent', function (): void {
-        writeScaffoldFile('resources/css/app.css', "@import 'tailwindcss';\n");
-        writeScaffoldFile('tailwind.config.js', "export default { /* VITE_BRAND_PRIMARY */ }\n");
-
-        expect((new FrontendScaffolder(scaffoldPath(), 'v22.22.1'))->hasLegacyTailwindBridge())->toBeFalse();
-    });
-});
-
 it('registers a css variable for every color of the brand preset', function (): void {
     // Guards against a palette key that exists in the config but never becomes a Tailwind color:
     // the utility would then silently produce nothing.

--- a/tests/Commands/NoerdInstallDemoPromptTest.php
+++ b/tests/Commands/NoerdInstallDemoPromptTest.php
@@ -120,7 +120,7 @@ it('runs noerd:demo when the demo app prompt is confirmed', function (): void {
     expect(InstallDemoPromptFixtureCommand::$calledCommands)
         ->toHaveCount(1)
         ->and(InstallDemoPromptFixtureCommand::$calledCommands[0]['command'])->toBe('noerd:demo')
-        ->and(InstallDemoPromptFixtureCommand::$calledCommands[0]['arguments'])->toBe(['--force' => true]);
+        ->and(InstallDemoPromptFixtureCommand::$calledCommands[0]['arguments'])->toBe(['--force' => true, '--migrate' => false, '--seed' => false]);
 });
 
 it('skips noerd:demo when the demo app prompt is declined', function (): void {

--- a/tests/Commands/NoerdUpdateAllTest.php
+++ b/tests/Commands/NoerdUpdateAllTest.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Support\Facades\Artisan;
 use Noerd\Commands\NoerdUpdateAllCommand;
+use Noerd\Contracts\RunsAfterModuleUpdates;
 use Noerd\Tests\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -62,6 +63,9 @@ class RecordingUpdateCommand extends Command
     }
 }
 
+/** A module update that declares it must run after the others. */
+class RecordingLastUpdateCommand extends RecordingUpdateCommand implements RunsAfterModuleUpdates {}
+
 /**
  * Fixture that pretends noerd:install has not been run yet.
  */
@@ -93,7 +97,7 @@ beforeEach(function (): void {
     // Registered out of alphabetical order on purpose: the run must sort, not follow registration.
     $kernel->registerCommand(new RecordingUpdateCommand('noerd:update-zz-beta'));
     $kernel->registerCommand(new RecordingUpdateCommand('noerd:update-zz-alpha'));
-    $kernel->registerCommand(new RecordingUpdateCommand('noerd:update-plus'));
+    $kernel->registerCommand(new RecordingLastUpdateCommand('noerd:update-plus'));
 
     $this->run = fn(array $parameters = []) => $this->artisan(
         'noerd:update-all',
@@ -101,7 +105,7 @@ beforeEach(function (): void {
     );
 });
 
-it('runs the core update first, module updates alphabetically and noerd:update-plus last', function (): void {
+it('runs the core update first, module updates alphabetically and RunsAfterModuleUpdates commands last', function (): void {
     ($this->run)(['--force' => true])->assertExitCode(0);
 
     expect(UpdateAllRecorder::$calls)->toBe([


### PR DESCRIPTION
## Summary

Fourth pre-release audit PR (stacked on #87).

**Middleware / helpers / models**
- `AppAccessMiddleware` has ONE behaviour in single- and multi-tenant mode: the route's app becomes the selected app (a deep link into app B no longer renders with app A's sidebar); no tenant → `noerd.no-tenant`.
- `TenantHelper::getSelectedTenantId()` no longer writes the session from a getter; the single-tenant fallback is read-only and memoized per request.
- `SetupCollectionDefinition` uses `BelongsToTenant` (the repository keeps its explicit tenant filter via `withoutGlobalScope`).
- `AtLeastOneTrue` implements `ValidationRule`; `EmailPreviewTestMail` uses `envelope()`/`content()`; models use `booted()`.
- `StaticConfigHelper`: the unused `items`/`type: dynamic` navigation branch is gone, module discovery honours `noerd.generators.modules_path`, a scalar YAML document never reaches an array-typed reader.
- `NoerdPage::$modelId` is typed (`int|string|null`), `delete()` needs a `$detailModel`, `preselect()` checks the handler exists; `mountList()`, `loadListFilters()`, `initDetail()`, `initPage()`, `initSettings()` are `protected` (they are not Livewire actions); `BelongsToTenant` no longer patches `$fillable`; resolver props are typed; `relatedModel(): ?Model`.

**Commands**
- `noerd:update-all` orders by the `Noerd\Contracts\RunsAfterModuleUpdates` marker instead of a hard-coded `noerd:update-plus` (companion: noerd-plus implements it).
- The Tailwind-3 `tailwind.config.js` bridge migration (an upgrade shim) is removed from `noerd:install` and `FrontendScaffolder` (with its four tests).
- `noerd:demo` gets explicit `--migrate` / `--seed` (non-interactive runs no longer migrate and seed silently); `noerd:install` forwards them.
- `Process` facade instead of `exec()`/`proc_open()`; `MakeUserAdminCommand` / `AssignAppsToTenantCommand` class names; accurate `noerd:install` / `noerd:update` descriptions; imports instead of inline FQCNs.

## Tests

`vendor/bin/pest` — 1147 passed. Docs updated for `noerd:update-all` ordering and `noerd:demo` options.