### PR TITLE
Make the super admin an explicit installation admin

### DIFF
--- a/docs/artisan-commands.md
+++ b/docs/artisan-commands.md
@@ -25,6 +25,7 @@ In addition, every installed app module ships its own `noerd:install-{module}` a
 |---------|-------------|
 | `noerd:create-admin` | Create a new user and make them an admin |
 | `noerd:make-admin` | Make an existing user an admin on all their tenants |
+| `noerd:super-admin` | Grant or revoke the installation-wide super admin flag of a user |
 | `noerd:create-tenant` | Create a new tenant |
 | `noerd:create-app` | Create a new app (TenantApp) with its own dashboard that can be assigned to tenants |
 | `noerd:assign-apps-to-tenant` | Assign apps to a tenant with interactive selection |
@@ -188,6 +189,23 @@ Makes an existing user an administrator by giving them admin profile access on a
 ```bash
 php artisan noerd:make-admin {user_id}
 ```
+
+## noerd:super-admin
+
+Grants or revokes the installation-wide super admin flag (see
+[Permissions → Super admin](permissions.md#super-admin-installation-admin)). The flag is
+`$guarded` on the model and not editable from any screen, so the console is the only way
+in — and out.
+
+```bash
+php artisan noerd:super-admin {user}            # grant — {user} is an ID or an email
+php artisan noerd:super-admin {user} --revoke   # withdraw
+```
+
+| Option | Description |
+|--------|-------------|
+| `--revoke` | Withdraw the super admin flag instead of granting it |
+| `--force` | Revoke even when the user is the last super admin of the installation (refused otherwise) |
 
 ## noerd:create-tenant
 

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -83,7 +83,7 @@ there.
 | `newComponent` | Livewire component opened by the "+" button — fallback for `newRoute` |
 | `quickCreate` | With `newRoute`/`newComponent`: open the "+" target as a narrow quick-create modal (`modelId: null`, `quickCreate: true`) |
 | `config` | The entry is hidden unless `config(...)` with this key is truthy (e.g. `noerd.features.currency`) |
-| `superAdmin` | The entry is only visible to super admins |
+| `superAdmin` | The entry is only visible to super admins — the installation admins, see [Permissions](permissions.md#super-admin-installation-admin) |
 
 ### Route vs. component
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -48,6 +48,35 @@ profile's SEMANTICS come from the authorization gates the module defines; the co
 baseline treats unknown keys like `User`. `NoerdUser::currentProfileKey()` exposes the raw
 stored key for such modules; `currentProfile()` resolves only the built-in enum cases.
 
+## Super admin (installation admin)
+
+Profiles are assigned PER TENANT. The one thing above them is the
+`super_admin` flag on `noerd_users`: an installation admin who administers
+every tenant of the installation.
+
+- `isAdmin()` is true in every tenant — the profile baseline and every gate
+  implementation bypass on it, `/setup` is reachable everywhere.
+- Sees and edits every tenant (Setup → Tenants) and every account
+  (Setup → Users), including accounts that belong to no tenant yet, and may
+  impersonate any of them.
+- May ENTER every tenant: the tenant switcher lists all tenants of the
+  installation and the per-request membership check accepts them.
+  `NoerdUser::accessibleTenants()` / `canAccessTenant()` are the single source
+  for "may this user work in that tenant" — never compare against
+  `$user->tenants` directly for that question; `administeredTenants()` is the
+  matching Setup scope (every tenant vs. the ADMIN-profile memberships).
+- Protected in the other direction: a tenant admin can never edit, impersonate
+  or (by e-mail) capture a super admin account.
+- Visible: the Profile column of the users list renders the `Super Admin`
+  badge (`profile_for_tenant`), followed by the tenant profile as plain text.
+- Set and withdrawn ONLY on the console — the column is `$guarded`, no screen
+  writes it: `php artisan noerd:super-admin {id|email}` grants the flag,
+  `--revoke` withdraws it (the last super admin of an installation only with
+  `--force`). `noerd:install` makes the first user of a fresh installation a
+  super admin (`noerd:create-admin --super-admin`).
+- A navigation entry with `superAdmin: true` is hidden from everybody else
+  (see [Navigation](navigation.md)).
+
 ## Abilities
 
 Every check goes through `Noerd\Helpers\AccessHelper`:

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -203,6 +203,12 @@ Authorization is generic and two-staged (reference: `docs/permissions.md` and
   baseline: Admin = setup access + bypass, User (or no profile) = everything, ReadOnly = read only.
   Modules may register ADDITIONAL profiles via `app(ProfileRegistry::class)->register(key, label)`
   (their semantics come from the gates that module defines; the core treats unknown keys like User).
+- ABOVE the profiles sits one installation-level flag: `noerd_users.super_admin` (`isSuperAdmin()`).
+  A super admin administers the whole installation — `isAdmin()` in every tenant, may ENTER every
+  tenant, sees every tenant and every account. It is `$guarded` and set ONLY on the console
+  (`noerd:super-admin {id|email}`, `--revoke` to withdraw), never from a screen. Whether a user may
+  WORK IN a tenant is `NoerdUser::canAccessTenant()` / `accessibleTenants()` — never compare
+  against `$user->tenants` directly for that question.
 - All checks go through `Noerd\Helpers\AccessHelper` (`canAccessApp`, `canReadObject`,
   `canWriteObject`, `canCreateObject`, `canDeleteObject`, `canPerformAction`, `canUseApp`). Create
   and write are SEPARATE abilities: `canSaveObject()` on detail/page components picks create (new

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -271,6 +271,7 @@
     "Summary": "Zusammenfassung",
     "Swiss Franc": "Schweizer Franken",
     "Switch list view": "Listenansicht wechseln",
+    "Super Admin": "Super-Admin",
     "Switch Tenant": "Mandant wechseln",
     "System Settings": "Systemeinstellungen",
     "Tags": "Tags",

--- a/resources/views/components/layout/quick-menu.blade.php
+++ b/resources/views/components/layout/quick-menu.blade.php
@@ -27,7 +27,7 @@ new class extends Component {
         $user = NoerdAuth::user();
 
         return config('noerd.features.multi_tenant')
-            && ($user->tenants->count() > 1
+            && ($user->accessibleTenants()->count() > 1
                 || ($user->isAdmin() && config('noerd.features.new_tenant')));
     }
 } ?>

--- a/resources/views/components/layout/tenant-switcher.blade.php
+++ b/resources/views/components/layout/tenant-switcher.blade.php
@@ -8,10 +8,9 @@ use Noerd\Helpers\NoerdAuth;
 new class extends Component {
     public function switchTenant(int $tenantId): void
     {
-        $user = NoerdAuth::user();
-        $accessToClientsIds = $user->tenants->pluck('id')->toArray();
-
-        if (! in_array($tenantId, $accessToClientsIds)) {
+        // Membership for everybody, every tenant of the installation for a
+        // super admin — the same answer the per-request membership check gives.
+        if (! NoerdAuth::user()->canAccessTenant($tenantId)) {
             return;
         }
 
@@ -55,7 +54,7 @@ new class extends Component {
 } ?>
 
 @php
-    $tenants = NoerdAuth::user()->tenants;
+    $tenants = NoerdAuth::user()->accessibleTenants();
     $selectedTenantId = \Noerd\Helpers\TenantHelper::getSelectedTenantId();
     $currentTenantName = $tenants->firstWhere('id', $selectedTenantId)?->name ?? __('Tenant');
     $canCreateTenant = NoerdAuth::user()->isAdmin()

--- a/resources/views/components/noerd-apps.blade.php
+++ b/resources/views/components/noerd-apps.blade.php
@@ -14,8 +14,8 @@ new class extends Component {
 
         // Fall back to an available tenant when none is selected, or when the user
         // is no longer assigned to the currently selected one.
-        if (! $selectedTenantId || ! $user->tenants->contains('id', $selectedTenantId)) {
-            TenantHelper::setSelectedTenantId($user->tenants->first()?->id);
+        if (! $selectedTenantId || ! $user->canAccessTenant($selectedTenantId)) {
+            TenantHelper::setSelectedTenantId($user->accessibleTenants()->first()?->id);
         }
     }
 

--- a/src/Commands/SuperAdminCommand.php
+++ b/src/Commands/SuperAdminCommand.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noerd\Commands;
+
+use Illuminate\Console\Command;
+use Noerd\Models\NoerdUser;
+
+/**
+ * Grants or revokes the installation-level super admin flag. The flag is
+ * deliberately NOT editable from any screen ($guarded on the model): a tenant
+ * admin must never be able to promote an account to administer the whole
+ * installation, so the console is the only way in — and, with --revoke, the
+ * only way out.
+ */
+class SuperAdminCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'noerd:super-admin
+                            {user : The ID or email of the user}
+                            {--revoke : Withdraw the super admin flag instead of granting it}
+                            {--force : Revoke even when the user is the last super admin of the installation}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Grant or revoke the installation-wide super admin flag of a user';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $user = $this->resolveUser((string) $this->argument('user'));
+
+        if (! $user) {
+            $this->error("User '{$this->argument('user')}' not found.");
+
+            return self::FAILURE;
+        }
+
+        return $this->option('revoke') ? $this->revoke($user) : $this->grant($user);
+    }
+
+    private function grant(NoerdUser $user): int
+    {
+        if ($user->isSuperAdmin()) {
+            $this->warn("User '{$user->name}' ({$user->email}) already is a super admin.");
+
+            return self::SUCCESS;
+        }
+
+        $user->super_admin = true;
+        $user->save();
+
+        $this->info("User '{$user->name}' ({$user->email}) is now a super admin.");
+
+        return self::SUCCESS;
+    }
+
+    private function revoke(NoerdUser $user): int
+    {
+        if (! $user->isSuperAdmin()) {
+            $this->warn("User '{$user->name}' ({$user->email}) is not a super admin.");
+
+            return self::SUCCESS;
+        }
+
+        // Without any super admin nobody administers the installation as a
+        // whole any more (unassigned accounts, tenants without an admin).
+        // noerd:install can bootstrap one again, but that is a deliberate step.
+        $isLast = NoerdUser::query()->where('super_admin', true)->whereKeyNot($user->id)->doesntExist();
+
+        if ($isLast && ! $this->option('force')) {
+            $this->error("User '{$user->name}' ({$user->email}) is the last super admin of this installation. Pass --force to revoke anyway.");
+
+            return self::FAILURE;
+        }
+
+        $user->super_admin = false;
+        $user->save();
+
+        $this->info("User '{$user->name}' ({$user->email}) is no longer a super admin.");
+
+        return self::SUCCESS;
+    }
+
+    private function resolveUser(string $identifier): ?NoerdUser
+    {
+        if (is_numeric($identifier)) {
+            return NoerdUser::find((int) $identifier);
+        }
+
+        return NoerdUser::query()->where('email', $identifier)->first();
+    }
+}

--- a/src/Listeners/InitializeTenantSession.php
+++ b/src/Listeners/InitializeTenantSession.php
@@ -29,10 +29,10 @@ class InitializeTenantSession
         if (! TenantHelper::hasTenant()) {
             $savedTenantId = $user->setting->selected_tenant_id;
 
-            if ($savedTenantId && $user->tenants->contains('id', $savedTenantId)) {
+            if ($savedTenantId && $user->canAccessTenant($savedTenantId)) {
                 TenantHelper::setSelectedTenantId($savedTenantId);
             } else {
-                $firstTenant = $user->tenants->first();
+                $firstTenant = $user->accessibleTenants()->first();
                 if ($firstTenant) {
                     TenantHelper::setSelectedTenantId($firstTenant->id);
                 }

--- a/src/Middleware/EnsureTenantMembership.php
+++ b/src/Middleware/EnsureTenantMembership.php
@@ -23,7 +23,8 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * On a revoked tenant the session falls back to another tenant the user still
  * belongs to, or to none at all (the setup middleware then routes them to the
- * no-tenant screen).
+ * no-tenant screen). A super admin may work in every tenant of the
+ * installation, so only a DELETED tenant is ever unselected for one.
  */
 class EnsureTenantMembership
 {
@@ -35,8 +36,8 @@ class EnsureTenantMembership
         $user = NoerdAuth::user();
         $selectedTenantId = TenantHelper::getSelectedTenantId();
 
-        if ($user && $selectedTenantId && ! $user->tenants()->whereKey($selectedTenantId)->exists()) {
-            TenantHelper::setSelectedTenantId($user->tenants()->value('tenants.id'));
+        if ($user && $selectedTenantId && ! $user->canAccessTenant($selectedTenantId)) {
+            TenantHelper::setSelectedTenantId($user->accessibleTenants()->first()?->id);
             TenantHelper::setSelectedApp(null);
         }
 

--- a/src/Middleware/SetupMiddleware.php
+++ b/src/Middleware/SetupMiddleware.php
@@ -23,7 +23,7 @@ class SetupMiddleware
         abort_unless($user, 403);
 
         if (! TenantHelper::getSelectedTenantId()) {
-            $firstTenantId = $user->tenants->first()?->id;
+            $firstTenantId = $user->accessibleTenants()->first()?->id;
 
             if (! $firstTenantId) {
                 return redirect()->route('noerd.no-tenant');

--- a/src/Models/NoerdUser.php
+++ b/src/Models/NoerdUser.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Noerd\Models;
 
 use Illuminate\Contracts\Translation\HasLocalePreference;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -94,19 +95,61 @@ class NoerdUser extends Authenticatable implements HasLocalePreference
     }
 
     /**
+     * The tenants the user may WORK IN: a super admin administers the whole
+     * installation and may enter every tenant, everybody else the tenants of
+     * their membership. The single source for the tenant switcher, the login
+     * session seed and the per-request membership check — never compare
+     * against `$user->tenants` directly for that question. Always read fresh
+     * (never the memoized relation): a membership revoked mid-request must be
+     * seen by the check that follows it.
+     *
+     * @return Collection<int, Tenant>
+     */
+    public function accessibleTenants(): Collection
+    {
+        return $this->isSuperAdmin()
+            ? Tenant::query()->orderBy('id')->get()
+            : $this->tenants()->get();
+    }
+
+    public function canAccessTenant(int $tenantId): bool
+    {
+        return $this->isSuperAdmin()
+            ? Tenant::query()->whereKey($tenantId)->exists()
+            : $this->tenants()->whereKey($tenantId)->exists();
+    }
+
+    /**
+     * The tenants the user ADMINISTERS (Setup → Users/Tenants scope): every
+     * tenant for a super admin, the ADMIN-profile memberships otherwise.
+     *
+     * @return Collection<int, Tenant>
+     */
+    public function administeredTenants(): Collection
+    {
+        return $this->isSuperAdmin()
+            ? Tenant::query()->orderBy('id')->get()
+            : $this->adminTenants;
+    }
+
+    /**
      * @return array{badge: string, text: string}
      */
     public function getProfileForTenantAttribute(): array
     {
         $key = $this->currentProfileKey();
 
-        if ($key === null) {
-            return ['badge' => '', 'text' => ''];
-        }
-
         // Registered profiles (ProfileRegistry) get their translated label;
         // an unregistered key falls back to the raw key rather than hiding.
-        return ['badge' => app(ProfileRegistry::class)->label($key) ?? $key, 'text' => ''];
+        $label = $key === null ? '' : (app(ProfileRegistry::class)->label($key) ?? $key);
+
+        // The installation-level role is visible wherever the profile is: the
+        // badge names it, the tenant profile (if any) follows as plain text.
+        if ($this->isSuperAdmin()) {
+            return ['badge' => __('Super Admin'), 'text' => $label];
+        }
+
+        return ['badge' => $label, 'text' => ''];
     }
 
     /**

--- a/src/Providers/NoerdServiceProvider.php
+++ b/src/Providers/NoerdServiceProvider.php
@@ -35,6 +35,7 @@ use Noerd\Commands\NoerdInstallCommand;
 use Noerd\Commands\NoerdUpdateAllCommand;
 use Noerd\Commands\NoerdUpdateCommand;
 use Noerd\Commands\PublishHomeCommand;
+use Noerd\Commands\SuperAdminCommand;
 use Noerd\Contracts\MediaResolverContract;
 use Noerd\Contracts\SetupCollectionDefinitionRepositoryContract;
 use Noerd\Helpers\CurrencyHelper;
@@ -395,6 +396,7 @@ class NoerdServiceProvider extends ServiceProvider
 
             $this->commands([
                 MakeUserAdminCommand::class,
+                SuperAdminCommand::class,
                 NoerdInfoCommand::class,
                 NoerdInstallCommand::class,
                 NoerdUpdateCommand::class,

--- a/src/Traits/TenantFilterTrait.php
+++ b/src/Traits/TenantFilterTrait.php
@@ -16,8 +16,10 @@ trait TenantFilterTrait
         $filter['options'] = [];
 
         // Guest-safe: a list rendered without an authenticated noerd user
-        // simply offers an empty tenant picklist instead of fataling.
-        $tenants = NoerdAuth::user()?->adminTenants ?? collect();
+        // simply offers an empty tenant picklist instead of fataling. The
+        // picklist mirrors the list scope: every tenant for a super admin,
+        // the administered tenants for a tenant admin.
+        $tenants = NoerdAuth::user()?->administeredTenants() ?? collect();
 
         foreach ($tenants as $tenant) {
             $filter['options'][$tenant->id] = $tenant->name;

--- a/tests/Commands/SuperAdminCommandTest.php
+++ b/tests/Commands/SuperAdminCommandTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Noerd\Models\NoerdUser;
+use Noerd\Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+/*
+ | The super admin flag is $guarded and has no screen — the console is the
+ | only way to grant it and, with --revoke, the only way to withdraw it.
+ */
+
+it('grants the super admin flag by user id', function (): void {
+    $user = NoerdUser::factory()->create(['super_admin' => false]);
+
+    $this->artisan('noerd:super-admin', ['user' => (string) $user->id])
+        ->expectsOutput("User '{$user->name}' ({$user->email}) is now a super admin.")
+        ->assertExitCode(0);
+
+    expect($user->fresh()->isSuperAdmin())->toBeTrue();
+});
+
+it('grants the super admin flag by email', function (): void {
+    $user = NoerdUser::factory()->create(['super_admin' => false, 'email' => 'operator@example.com']);
+
+    $this->artisan('noerd:super-admin', ['user' => 'operator@example.com'])
+        ->assertExitCode(0);
+
+    expect($user->fresh()->isSuperAdmin())->toBeTrue();
+});
+
+it('leaves an existing super admin untouched when granting again', function (): void {
+    $user = NoerdUser::factory()->create(['super_admin' => true]);
+
+    $this->artisan('noerd:super-admin', ['user' => (string) $user->id])
+        ->expectsOutput("User '{$user->name}' ({$user->email}) already is a super admin.")
+        ->assertExitCode(0);
+
+    expect($user->fresh()->isSuperAdmin())->toBeTrue();
+});
+
+it('revokes the super admin flag while another super admin remains', function (): void {
+    NoerdUser::factory()->create(['super_admin' => true]);
+    $user = NoerdUser::factory()->create(['super_admin' => true]);
+
+    $this->artisan('noerd:super-admin', ['user' => (string) $user->id, '--revoke' => true])
+        ->expectsOutput("User '{$user->name}' ({$user->email}) is no longer a super admin.")
+        ->assertExitCode(0);
+
+    expect($user->fresh()->isSuperAdmin())->toBeFalse();
+});
+
+it('refuses to revoke the last super admin without --force', function (): void {
+    $user = NoerdUser::factory()->create(['super_admin' => true]);
+
+    $this->artisan('noerd:super-admin', ['user' => (string) $user->id, '--revoke' => true])
+        ->expectsOutput("User '{$user->name}' ({$user->email}) is the last super admin of this installation. Pass --force to revoke anyway.")
+        ->assertExitCode(1);
+
+    expect($user->fresh()->isSuperAdmin())->toBeTrue();
+});
+
+it('revokes the last super admin with --force', function (): void {
+    $user = NoerdUser::factory()->create(['super_admin' => true]);
+
+    $this->artisan('noerd:super-admin', ['user' => (string) $user->id, '--revoke' => true, '--force' => true])
+        ->assertExitCode(0);
+
+    expect($user->fresh()->isSuperAdmin())->toBeFalse();
+});
+
+it('reports a revoke on a user that is no super admin', function (): void {
+    $user = NoerdUser::factory()->create(['super_admin' => false]);
+
+    $this->artisan('noerd:super-admin', ['user' => (string) $user->id, '--revoke' => true])
+        ->expectsOutput("User '{$user->name}' ({$user->email}) is not a super admin.")
+        ->assertExitCode(0);
+});
+
+it('fails for an unknown user', function (): void {
+    $this->artisan('noerd:super-admin', ['user' => 'nobody@example.com'])
+        ->expectsOutput("User 'nobody@example.com' not found.")
+        ->assertExitCode(1);
+});

--- a/tests/Feature/SuperAdminTenantAccessTest.php
+++ b/tests/Feature/SuperAdminTenantAccessTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Noerd\Enums\Profile;
+use Noerd\Helpers\TenantHelper;
+use Noerd\Middleware\SetupMiddleware;
+use Noerd\Models\NoerdUser;
+use Noerd\Models\Tenant;
+use Noerd\Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+/*
+ | A super admin administers the INSTALLATION: it may work in every tenant
+ | without a membership row, and the role is visible wherever the tenant
+ | profile is shown. A tenant admin keeps the membership semantics.
+ */
+
+it('resolves every tenant of the installation as accessible for a super admin', function (): void {
+    $member = Tenant::factory()->create();
+    $foreign = Tenant::factory()->create();
+    $superAdmin = NoerdUser::factory()->create(['super_admin' => true]);
+    $superAdmin->tenants()->attach($member->id);
+
+    expect($superAdmin->accessibleTenants()->pluck('id')->all())->toBe([$member->id, $foreign->id])
+        ->and($superAdmin->canAccessTenant($foreign->id))->toBeTrue()
+        ->and($superAdmin->canAccessTenant($foreign->id + 999))->toBeFalse()
+        ->and($superAdmin->administeredTenants()->pluck('id')->all())->toBe([$member->id, $foreign->id]);
+});
+
+it('resolves only the membership tenants as accessible for a regular user', function (): void {
+    $member = Tenant::factory()->create();
+    $foreign = Tenant::factory()->create();
+    $user = NoerdUser::factory()->create(['super_admin' => false]);
+    $user->tenants()->attach($member->id, ['profile_key' => Profile::Admin->value]);
+
+    expect($user->accessibleTenants()->pluck('id')->all())->toBe([$member->id])
+        ->and($user->canAccessTenant($foreign->id))->toBeFalse()
+        ->and($user->administeredTenants()->pluck('id')->all())->toBe([$member->id]);
+});
+
+it('labels a super admin in the profile column and keeps the tenant profile as text', function (): void {
+    $tenant = Tenant::factory()->create();
+    TenantHelper::setSelectedTenantId($tenant->id);
+
+    $withProfile = NoerdUser::factory()->create(['super_admin' => true]);
+    $withProfile->tenants()->attach($tenant->id, ['profile_key' => Profile::Admin->value]);
+
+    $withoutMembership = NoerdUser::factory()->create(['super_admin' => true]);
+
+    $tenantAdmin = NoerdUser::factory()->create(['super_admin' => false]);
+    $tenantAdmin->tenants()->attach($tenant->id, ['profile_key' => Profile::Admin->value]);
+
+    expect($withProfile->profile_for_tenant)->toBe(['badge' => __('Super Admin'), 'text' => Profile::Admin->label()])
+        ->and($withoutMembership->profile_for_tenant)->toBe(['badge' => __('Super Admin'), 'text' => ''])
+        ->and($tenantAdmin->profile_for_tenant)->toBe(['badge' => Profile::Admin->label(), 'text' => '']);
+});
+
+it('renders the super admin badge in the users list', function (): void {
+    $tenant = Tenant::factory()->create();
+    $superAdmin = NoerdUser::factory()->create(['super_admin' => true, 'name' => 'Zz Installation Admin']);
+    $superAdmin->tenants()->attach($tenant->id, ['profile_key' => Profile::Admin->value]);
+    TenantHelper::setSelectedTenantId($tenant->id);
+    TenantHelper::setSelectedApp('SETUP');
+    $this->actingAs($superAdmin);
+
+    Livewire::test('noerd::noerd-users-list')
+        ->assertSee('Zz Installation Admin')
+        ->assertSee(__('Super Admin'));
+});
+
+it('seeds the setup session with the first tenant for a super admin without any membership', function (): void {
+    $tenant = Tenant::factory()->create();
+    $superAdmin = NoerdUser::factory()->create(['super_admin' => true]);
+    $this->actingAs($superAdmin);
+    TenantHelper::clear();
+
+    $response = app(SetupMiddleware::class)->handle(request(), fn($request) => response('ok'));
+
+    expect($response->getContent())->toBe('ok')
+        ->and(TenantHelper::getSelectedTenantId())->toBe($tenant->id);
+});
+
+it('still routes a tenant admin without any membership to the no-tenant screen', function (): void {
+    Tenant::factory()->create();
+    $user = NoerdUser::factory()->create(['super_admin' => false]);
+    $this->actingAs($user);
+    TenantHelper::clear();
+
+    $response = app(SetupMiddleware::class)->handle(request(), fn($request) => response('ok'));
+
+    expect($response->isRedirect(route('noerd.no-tenant')))->toBeTrue();
+});
+
+it('restores a super admin\'s saved tenant on authentication even without a membership', function (): void {
+    $foreign = Tenant::factory()->create();
+    $superAdmin = NoerdUser::factory()->create(['super_admin' => true]);
+    $superAdmin->selected_tenant_id = $foreign->id;
+
+    TenantHelper::clear();
+    $this->actingAs($superAdmin);
+
+    expect(TenantHelper::getSelectedTenantId())->toBe($foreign->id);
+});

--- a/tests/Feature/TenantMembershipRevocationTest.php
+++ b/tests/Feature/TenantMembershipRevocationTest.php
@@ -68,3 +68,28 @@ it('clears the tenant entirely when the last membership is revoked', function ()
 
     expect(TenantHelper::getSelectedTenantId())->toBeNull();
 });
+
+it('keeps a tenant a super admin works in without a membership', function (): void {
+    $foreign = Tenant::factory()->create();
+    $superAdmin = NoerdUser::factory()->create(['super_admin' => true]);
+    TenantHelper::setSelectedTenantId($foreign->id);
+    $this->actingAs($superAdmin);
+
+    zzRunMembershipMiddleware();
+
+    expect(TenantHelper::getSelectedTenantId())->toBe($foreign->id);
+});
+
+it('falls back to another tenant for a super admin when the selected one is deleted', function (): void {
+    $remaining = Tenant::factory()->create();
+    $deleted = Tenant::factory()->create();
+    $superAdmin = NoerdUser::factory()->create(['super_admin' => true]);
+    TenantHelper::setSelectedTenantId($deleted->id);
+    $this->actingAs($superAdmin);
+
+    $deleted->delete();
+
+    zzRunMembershipMiddleware();
+
+    expect(TenantHelper::getSelectedTenantId())->toBe($remaining->id);
+});

--- a/tests/Feature/TenantSwitcherTest.php
+++ b/tests/Feature/TenantSwitcherTest.php
@@ -113,3 +113,47 @@ it('does not switch to a tenant the user has no access to', function (): void {
 
     expect(TenantHelper::getSelectedTenantId())->toBe($member['tenants'][0]->id);
 });
+
+it('lists every tenant of the installation for a super admin', function (): void {
+    $superAdmin = NoerdUser::factory()->create(['super_admin' => true]);
+    $member = Tenant::factory()->create(['name' => 'Member Tenant']);
+    $foreign = Tenant::factory()->create(['name' => 'Foreign Tenant']);
+    $superAdmin->tenants()->attach($member->id);
+    TenantHelper::setSelectedTenantId($member->id);
+
+    $this->actingAs($superAdmin);
+
+    Livewire::test('noerd::layout.tenant-switcher')
+        ->assertSee('Member Tenant')
+        ->assertSee('Foreign Tenant');
+});
+
+it('lets a super admin switch to a tenant it is no member of', function (): void {
+    $superAdmin = NoerdUser::factory()->create(['super_admin' => true]);
+    $member = Tenant::factory()->create();
+    $foreign = Tenant::factory()->create();
+    $superAdmin->tenants()->attach($member->id);
+    TenantHelper::setSelectedTenantId($member->id);
+
+    $this->actingAs($superAdmin);
+
+    Livewire::test('noerd::layout.tenant-switcher')
+        ->call('switchTenant', $foreign->id)
+        ->assertRedirect('/');
+
+    expect(TenantHelper::getSelectedTenantId())->toBe($foreign->id);
+});
+
+it('shows the switcher to a super admin of a single membership when more tenants exist', function (): void {
+    config(['noerd.features.multi_tenant' => true, 'noerd.features.new_tenant' => false]);
+    $superAdmin = NoerdUser::factory()->create(['super_admin' => true]);
+    $member = Tenant::factory()->create();
+    Tenant::factory()->create();
+    $superAdmin->tenants()->attach($member->id);
+    TenantHelper::setSelectedTenantId($member->id);
+
+    $this->actingAs($superAdmin);
+
+    Livewire::test('noerd::layout.quick-menu')
+        ->assertSeeLivewire('noerd::layout.tenant-switcher');
+});


### PR DESCRIPTION
## Summary

The `super_admin` flag on `noerd_users` was an invisible, hardcoded bypass next to the per-tenant profile model: nothing in the UI showed who carries it, the console could only grant it, and its semantics were inconsistent (edit every tenant in Setup → Tenants, but the tenant switcher only offered the user's own memberships). This PR keeps the flag and turns it into an explicit **installation admin**:

- **Visible.** The Profile column of the users list renders a `Super Admin` badge (`profile_for_tenant`), followed by the tenant profile as plain text. German translation added.
- **Revocable.** New `noerd:super-admin {id|email}` command grants the flag, `--revoke` withdraws it; the last super admin of an installation is only revoked with `--force`. Registered next to `noerd:make-admin`.
- **Consistent tenant access.** A super admin may now enter every tenant of the installation, not only its memberships. `NoerdUser::accessibleTenants()` / `canAccessTenant()` are the single source for "may this user work in that tenant" (fresh reads — a membership revoked mid-request stays visible to the following check); `administeredTenants()` is the matching Setup scope. Used by the tenant switcher, the quick-menu switcher visibility, `SetupMiddleware`, `EnsureTenantMembership`, `InitializeTenantSession`, the apps screen fallback and the users-list tenant picklist. Members keep the membership semantics unchanged.
- **Documented.** New "Super admin (installation admin)" section in `docs/permissions.md`, the command in `docs/artisan-commands.md`, the `superAdmin:` navigation flag now points at that section, and the Boost guideline carries the rule (the host's generated CLAUDE.md block follows with the next `boost:update`).

## Tests

- `tests/Commands/SuperAdminCommandTest.php` — grant by id/email, idempotent grant, revoke, last-super-admin guard with and without `--force`, unknown user.
- `tests/Feature/SuperAdminTenantAccessTest.php` — accessible/administered tenant resolution for super admins vs. members, badge in the profile accessor and the users list, `SetupMiddleware` seeding without a membership, saved tenant restored on authentication.
- `TenantSwitcherTest` / `TenantMembershipRevocationTest` — super admin lists and switches to a non-member tenant, keeps a non-member tenant per request, falls back only when the tenant is deleted.

Full module suite: 1169 passed.
