### PR TITLE
Turn the demo app into a slim showcase of the field types

### DIFF
--- a/demo/app-configs/demo/details/demo-customer-detail.yml
+++ b/demo/app-configs/demo/details/demo-customer-detail.yml
@@ -1,5 +1,10 @@
 title: Demo Customer
-description: ''
+description: 'A showcase of the field types a detail YAML can use'
+tabs:
+  - number: 1
+    label: General
+  - number: 2
+    label: Details
 fields:
   - name: detailData.name
     label: Name
@@ -15,13 +20,39 @@ fields:
     type: select
     optionsMethod: categoryOptions
     colspan: 6
+  - name: detailData.status
+    label: Status
+    type: select
+    colspan: 3
+    options:
+      - value: new
+        label: New
+      - value: in_progress
+        label: In Progress
+      - value: completed
+        label: Completed
+      - value: cancelled
+        label: Cancelled
+  - name: detailData.priority
+    label: Priority
+    type: select
+    colspan: 3
+    options:
+      - value: low
+        label: Low
+      - value: medium
+        label: Medium
+      - value: high
+        label: High
+      - value: critical
+        label: Critical
   - name: detailData.email
     label: Email
     type: email
     colspan: 6
   - name: detailData.phone
     label: Phone
-    type: text
+    type: phone
     colspan: 6
   - name: detailData.address
     label: Address
@@ -30,8 +61,47 @@ fields:
   - name: detailData.zipcode
     label: Zip Code
     type: text
-    colspan: 6
+    colspan: 2
   - name: detailData.city
     label: City
     type: text
+    colspan: 4
+  - name: tagIds
+    label: Tags
+    type: belongsToMany
+    optionsMethod: tagOptions
     colspan: 6
+  - name: detailData.is_active
+    label: Active
+    type: checkbox
+    colspan: 6
+  - name: detailData.revenue
+    label: Revenue
+    type: currency
+    colspan: 4
+    tab: 2
+  - name: detailData.contract_start
+    label: Contract Start
+    type: date
+    colspan: 4
+    tab: 2
+  - name: detailData.preferred_time
+    label: Preferred Time
+    type: time
+    colspan: 4
+    tab: 2
+  - name: detailData.brand_color
+    label: Brand Color
+    type: colorHex
+    colspan: 6
+    tab: 2
+  - name: detailData.description
+    label: Description
+    type: textarea
+    colspan: 12
+    tab: 2
+  - name: detailData.content
+    label: Notes
+    type: richText
+    colspan: 12
+    tab: 2

--- a/demo/app-configs/demo/lists/demo-categories-list.yml
+++ b/demo/app-configs/demo/lists/demo-categories-list.yml
@@ -1,9 +1,10 @@
 title: Demo Categories
+defaultSort:
+  field: name
+  direction: asc
 actions:
   - label: New Demo Category
-    action: listAction
-disableSearch: false
+    route: demo-category.detail
 columns:
   - field: name
     label: Name
-    type: text

--- a/demo/app-configs/demo/lists/demo-customers-list.yml
+++ b/demo/app-configs/demo/lists/demo-customers-list.yml
@@ -1,17 +1,25 @@
 title: Demo Customers
+defaultSort:
+  field: name
+  direction: asc
 actions:
   - label: New Demo Customer
-    action: listAction
-disableSearch: false
+    route: demo-customer.detail
 columns:
   - field: name
     label: Name
-    type: text
   - field: company_name
     label: Company
-  - field: email
-    label: Email
-  - field: phone
-    label: Phone
-  - field: city
-    label: City
+  - field: status
+    label: Status
+  - field: priority
+    label: Priority
+  - field: revenue
+    label: Revenue
+    type: currency
+  - field: contract_start
+    label: Contract Start
+    type: date
+  - field: is_active
+    label: Active
+    type: bool

--- a/demo/app-configs/demo/lists/demo-tags-list.yml
+++ b/demo/app-configs/demo/lists/demo-tags-list.yml
@@ -1,9 +1,10 @@
 title: Demo Tags
+defaultSort:
+  field: name
+  direction: asc
 actions:
   - label: New Demo Tag
-    action: listAction
-disableSearch: false
+    route: demo-tag.detail
 columns:
   - field: name
     label: Name
-    type: text

--- a/demo/app-configs/demo/navigation.yml
+++ b/demo/app-configs/demo/navigation.yml
@@ -8,11 +8,15 @@
         - title: Demo Customers
           route: demo-customers
           heroicon: users
+          newRoute: demo-customer.detail
+          newComponent: demo-customer-detail
         - title: Demo Categories
           route: demo-categories
           heroicon: tag
+          newRoute: demo-category.detail
           newComponent: demo-category-detail
         - title: Demo Tags
           route: demo-tags
           heroicon: hashtag
+          newRoute: demo-tag.detail
           newComponent: demo-tag-detail

--- a/demo/migrations/create_demo_categories_table.php
+++ b/demo/migrations/create_demo_categories_table.php
@@ -13,7 +13,7 @@ return new class extends Migration {
 
         Schema::create('demo_categories', function (Blueprint $table): void {
             $table->id();
-            $table->foreignId('tenant_id')->constrained('tenants')->onDelete('cascade');
+            $table->foreignId('tenant_id')->constrained('tenants')->cascadeOnDelete();
             $table->string('name')->nullable();
             $table->timestamps();
         });

--- a/demo/migrations/create_demo_customers_table.php
+++ b/demo/migrations/create_demo_customers_table.php
@@ -13,7 +13,7 @@ return new class extends Migration {
 
         Schema::create('demo_customers', function (Blueprint $table): void {
             $table->id();
-            $table->foreignId('tenant_id')->constrained('tenants')->onDelete('cascade');
+            $table->foreignId('tenant_id')->constrained('tenants')->cascadeOnDelete();
             $table->string('name')->nullable();
             $table->string('company_name')->nullable();
             $table->string('email')->nullable();

--- a/demo/migrations/create_demo_tags_table.php
+++ b/demo/migrations/create_demo_tags_table.php
@@ -13,7 +13,7 @@ return new class extends Migration {
 
         Schema::create('demo_tags', function (Blueprint $table): void {
             $table->id();
-            $table->foreignId('tenant_id')->constrained('tenants')->onDelete('cascade');
+            $table->foreignId('tenant_id')->constrained('tenants')->cascadeOnDelete();
             $table->string('name')->nullable();
             $table->timestamps();
         });

--- a/demo/views/demo-categories-list.blade.php
+++ b/demo/views/demo-categories-list.blade.php
@@ -8,18 +8,9 @@ new class extends Component {
     use NoerdList;
 
     public $listModel = DemoCategory::class;
+    public ?string $detailRoute = 'demo-category.detail';
+
     public $detailComponent = 'demo-category-detail';
-
-    public function rendering()
-    {
-        if ((int) request()->demoCategoryId) {
-            $this->listAction(request()->demoCategoryId);
-        }
-
-        if (request()->create) {
-            $this->listAction();
-        }
-    }
 }; ?>
 
 <x-noerd::page>

--- a/demo/views/demo-category-detail.blade.php
+++ b/demo/views/demo-category-detail.blade.php
@@ -10,19 +10,6 @@ new class extends Component {
     public $detailModel = DemoCategory::class;
 
     public ?string $detailPrimary = 'demoCategoryId';
-
-    public function store(): void
-    {
-        $this->validateFromLayout();
-
-        $demoCategory = DemoCategory::updateOrCreate(
-            ['id' => $this->modelId],
-            array_merge($this->detailData, ['tenant_id' => auth()->user()->selected_tenant_id]),
-        );
-
-        $this->storeProcess($demoCategory);
-    }
-
 }; ?>
 
 <x-noerd::page>
@@ -30,10 +17,7 @@ new class extends Component {
         <x-noerd::modal-title>{{ __('Demo Category') }}</x-noerd::modal-title>
     </x-slot:header>
 
-    <x-noerd::tab-content :layout="$pageLayout" :modelId="$modelId">
-        <x-slot:tab1>
-        </x-slot:tab1>
-    </x-noerd::tab-content>
+    <x-noerd::tab-content :layout="$pageLayout" :modelId="$modelId" />
 
     <x-slot:footer>
         <x-noerd::delete-save-bar :showDelete="isset($modelId)"/>

--- a/demo/views/demo-customer-detail.blade.php
+++ b/demo/views/demo-customer-detail.blade.php
@@ -2,6 +2,7 @@
 
 use App\Models\DemoCategory;
 use App\Models\DemoCustomer;
+use App\Models\DemoTag;
 use Livewire\Component;
 use Noerd\Traits\NoerdDetail;
 
@@ -12,41 +13,58 @@ new class extends Component {
 
     public ?string $detailPrimary = 'demoCustomerId';
 
-    public function categoryOptions(): array
+    /** The tags picked in the belongsToMany field. */
+    public array $tagIds = [];
+
+    public function mount(): void
     {
-        return ['' => '-'] + DemoCategory::orderBy('name')->pluck('name', 'id')->toArray();
+        $this->initDetail();
+
+        if ($this->modelId) {
+            $this->tagIds = DemoCustomer::find($this->modelId)?->tags()->pluck('demo_tags.id')->all() ?? [];
+        }
     }
 
+    public function categoryOptions(): array
+    {
+        return ['' => '-'] + DemoCategory::orderBy('name')->pluck('name', 'id')->all();
+    }
+
+    public function tagOptions(): array
+    {
+        return DemoTag::orderBy('name')->pluck('name', 'id')->all();
+    }
+
+    /**
+     * The trait's default store() persists the form; the many-to-many tags are
+     * the one thing the YAML cannot express, so they are synced here.
+     */
     public function store(): void
     {
+        if (! $this->canSaveObject()) {
+            return;
+        }
+
         $this->validateFromLayout();
 
         $this->detailData['demo_category_id'] = ($this->detailData['demo_category_id'] ?? null) ?: null;
 
         $demoCustomer = DemoCustomer::updateOrCreate(
             ['id' => $this->modelId],
-            array_merge($this->detailData, ['tenant_id' => auth()->user()->selected_tenant_id]),
+            $this->writableDetailData(DemoCustomer::class),
         );
+        $demoCustomer->tags()->sync($this->tagIds);
 
-        $this->showSuccessIndicator = true;
-
-        if (! $this->modelId) {
-            $this->modelId = $demoCustomer->id;
-        }
+        $this->finishStore($demoCustomer);
     }
-
-};
-?>
+}; ?>
 
 <x-noerd::page>
     <x-slot:header>
-        <x-noerd::modal-title>Demo Customer</x-noerd::modal-title>
+        <x-noerd::modal-title>{{ __('Demo Customer') }}</x-noerd::modal-title>
     </x-slot:header>
 
-    <x-noerd::tab-content :layout="$pageLayout" :modelId="$modelId">
-        <x-slot:tab1>
-        </x-slot:tab1>
-    </x-noerd::tab-content>
+    <x-noerd::tab-content :layout="$pageLayout" :modelId="$modelId" />
 
     <x-slot:footer>
         <x-noerd::delete-save-bar :showDelete="isset($modelId)"/>

--- a/demo/views/demo-customers-list.blade.php
+++ b/demo/views/demo-customers-list.blade.php
@@ -8,9 +8,10 @@ new class extends Component {
     use NoerdList;
 
     public $listModel = DemoCustomer::class;
+    public ?string $detailRoute = 'demo-customer.detail';
+
     public $detailComponent = 'demo-customer-detail';
-};
-?>
+}; ?>
 
 <x-noerd::page>
     <x-noerd::list/>

--- a/demo/views/demo-tag-detail.blade.php
+++ b/demo/views/demo-tag-detail.blade.php
@@ -10,31 +10,14 @@ new class extends Component {
     public $detailModel = DemoTag::class;
 
     public ?string $detailPrimary = 'demoTagId';
-
-    public function store(): void
-    {
-        $this->validateFromLayout();
-
-        $demoTag = DemoTag::updateOrCreate(
-            ['id' => $this->modelId],
-            array_merge($this->detailData, ['tenant_id' => auth()->user()->selected_tenant_id]),
-        );
-
-        $this->storeProcess($demoTag);
-    }
-
-};
-?>
+}; ?>
 
 <x-noerd::page>
     <x-slot:header>
         <x-noerd::modal-title>{{ __('Demo Tag') }}</x-noerd::modal-title>
     </x-slot:header>
 
-    <x-noerd::tab-content :layout="$pageLayout" :modelId="$modelId">
-        <x-slot:tab1>
-        </x-slot:tab1>
-    </x-noerd::tab-content>
+    <x-noerd::tab-content :layout="$pageLayout" :modelId="$modelId" />
 
     <x-slot:footer>
         <x-noerd::delete-save-bar :showDelete="isset($modelId)"/>

--- a/demo/views/demo-tags-list.blade.php
+++ b/demo/views/demo-tags-list.blade.php
@@ -8,9 +8,10 @@ new class extends Component {
     use NoerdList;
 
     public $listModel = DemoTag::class;
+    public ?string $detailRoute = 'demo-tag.detail';
+
     public $detailComponent = 'demo-tag-detail';
-};
-?>
+}; ?>
 
 <x-noerd::page>
     <x-noerd::list/>

--- a/src/Commands/NoerdDemoCommand.php
+++ b/src/Commands/NoerdDemoCommand.php
@@ -170,7 +170,7 @@ class NoerdDemoCommand extends Command
 
 
 // Noerd Demo
-Route::group(['middleware' => ['noerd']], function (): void {
+Route::group(['middleware' => ['noerd', 'app-access:demo']], function (): void {
     Route::livewire('demo-customers', 'demo-customers-list')->name('demo-customers');
     Route::livewire('demo-customer/{modelId}', 'demo-customer-detail')->name('demo-customer.detail');
     Route::livewire('demo-categories', 'demo-categories-list')->name('demo-categories');

--- a/tests/Commands/NoerdDemoRoutesTest.php
+++ b/tests/Commands/NoerdDemoRoutesTest.php
@@ -55,7 +55,7 @@ it('appends the demo route block protected by the noerd middleware group', funct
     $appended = mb_substr(File::get($routeFile), mb_strlen($before));
 
     expect($appended)
-        ->toContain("Route::group(['middleware' => ['noerd']]")
+        ->toContain("Route::group(['middleware' => ['noerd', 'app-access:demo']]")
         ->toContain("Route::livewire('demo-customers', 'demo-customers-list')")
         // A bare 'auth' middleware checks the default 'web' guard while noerd logs
         // in via its own 'noerd' guard, producing an endless login redirect loop.

--- a/tests/Commands/NoerdDemoShowcaseTest.php
+++ b/tests/Commands/NoerdDemoShowcaseTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Console\OutputStyle;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Livewire\Livewire;
+use Noerd\Commands\NoerdDemoCommand;
+use Noerd\Models\NoerdUser;
+use Noerd\Tests\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+/**
+ * The demo app is the first thing a new user opens: it must work with the
+ * slim components exactly as shipped. The demo's own files are wired into
+ * the testbench skeleton here — models required directly, migrations run,
+ * app configs published, views registered as a Livewire location.
+ */
+beforeEach(function (): void {
+    $demoDir = dirname(__DIR__, 2) . '/demo';
+
+    foreach (['DemoCategory', 'DemoTag', 'DemoCustomer'] as $model) {
+        if (! class_exists('App\\Models\\' . $model)) {
+            require_once "{$demoDir}/Models/{$model}.php";
+        }
+    }
+
+    foreach (['create_demo_categories_table', 'create_demo_tags_table', 'create_demo_customers_table', 'create_demo_customer_demo_tag_table'] as $migration) {
+        (require "{$demoDir}/migrations/{$migration}.php")->up();
+    }
+
+    $command = new NoerdDemoCommand();
+    $command->setLaravel(app());
+    $command->setOutput(new OutputStyle(new ArrayInput([]), new BufferedOutput()));
+    (new ReflectionProperty($command, 'demoDir'))->setValue($command, $demoDir);
+    (new ReflectionMethod($command, 'publishAppConfigs'))->invoke($command);
+
+    Livewire::addLocation(viewPath: "{$demoDir}/views");
+
+    $this->actingAs(NoerdUser::factory()->adminUser()->withSelectedApp('demo')->create());
+});
+
+afterEach(function (): void {
+    File::deleteDirectory(base_path('app-configs/demo'));
+});
+
+it('stores a demo customer with its tags through the slim detail', function (): void {
+    $category = App\Models\DemoCategory::create(['name' => 'Enterprise']);
+    $tag = App\Models\DemoTag::create(['name' => 'VIP']);
+
+    Livewire::test('demo-customer-detail')
+        ->set('detailData.name', 'Sarah Johnson')
+        ->set('detailData.demo_category_id', $category->id)
+        ->set('detailData.status', 'completed')
+        ->set('detailData.revenue', 245000)
+        ->set('tagIds', [$tag->id])
+        ->call('store')
+        ->assertHasNoErrors()
+        ->assertSet('showSuccessIndicator', true);
+
+    $customer = App\Models\DemoCustomer::firstWhere('name', 'Sarah Johnson');
+
+    expect($customer)->not->toBeNull()
+        ->and($customer->tenant_id)->toBe(NoerdUser::first()->selected_tenant_id)
+        ->and($customer->demo_category_id)->toBe($category->id)
+        ->and($customer->status)->toBe('completed')
+        ->and($customer->tags->pluck('id')->all())->toBe([$tag->id]);
+});
+
+it('renders the demo customers list with the picklist badge of the paired detail', function (): void {
+    App\Models\DemoCustomer::create(['name' => 'Acme', 'status' => 'in_progress']);
+
+    Livewire::test('demo-customers-list')
+        ->assertOk()
+        ->assertSee('Acme')
+        ->assertSee('In Progress');
+});
+
+it('opens a record through the demo detail route when it is registered', function (): void {
+    registerTestLivewireRoute('demo-customer/{modelId}', 'demo-customer-detail', 'demo-customer.detail');
+    $customer = App\Models\DemoCustomer::create(['name' => 'Acme']);
+
+    Livewire::test('demo-customers-list')
+        ->call('openListRow', $customer->id)
+        ->assertDispatched('noerdModal');
+});


### PR DESCRIPTION
## Summary

Sixth pre-release audit PR (stacked on #90). The demo is the first thing a new user runs — it now follows the pattern the guideline teaches.

- The three demo details are slim (`$detailModel` + `$detailPrimary`); the hand-rolled `store()` overrides that mass-assigned `$detailData` and read `auth()->user()` on the host guard (a fatal with the default `noerd` guard) are gone. The customer detail keeps one override to sync its many-to-many tags via `writableDetailData()` + `finishStore()`.
- The customer YAML showcases the field types on two tabs: `select` with inline options (rendered as translated badges in the list), `currency`, `date`, `time`, `colorHex`, `checkbox`, `phone`, `email`, `textarea`, `richText`, `belongsToMany` — every column the demo schema and seeder already had.
- Lists declare `$detailRoute` + `$detailComponent`, `defaultSort:` and a `route:` "New" action; the navigation uses `newRoute:` + `newComponent:`; the demo routes sit behind `['noerd', 'app-access:demo']`; migrations use `cascadeOnDelete()`.
- New `NoerdDemoShowcaseTest` wires the shipped demo files into the testbench skeleton and proves the store roundtrip (incl. tenant stamp and tags), the list badge and the route-modal opening.

## Tests

`vendor/bin/pest` — 1150 passed.