### PR TITLE
Bump version to v0.14.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
             "name": "Johannes Brock"
         }
     ],
-    "version": "v0.14.7",
+    "version": "v0.14.8",
     "license": "MIT",
     "require": {
         "php": "^8.3",


### PR DESCRIPTION
Release commit for the already published tag v0.14.8 (main is protected, so the bump lands through this PR). The tag ships the merged pre-release audit (#88–#99) incl. the RunsAfterModuleUpdates contract that noerd-plus depends on.