### PR TITLE
Correct the modal-stack test docblock and cover the relation box zero-count fallback

### DIFF
--- a/tests/Feature/ModalStackRouteResolutionTest.php
+++ b/tests/Feature/ModalStackRouteResolutionTest.php
@@ -13,10 +13,10 @@ uses(TestCase::class);
  * by COMPONENT name (opened as-is, URL untouched) — plus the precedence between
  * them when a caller supplies both.
  *
- * The modal stack lives in the sibling noerd-modal package, whose own suite cannot
- * run inside this project's test run (it corrupts the shared test database, see the
- * exclude in phpunit.xml). This mirrors that contract here against synthetic zz.*
- * routes, so a regression in either flavour is caught by the normal suite.
+ * The modal stack lives in the sibling noerd-modal package. Its own suite proves the
+ * same contract, but it does not run in the standalone noerd package run (noerd-modal
+ * is a vendor dependency there), so this file mirrors the contract against synthetic
+ * zz.* routes and a regression in either flavour is caught by the normal suite.
  *
  * Which of the two a given YAML/component picks is per-installation configuration
  * and is deliberately NOT asserted anywhere — only that both keep working.

--- a/tests/Feature/RelationBoxTest.php
+++ b/tests/Feature/RelationBoxTest.php
@@ -170,3 +170,22 @@ describe('registry contributions', function (): void {
             ->not->toContain('$modalRoute(');
     });
 });
+
+describe('count fallback', function (): void {
+
+    it('computes a zero count for an unknown relation method instead of failing', function (): void {
+        [$component] = mountRelationBox([
+            [
+                'label' => 'Unknown',
+                'heroicon' => 'users',
+                'relation' => 'doesNotExist',
+                'component' => 'zz::tenant-apps-list',
+                'arguments' => ['tenantId' => '$modelId'],
+            ],
+        ]);
+
+        $component
+            ->assertSet('resolvedRelations.0.label', 'Unknown')
+            ->assertSet('resolvedRelations.0.count', 0);
+    });
+});


### PR DESCRIPTION
Follow-ups from the module test-suite audit: the docblock in ModalStackRouteResolutionTest claimed the noerd-modal suite is excluded from the host phpunit.xml (it is not; the mirror exists for the standalone package run), and the relation box's zero-count fallback for an unknown relation method was only proven in crm — it now lives in the core RelationBoxTest.