### PR TITLE
Flush Eloquent's guardable column cache between testbench tests

### DIFF
--- a/tests/Feature/GuardableColumnsIsolationTest.php
+++ b/tests/Feature/GuardableColumnsIsolationTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Noerd\Models\Tenant;
+use Noerd\Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+/*
+ | Eloquent memoizes every model's guardable COLUMN LIST in a process-global
+ | static, filled from the schema of whichever connection first mass-assigns
+ | that model. These testbench tests run the package migrations alone, a host
+ | application runs its own on top — so a leaked column list makes the other
+ | suite silently drop writes to columns it does not know. The TestCase flushes
+ | the cache around every test; these two cases guard that boundary.
+ */
+
+/** @return array<class-string, array<int, string>> */
+function zzGuardableColumns(): array
+{
+    return Closure::bind(static fn(): array => Model::$guardableColumns, null, Model::class)();
+}
+
+it('drops a mass-assigned column that the cached column list does not know', function (): void {
+    Closure::bind(static function (): void {
+        Model::$guardableColumns[Tenant::class] = ['id', 'name'];
+    }, null, Model::class)();
+
+    expect(zzGuardableColumns())->toHaveKey(Tenant::class)
+        ->and((new Tenant())->fill(['uuid' => 'zz-poisoned'])->uuid)->toBeNull();
+});
+
+it('starts with no column list left over from the previous test', function (): void {
+    expect(zzGuardableColumns())->not->toHaveKey(Tenant::class)
+        ->and((new Tenant())->fill(['uuid' => 'zz-clean'])->uuid)->toBe('zz-clean');
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Noerd\Tests;
 
+use Closure;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Testing\RefreshDatabaseState;
 use Illuminate\Support\Facades\File;
 use Livewire\Livewire;
@@ -51,6 +53,7 @@ abstract class TestCase extends BaseTestCase
 
     protected function setUp(): void
     {
+        self::flushGuardableColumnsCache();
         $this->swapInTestbenchRefreshDatabaseState();
 
         try {
@@ -75,8 +78,10 @@ abstract class TestCase extends BaseTestCase
             parent::tearDown();
         } finally {
             $this->swapOutTestbenchRefreshDatabaseState();
+            self::flushGuardableColumnsCache();
         }
     }
+
     protected function getPackageProviders($app): array
     {
         return [
@@ -139,6 +144,24 @@ abstract class TestCase extends BaseTestCase
         if (static::usesRefreshDatabaseTestingConcern()) {
             $this->loadMigrationsFrom(\Orchestra\Testbench\default_migration_path());
         }
+    }
+
+    /**
+     * Eloquent memoizes every model's guardable COLUMN LIST in a process-global
+     * static, filled from the schema of whichever connection first mass-assigns
+     * that model. The testbench app (the package migrations alone) and a host
+     * application (its own migrations on top) disagree about those columns —
+     * `tenants.email`, for one, exists only in the host — so without this flush
+     * the suite that runs first teaches Eloquent a column list the other suite
+     * then filters its own writes through, and `update(['email' => null])`
+     * becomes a silent no-op instead of an error. Flushed around every test so
+     * each suite reads its own schema.
+     */
+    private static function flushGuardableColumnsCache(): void
+    {
+        Closure::bind(static function (): void {
+            Model::$guardableColumns = [];
+        }, null, Model::class)();
     }
 
     private function swapInTestbenchRefreshDatabaseState(): void


### PR DESCRIPTION
## Problem

Eloquent memoizes each model's guardable **column list** in the process-global static `Model::$guardableColumns` (`GuardsAttributes::isGuardableColumn()`), filled from the schema of whichever connection first mass-assigns that model. A key missing from that list counts as guarded and is dropped by `fill()` without any error.

The package testbench app runs the package migrations alone; a host application runs its own on top. When both suites run in one PHPUnit process, the first one to touch a model teaches Eloquent a column list the other then filters its own writes through.

Concretely, in a host project whose `tenants` table carries an `email` column added by a project migration (the package's `create_tenants_table` ships `id, name, uuid, timestamps`), every host test running after this package's suite silently lost that column:

```php
$tenant->update(['email' => null]); // no-op, no error
```

Model factories were unaffected — `Factory::make()` runs unguarded — so the leak only surfaced on guarded writes, which made it look like an unrelated flaky test in the host suite.

## Fix

`Noerd\Tests\TestCase` already isolates `RefreshDatabaseState` from a host suite for exactly this reason. It now flushes the guardable-column cache in `setUp()` and `tearDown()` as well, so neither suite inherits the other's schema.

## Test

`tests/Feature/GuardableColumnsIsolationTest.php` guards the boundary with two ordered cases: the first poisons `Tenant`'s cached column list and proves the resulting silent drop, the second proves the flush kept that poison out of the next test. Verified it fails when the flush is removed.