### PR TITLE
Rename noerd:create-app, noerd:create-tenant and noerd:create-admin to noerd:make-app, noerd:make-tenant and noerd:make-admin-user

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ composer require noerd/noerd
 php artisan noerd:install
 
 # 2. Create your first app
-php artisan noerd:create-app
+php artisan noerd:make-app
 
 # 3. Create a model and its migration, then migrate
 php artisan make:model Customer -m
@@ -43,7 +43,7 @@ class Customer extends Model
 
 - `noerd:install` publishes the config and the frontend scaffold (Vite, Tailwind CSS 4), runs the
   migrations, creates the default tenant and an admin user, and optionally installs demo data.
-- `noerd:create-app` asks where the app lives (project or an `app-modules/` package), for a
+- `noerd:make-app` asks where the app lives (project or an `app-modules/` package), for a
   title, a name and an icon, scaffolds a dashboard for the app and offers to assign it to your
   tenants. Use `noerd:assign-apps-to-tenant` to change that later.
 - `noerd:make-resource` reads the model's columns and generates the list and detail components,

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ Documentation for the Noerd framework — a YAML-driven modular framework for La
 
 - [Installation](installation.md) — requirements, `noerd:install`, created tables, routes and the frontend scaffold
 - [Example Application](example-application.md) — the Demo Customers app installed by `noerd:demo`, as a reference
-- [Creating Apps](create-app.md) — register a tenant app with its own dashboard, in the project or as a module (`noerd:create-app`)
+- [Creating Apps](make-app.md) — register a tenant app with its own dashboard, in the project or as a module (`noerd:make-app`)
 - [Creating Modules](creating-modules.md) — scaffold a module with `noerd:module`, install/update commands, custom attributes
 - [Artisan Commands](artisan-commands.md) — every `noerd:*` command with its options
 

--- a/docs/artisan-commands.md
+++ b/docs/artisan-commands.md
@@ -23,11 +23,11 @@ In addition, every installed app module ships its own `noerd:install-{module}` a
 
 | Command | Description |
 |---------|-------------|
-| `noerd:create-admin` | Create a new user and make them an admin |
+| `noerd:make-admin-user` | Create a new user and make them an admin |
 | `noerd:make-admin` | Make an existing user an admin on all their tenants |
 | `noerd:super-admin` | Grant or revoke the installation-wide super admin flag of a user |
-| `noerd:create-tenant` | Create a new tenant |
-| `noerd:create-app` | Create a new app (TenantApp) with its own dashboard that can be assigned to tenants |
+| `noerd:make-tenant` | Create a new tenant |
+| `noerd:make-app` | Create a new app (TenantApp) with its own dashboard that can be assigned to tenants |
 | `noerd:assign-apps-to-tenant` | Assign apps to a tenant with interactive selection |
 
 ### Scaffolding
@@ -167,12 +167,12 @@ Displays the currently installed Noerd version.
 php artisan noerd:info
 ```
 
-## noerd:create-admin
+## noerd:make-admin-user
 
 Creates a new user and makes them an administrator.
 
 ```bash
-php artisan noerd:create-admin
+php artisan noerd:make-admin-user
 ```
 
 | Option | Description |
@@ -207,13 +207,13 @@ php artisan noerd:super-admin {user} --revoke   # withdraw
 | `--revoke` | Withdraw the super admin flag instead of granting it |
 | `--force` | Revoke even when the user is the last super admin of the installation (refused otherwise) |
 
-## noerd:create-tenant
+## noerd:make-tenant
 
 Creates a new tenant (a single `tenants` row; profiles are hardcoded, see
 [Permissions](permissions.md)).
 
 ```bash
-php artisan noerd:create-tenant
+php artisan noerd:make-tenant
 ```
 
 | Option | Description |
@@ -221,18 +221,18 @@ php artisan noerd:create-tenant
 | `--name=` | The name of the tenant |
 | `--default` | Use "Default" as the tenant name |
 
-## noerd:create-app
+## noerd:make-app
 
 Creates a new app (TenantApp) that can be assigned to tenants. Without options the command runs as
 an interactive wizard that first asks whether the app lives in the **project** or becomes a
-**module** under `app-modules/{app}` (see [Create an App](create-app.md)). Every app comes with
+**module** under `app-modules/{app}` (see [Create an App](make-app.md)). Every app comes with
 its own dashboard: in the project the command runs `noerd:make-dashboard` and stores the generated
 `{app}.dashboard` route as the app's main route; in module mode it hands the scaffold to
 `noerd:module`, registers the package with Composer and runs the generated `noerd:install-{app}`
 in its silent scaffold mode (only the tenant assignment is asked).
 
 ```bash
-php artisan noerd:create-app
+php artisan noerd:make-app
 ```
 
 | Option | Description |
@@ -261,7 +261,7 @@ php artisan noerd:assign-apps-to-tenant
 Creates a new module with its directory structure, dashboard, routes, navigation, translations,
 the tenant-app migration stub, the install and update commands and the ServiceProvider. It
 generates no model — record types are added with `noerd:make-resource {Model} --app={module}`.
-`noerd:create-app` uses it for the module mode.
+`noerd:make-app` uses it for the module mode.
 
 ```bash
 php artisan noerd:module
@@ -275,10 +275,10 @@ php artisan noerd:module inventory --title="Inventory" --icon=cube
 |--------|-------------|
 | `--title=` | The display title of the tenant app (default: the module name as a headline) |
 | `--icon=` | The heroicon of the tenant app, as a name (`cube`) or in the stored form (`heroicon:outline:cube`); required in non-interactive runs |
-| `--no-hints` | Do not print the next steps (`noerd:create-app` runs them itself) |
+| `--no-hints` | Do not print the next steps (`noerd:make-app` runs them itself) |
 
 The generated `noerd:install-{module}` command accepts `--scaffold` besides `--force`: the silent
-run `noerd:create-app` uses right after the scaffold — configs are published, the app registered,
+run `noerd:make-app` uses right after the scaffold — configs are published, the app registered,
 and the only question is the tenant assignment (no migration or `npm run build` prompt).
 
 See [Creating Modules](creating-modules.md) for the generated structure.
@@ -402,7 +402,7 @@ php artisan noerd:make-page sent-mails --app=inventory
 Generates a dashboard Blade file for an app (`resources/views/components/{app}-dashboard.blade.php`),
 adds the `{app}.dashboard` route to `routes/web.php` (inside the `noerd` + `app-access:{app}`
 middleware group) and links it from the app's `navigation.yml` — creating the navigation file when
-the app has none yet. `noerd:create-app` runs this command automatically for every new app in the
+the app has none yet. `noerd:make-app` runs this command automatically for every new app in the
 project (a module gets its dashboard from `noerd:module`).
 
 ```bash

--- a/docs/creating-modules.md
+++ b/docs/creating-modules.md
@@ -5,8 +5,8 @@ Using modules is completely optional. The application works perfectly fine witho
 The module approach is very inspired by https://github.com/InterNACHI/modular
 
 Use the `noerd:module` Artisan command to create a new module with complete directory structure —
-or choose **Module** in `php artisan noerd:create-app`, which asks the same questions, calls
-`noerd:module` for you and runs the Composer and install steps (see [Create an App](create-app.md)).
+or choose **Module** in `php artisan noerd:make-app`, which asks the same questions, calls
+`noerd:module` for you and runs the Composer and install steps (see [Create an App](make-app.md)).
 
 ## Quick Start
 
@@ -40,7 +40,7 @@ php artisan noerd:install-{module-name}
 php artisan noerd:make-resource Item --app={module-name}
 ```
 
-Never register the app manually via `noerd:create-app` — the generated install command does all of
+Never register the app manually via `noerd:make-app` — the generated install command does all of
 it and stays re-runnable.
 
 ## What the scaffold gives you
@@ -111,7 +111,7 @@ Artisan commands; `noerd:module` generates both from its stubs:
   `getModuleKey()`, `getDefaultAppTitle()`, `getAppIcon()`, `getAppRoute()` and `getSourceDir()`.
   Its `handle()` calls `$this->runModuleInstallation()`, which copies the YAML configs into
   `app-configs/{module}/`, registers the tenant app and runs the migrations. With `--scaffold`
-  (declared by the generated command) it runs silently right after `noerd:create-app` — configs,
+  (declared by the generated command) it runs silently right after `noerd:make-app` — configs,
   registration and the tenant assignment question only, no migration or build prompt.
 - **`noerd:update-{module}`** — a slim subclass of the install command whose `handle()` calls
   `$this->runModuleUpdate()` (never `runModuleInstallation()`, which prompts for the tenant

--- a/docs/example-application.md
+++ b/docs/example-application.md
@@ -57,5 +57,5 @@ are protected by `app-access:demo` (see [Authentication](auth.md), [Permissions]
 
 ## Further reading
 
-- [Create an App](create-app.md) — register your own app the same way
+- [Create an App](make-app.md) — register your own app the same way
 - [Creating Modules](creating-modules.md) — package an app as a reusable module

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -148,4 +148,4 @@ You should now have access to `/noerd-apps` with your created user. If you insta
 
 ## Next Steps
 
-Continue with [Create an App](create-app.md) to create your first own app.
+Continue with [Create an App](make-app.md) to create your first own app.

--- a/docs/make-app.md
+++ b/docs/make-app.md
@@ -5,7 +5,7 @@ Now that at least one user and one tenant have been set up, the first app can be
 ![Noerd Example App](/assets/apps.png "Navigation")
 
 ```bash
-php artisan noerd:create-app
+php artisan noerd:make-app
 ```
 
 The command first asks **where** the app should live:
@@ -69,10 +69,10 @@ php artisan noerd:make-resource {Model} --app=my-app
 ## Non-interactive use
 
 For install scripts, every prompt has an option (the full option table is in
-[Artisan Commands](artisan-commands.md#noerdcreate-app)):
+[Artisan Commands](artisan-commands.md#noerdmake-app)):
 
 ```bash
-php artisan noerd:create-app --title="Inventory Management" --name=INVENTORY \
+php artisan noerd:make-app --title="Inventory Management" --name=INVENTORY \
     --icon=heroicon:outline:users --active=1
 ```
 
@@ -80,7 +80,7 @@ Pass `--route=` only when the app tile should open an existing route instead —
 generated then:
 
 ```bash
-php artisan noerd:create-app --title="Inventory Management" --name=INVENTORY \
+php artisan noerd:make-app --title="Inventory Management" --name=INVENTORY \
     --icon=heroicon:outline:users --route=inventory.index
 ```
 
@@ -88,7 +88,7 @@ Module mode needs `--module`; a scripted run scaffolds the module and prints the
 install steps instead of running them:
 
 ```bash
-php artisan noerd:create-app --title="Inventory Management" --name=INVENTORY \
+php artisan noerd:make-app --title="Inventory Management" --name=INVENTORY \
     --icon=heroicon:outline:users --module
 ```
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -73,7 +73,7 @@ every tenant of the installation.
   writes it: `php artisan noerd:super-admin {id|email}` grants the flag,
   `--revoke` withdraws it (the last super admin of an installation only with
   `--force`). `noerd:install` makes the first user of a fresh installation a
-  super admin (`noerd:create-admin --super-admin`).
+  super admin (`noerd:make-admin-user --super-admin`).
 - A navigation entry with `superAdmin: true` is hidden from everybody else
   (see [Navigation](navigation.md)).
 

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -127,14 +127,14 @@ Example for user: users-list.blade.php (plural) and user-detail.blade.php (singu
         heroicon: cog-6-tooth
 ```
 - Tenant-app icons (`tenant_apps.icon`, the tile on the apps page and in the app bar) are heroicons
-  too, stored as `heroicon:outline:{name}` and rendered by `noerd::app-icon`. `noerd:create-app` and
+  too, stored as `heroicon:outline:{name}` and rendered by `noerd::app-icon`. `noerd:make-app` and
   `noerd:module` ask for the heroicon; a module's install command returns it from `getAppIcon()`. A
   module ships NO icon file. Only when no heroicon fits, add a Blade icon by hand
   (`resources/views/components/icons/app.blade.php`) and return `{module}::icons.app` instead.
-- Every app — root app or module — ships its own dashboard: `noerd:create-app` scaffolds
+- Every app — root app or module — ships its own dashboard: `noerd:make-app` scaffolds
   `{app}-dashboard` (root) or `{module}::{module}-dashboard` (module, via `noerd:module`), and the
   app's main route opens it. Never point a new app's tile at a list.
-- Neither `noerd:create-app` nor `noerd:module` generates a model: an app starts with its dashboard,
+- Neither `noerd:make-app` nor `noerd:module` generates a model: an app starts with its dashboard,
   and every record type is added with `noerd:make-resource {Model} --app={app}` (list + detail,
   YAML, routes, navigation) once the model and its migration exist. For a MODULE app
   (`app-modules/{app}/composer.json` exists) the `noerd:make-*` generators write into the module —
@@ -155,7 +155,7 @@ Example for user: users-list.blade.php (plural) and user-detail.blade.php (singu
   (every installed module) — both are idempotent.
 
 ### Install Command Required for Every App Module
-- Every module that is a tenant app (has `app-configs/{module}/` with a `navigation.yml`) MUST ship a `noerd:install-{module}` command. New submodules always get one — never rely on the manual `noerd:create-app` flow.
+- Every module that is a tenant app (has `app-configs/{module}/` with a `navigation.yml`) MUST ship a `noerd:install-{module}` command. New submodules always get one — never rely on the manual `noerd:make-app` flow.
 - The command extends `Illuminate\Console\Command`, uses the `HasModuleInstallation` and `RequiresNoerdInstallation` traits, and implements `getModuleName()`, `getModuleKey()`, `getDefaultAppTitle()`, `getAppIcon()`, `getAppRoute()` and `getSourceDir()`. Its `handle()` calls `$this->runModuleInstallation()` (which copies the YAML configs, registers the app via a published migration and runs migrations).
 - Register the command in the module's ServiceProvider inside `if ($this->app->runningInConsole()) { $this->commands([...]); }`.
 - The `noerd:module` scaffolder generates this command and its ServiceProvider registration automatically, from `src/Commands/stubs/module/install-command.stub`.

--- a/resources/boost/skills/noerd-module-development/SKILL.md
+++ b/resources/boost/skills/noerd-module-development/SKILL.md
@@ -11,17 +11,17 @@ metadata:
 A module is a Composer package under `app-modules/{module}/` (namespace `Noerd\{Module}` by
 convention) that ships a tenant app: YAML configs, Livewire components, model, migrations, routes,
 translations, tests and an install/update command. Hard rules: `noerd/noerd` Boost guideline. Docs:
-`vendor/noerd/noerd/docs/creating-modules.md`, `create-app.md`, `navigation.md`,
+`vendor/noerd/noerd/docs/creating-modules.md`, `make-app.md`, `navigation.md`,
 `artisan-commands.md`, `traits.md`, `ai-agents.md`.
 
 ## 1. Scaffold
 
 ```bash
-php artisan noerd:create-app        # choose "Module": asks title, name, heroicon, then registers with Composer and installs (tenant assignment is the only question)
+php artisan noerd:make-app        # choose "Module": asks title, name, heroicon, then registers with Composer and installs (tenant assignment is the only question)
 php artisan noerd:module            # the scaffolder itself: module name, app title, heroicon
                                     # scripted: noerd:module inventory --title=Inventory --icon=cube
 composer update noerd/{module}
-php artisan noerd:install-{module}  # copies YAML, registers the tenant app, migrates (--scaffold = the silent create-app run)
+php artisan noerd:install-{module}  # copies YAML, registers the tenant app, migrates (--scaffold = the silent make-app run)
 php artisan noerd:make-resource Item --app={module}   # per record type, after model + migration exist in the module
 ```
 
@@ -30,7 +30,7 @@ The scaffold is dashboard + plumbing, no model. `noerd:make-resource` / `make-li
 into it: components under `{app}::`, routes into `routes/{app}-routes.php`, YAML + navigation into
 both copies.
 
-Never write the `tenant_apps` row of a module by hand or via the root `noerd:create-app` flow —
+Never write the `tenant_apps` row of a module by hand or via the root `noerd:make-app` flow —
 the generated install command registers it (name = UPPERCASE module key, icon = the heroicon from
 `getAppIcon()`, route = the module dashboard). A module ships no icon file; a Blade icon is only
 the manual exception when no heroicon fits.

--- a/src/Commands/Concerns/AsksForHeroicon.php
+++ b/src/Commands/Concerns/AsksForHeroicon.php
@@ -11,7 +11,7 @@ use WireUi\Heroicons\HeroiconsServiceProvider;
 
 /**
  * Tenant-app icons are heroicons stored as `heroicon:outline:{name}` and
- * rendered by `noerd::app-icon`. Shared by noerd:create-app and noerd:module.
+ * rendered by `noerd::app-icon`. Shared by noerd:make-app and noerd:module.
  */
 trait AsksForHeroicon
 {

--- a/src/Commands/Concerns/GeneratesResourceFiles.php
+++ b/src/Commands/Concerns/GeneratesResourceFiles.php
@@ -234,7 +234,7 @@ trait GeneratesResourceFiles
     }
 
     /**
-     * An app scaffolded as a module (noerd:create-app → Module / noerd:module) owns
+     * An app scaffolded as a module (noerd:make-app → Module / noerd:module) owns
      * its files: Blade components go into the module (Livewire namespace `{app}::`),
      * routes into `routes/{app}-routes.php`, YAML and navigation into the module
      * copy AND the installed project copy. Everything else targets the project root.

--- a/src/Commands/MakeAdminUserCommand.php
+++ b/src/Commands/MakeAdminUserCommand.php
@@ -13,14 +13,14 @@ use function Laravel\Prompts\text;
 use Noerd\Models\NoerdUser;
 use Noerd\Models\Tenant;
 
-class CreateAdminCommand extends Command
+class MakeAdminUserCommand extends Command
 {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'noerd:create-admin
+    protected $signature = 'noerd:make-admin-user
                             {--name= : The name of the user}
                             {--email= : The email of the user}
                             {--password= : The password of the user}
@@ -31,6 +31,13 @@ class CreateAdminCommand extends Command
      *
      * @var string
      */
+    /**
+     * The former command name, kept so existing install scripts keep working.
+     *
+     * @var array<int, string>
+     */
+    protected $aliases = ['noerd:create-admin'];
+
     protected $description = 'Create a new user and make them an admin';
 
     /**
@@ -40,7 +47,7 @@ class CreateAdminCommand extends Command
     {
         // Check if any tenants exist
         if (Tenant::count() === 0) {
-            $this->error('No tenants found. Please run "php artisan noerd:create-tenant" first.');
+            $this->error('No tenants found. Please run "php artisan noerd:make-tenant" first.');
 
             return self::FAILURE;
         }

--- a/src/Commands/MakeAppCommand.php
+++ b/src/Commands/MakeAppCommand.php
@@ -24,7 +24,7 @@ use Noerd\Models\Tenant;
 use Noerd\Models\TenantApp;
 use Symfony\Component\Process\Process as SymfonyProcess;
 
-class CreateTenantAppCommand extends Command
+class MakeAppCommand extends Command
 {
     use AsksForHeroicon;
 
@@ -33,7 +33,7 @@ class CreateTenantAppCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'noerd:create-app
+    protected $signature = 'noerd:make-app
                             {--title= : The display title of the app}
                             {--name= : The unique name identifier of the app}
                             {--icon= : The icon identifier for the app}
@@ -46,6 +46,13 @@ class CreateTenantAppCommand extends Command
      *
      * @var string
      */
+    /**
+     * The former command name, kept so existing install scripts keep working.
+     *
+     * @var array<int, string>
+     */
+    protected $aliases = ['noerd:create-app'];
+
     protected $description = 'Create a new app with its own dashboard that can be assigned to tenants';
 
     /**

--- a/src/Commands/MakeDashboardCommand.php
+++ b/src/Commands/MakeDashboardCommand.php
@@ -29,7 +29,7 @@ class MakeDashboardCommand extends Command
 
     /**
      * The route name of the dashboard generated for the given app — the target
-     * noerd:create-app stores as the app's main route.
+     * noerd:make-app stores as the app's main route.
      */
     public static function routeNameFor(string $app): string
     {
@@ -191,7 +191,7 @@ class MakeDashboardCommand extends Command
 
     /**
      * Confirm a scaffolding step, defaulting to yes. A non-interactive run (e.g. the
-     * call from noerd:create-app) never asks: the child command shares the caller's
+     * call from noerd:make-app) never asks: the child command shares the caller's
      * output style, so the question would otherwise reach the caller's prompt.
      */
     protected function confirmStep(string $question): bool

--- a/src/Commands/MakeModuleCommand.php
+++ b/src/Commands/MakeModuleCommand.php
@@ -30,7 +30,7 @@ class MakeModuleCommand extends Command
                             {name? : The name of the module}
                             {--title= : The display title of the tenant app}
                             {--icon= : The heroicon of the tenant app (name or heroicon:outline:name)}
-                            {--no-hints : Do not print the next steps (noerd:create-app runs them itself)}';
+                            {--no-hints : Do not print the next steps (noerd:make-app runs them itself)}';
 
     protected $description = 'Create a new Noerd module with dashboard, install/update commands and directory structure';
 

--- a/src/Commands/MakeTenantCommand.php
+++ b/src/Commands/MakeTenantCommand.php
@@ -11,14 +11,14 @@ use function Laravel\Prompts\text;
 
 use Noerd\Models\Tenant;
 
-class CreateTenantCommand extends Command
+class MakeTenantCommand extends Command
 {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'noerd:create-tenant
+    protected $signature = 'noerd:make-tenant
                             {--name= : The name of the tenant}
                             {--default : Use "Default" as the tenant name}';
 
@@ -27,6 +27,13 @@ class CreateTenantCommand extends Command
      *
      * @var string
      */
+    /**
+     * The former command name, kept so existing install scripts keep working.
+     *
+     * @var array<int, string>
+     */
+    protected $aliases = ['noerd:create-tenant'];
+
     protected $description = 'Create a new tenant';
 
     /**

--- a/src/Commands/NoerdInstallCommand.php
+++ b/src/Commands/NoerdInstallCommand.php
@@ -540,7 +540,7 @@ class NoerdInstallCommand extends Command
     /**
      * Setup an admin user - either create a new one or promote an existing user.
      * Skipped in non-interactive runs: an admin needs prompted credentials, and
-     * `noerd:create-admin` accepts them as options for scripted setups.
+     * `noerd:make-admin-user` accepts them as options for scripted setups.
      */
     protected function setupAdminUser(): void
     {
@@ -549,7 +549,7 @@ class NoerdInstallCommand extends Command
         $this->line('================');
 
         if (! $this->input->isInteractive()) {
-            $this->line('<comment>Non-interactive run: skipping admin setup. Create one with: php artisan noerd:create-admin --name= --email= --password=</comment>');
+            $this->line('<comment>Non-interactive run: skipping admin setup. Create one with: php artisan noerd:make-admin-user --name= --email= --password=</comment>');
             return;
         }
 
@@ -564,7 +564,7 @@ class NoerdInstallCommand extends Command
 
     /**
      * Create a new admin user when no users exist. Delegates to
-     * noerd:create-admin, which owns the prompts and their validation —
+     * noerd:make-admin-user, which owns the prompts and their validation —
      * the first user of an installation becomes super admin.
      */
     protected function setupNewAdminUser(): void
@@ -576,7 +576,7 @@ class NoerdInstallCommand extends Command
             return;
         }
 
-        $this->call('noerd:create-admin', ['--super-admin' => true]);
+        $this->call('noerd:make-admin-user', ['--super-admin' => true]);
     }
 
     /**
@@ -683,7 +683,7 @@ class NoerdInstallCommand extends Command
 
         // Create default tenant if none exist
         if (Tenant::count() === 0) {
-            $this->call('noerd:create-tenant');
+            $this->call('noerd:make-tenant');
             $this->autoAssignAllApps();
         } else {
             $this->line('<comment>Tenant(s) already exist, skipping.</comment>');

--- a/src/Commands/stubs/module/install-command.stub
+++ b/src/Commands/stubs/module/install-command.stub
@@ -13,7 +13,7 @@ class {{ModuleName}}InstallCommand extends Command
 
     protected $signature = 'noerd:install-{{module-name}}
                             {--force : Overwrite existing files without asking}
-                            {--scaffold : Silent post-scaffold run (noerd:create-app) — only the tenant assignment is asked}';
+                            {--scaffold : Silent post-scaffold run (noerd:make-app) — only the tenant assignment is asked}';
 
     protected $description = 'Install {{ModuleName}} module content and navigation';
 

--- a/src/Providers/NoerdServiceProvider.php
+++ b/src/Providers/NoerdServiceProvider.php
@@ -15,11 +15,10 @@ use Illuminate\Support\Str;
 use Livewire\ComponentHookRegistry;
 use Livewire\Livewire;
 use Noerd\Commands\AssignAppsToTenantCommand;
-use Noerd\Commands\CreateAdminCommand;
-use Noerd\Commands\CreateTenantAppCommand;
-use Noerd\Commands\CreateTenantCommand;
 use Noerd\Commands\ExportSetupCollectionDefinitionsCommand;
 use Noerd\Commands\ImportSetupCollectionDefinitionsCommand;
+use Noerd\Commands\MakeAdminUserCommand;
+use Noerd\Commands\MakeAppCommand;
 use Noerd\Commands\MakeCollectionCommand;
 use Noerd\Commands\MakeDashboardCommand;
 use Noerd\Commands\MakeDetailCommand;
@@ -27,6 +26,7 @@ use Noerd\Commands\MakeListCommand;
 use Noerd\Commands\MakeModuleCommand;
 use Noerd\Commands\MakePageCommand;
 use Noerd\Commands\MakeResourceCommand;
+use Noerd\Commands\MakeTenantCommand;
 use Noerd\Commands\MakeThemeCommand;
 use Noerd\Commands\MakeUserAdminCommand;
 use Noerd\Commands\NoerdDemoCommand;
@@ -403,7 +403,7 @@ class NoerdServiceProvider extends ServiceProvider
                 NoerdInstallCommand::class,
                 NoerdUpdateCommand::class,
                 NoerdUpdateAllCommand::class,
-                CreateTenantAppCommand::class,
+                MakeAppCommand::class,
                 AssignAppsToTenantCommand::class,
                 MakeModuleCommand::class,
                 MakeResourceCommand::class,
@@ -413,8 +413,8 @@ class NoerdServiceProvider extends ServiceProvider
                 MakeDashboardCommand::class,
                 MakeCollectionCommand::class,
                 MakeThemeCommand::class,
-                CreateAdminCommand::class,
-                CreateTenantCommand::class,
+                MakeAdminUserCommand::class,
+                MakeTenantCommand::class,
                 NoerdDemoCommand::class,
                 PublishHomeCommand::class,
                 ImportSetupCollectionDefinitionsCommand::class,

--- a/src/Traits/HasModuleInstallation.php
+++ b/src/Traits/HasModuleInstallation.php
@@ -168,7 +168,7 @@ trait HasModuleInstallation
     }
 
     /**
-     * The silent post-scaffold run started by noerd:create-app (`--scaffold`, when
+     * The silent post-scaffold run started by noerd:make-app (`--scaffold`, when
      * the command declares the option): nothing is asked or printed except the
      * tenant assignment; migrations and the frontend build are not offered.
      */

--- a/tests/Commands/MakeAdminUserCommandTest.php
+++ b/tests/Commands/MakeAdminUserCommandTest.php
@@ -12,12 +12,12 @@ uses(RefreshDatabase::class);
 
 it('fails when no tenants exist', function (): void {
     // The message is the behaviour: it names the command that has to run first.
-    $this->artisan('noerd:create-admin', [
+    $this->artisan('noerd:make-admin-user', [
         '--name' => 'Test Admin',
         '--email' => 'admin@example.com',
         '--password' => 'password123',
     ])
-        ->expectsOutput('No tenants found. Please run "php artisan noerd:create-tenant" first.')
+        ->expectsOutput('No tenants found. Please run "php artisan noerd:make-tenant" first.')
         ->assertExitCode(1);
 
     // Verify user was NOT created
@@ -28,7 +28,7 @@ it('creates a new admin user with command options', function (): void {
     // Create a tenant first so the make-admin command has something to work with
     Tenant::factory()->create(['name' => 'Test Tenant']);
 
-    $this->artisan('noerd:create-admin', [
+    $this->artisan('noerd:make-admin-user', [
         '--name' => 'Test Admin',
         '--email' => 'admin@example.com',
         '--password' => 'password123',
@@ -47,7 +47,7 @@ it('creates a super admin user when flag is provided', function (): void {
     // Create a tenant first
     Tenant::factory()->create(['name' => 'Test Tenant']);
 
-    $this->artisan('noerd:create-admin', [
+    $this->artisan('noerd:make-admin-user', [
         '--name' => 'Super Admin',
         '--email' => 'superadmin@example.com',
         '--password' => 'password123',
@@ -65,7 +65,7 @@ it('rejects invalid credentials', function (array $options, string $error): void
     Tenant::factory()->create(['name' => 'Test Tenant']);
 
     // The error message is the behaviour: it tells the operator what to fix.
-    $this->artisan('noerd:create-admin', $options)
+    $this->artisan('noerd:make-admin-user', $options)
         ->expectsOutput($error)
         ->assertExitCode(1);
 
@@ -85,7 +85,7 @@ it('fails with duplicate email', function (): void {
     Tenant::factory()->create(['name' => 'Test Tenant']);
     NoerdUser::factory()->create(['email' => 'existing@example.com']);
 
-    $this->artisan('noerd:create-admin', [
+    $this->artisan('noerd:make-admin-user', [
         '--name' => 'Test User',
         '--email' => 'existing@example.com',
         '--password' => 'password123',
@@ -101,7 +101,7 @@ it('assigns user to all tenants as admin', function (): void {
     $tenant1 = Tenant::factory()->create(['name' => 'Tenant 1']);
     $tenant2 = Tenant::factory()->create(['name' => 'Tenant 2']);
 
-    $this->artisan('noerd:create-admin', [
+    $this->artisan('noerd:make-admin-user', [
         '--name' => 'Multi-Tenant Admin',
         '--email' => 'multiadmin@example.com',
         '--password' => 'password123',

--- a/tests/Commands/MakeAppCommandTest.php
+++ b/tests/Commands/MakeAppCommandTest.php
@@ -61,7 +61,7 @@ afterEach(function (): void {
 });
 
 it('successfully creates a app with all parameters', function (): void {
-    $this->artisan('noerd:create-app', [
+    $this->artisan('noerd:make-app', [
         '--title' => 'Test Application',
         '--name' => 'TEST_APP',
         '--icon' => 'icons.test',
@@ -79,7 +79,7 @@ it('successfully creates a app with all parameters', function (): void {
 });
 
 it('scaffolds a dashboard for the new app and uses its route without asking', function (): void {
-    $this->artisan('noerd:create-app', [
+    $this->artisan('noerd:make-app', [
         '--title' => 'Time Booking',
         '--name' => 'TB',
         '--icon' => 'icons.tb',
@@ -110,7 +110,7 @@ it('scaffolds a dashboard for the new app and uses its route without asking', fu
 it('creates the routes file when the project has none yet', function (): void {
     File::delete(base_path('routes/web.php'));
 
-    $this->artisan('noerd:create-app', [
+    $this->artisan('noerd:make-app', [
         '--title' => 'Fresh App',
         '--name' => 'FRESH',
         '--icon' => 'icons.fresh',
@@ -137,7 +137,7 @@ it('keeps an existing navigation and only inserts the dashboard entry', function
         '',
     ]));
 
-    $this->artisan('noerd:create-app', [
+    $this->artisan('noerd:make-app', [
         '--title' => 'Existing',
         '--name' => 'EXISTING_NAV',
         '--icon' => 'icons.existing',
@@ -148,7 +148,7 @@ it('keeps an existing navigation and only inserts the dashboard entry', function
 });
 
 it('points the app at an explicit route and skips the dashboard scaffold', function (): void {
-    $this->artisan('noerd:create-app', [
+    $this->artisan('noerd:make-app', [
         '--title' => 'Custom Route App',
         '--name' => 'CUSTOM_ROUTE',
         '--icon' => 'icons.custom',
@@ -161,7 +161,7 @@ it('points the app at an explicit route and skips the dashboard scaffold', funct
 });
 
 it('creates an inactive tenant app when active is set to 0', function (): void {
-    $this->artisan('noerd:create-app', [
+    $this->artisan('noerd:make-app', [
         '--title' => 'Inactive App',
         '--name' => 'INACTIVE_APP',
         '--icon' => 'icons.inactive',
@@ -173,7 +173,7 @@ it('creates an inactive tenant app when active is set to 0', function (): void {
 });
 
 it('defaults to active when active parameter is not provided', function (): void {
-    $this->artisan('noerd:create-app', [
+    $this->artisan('noerd:make-app', [
         '--title' => 'Default Active App',
         '--name' => 'DEFAULT_ACTIVE',
         '--icon' => 'icons.default',
@@ -187,7 +187,7 @@ it('rejects invalid app input', function (array $options, string $error): void {
     $appCountBefore = TenantApp::count();
 
     // The error message is the behaviour here: it tells the operator what to fix.
-    $this->artisan('noerd:create-app', $options)
+    $this->artisan('noerd:make-app', $options)
         ->expectsOutput($error)
         ->assertExitCode(1);
 
@@ -208,7 +208,7 @@ it('rejects invalid app input', function (array $options, string $error): void {
 ]);
 
 it('normalizes the app name to the uppercase underscore form', function (string $input, string $expected): void {
-    $this->artisan('noerd:create-app', [
+    $this->artisan('noerd:make-app', [
         '--title' => 'Normalized App',
         '--name' => $input,
         '--icon' => 'icons.test',
@@ -234,7 +234,7 @@ it('fails when app name already exists', function (): void {
     ]);
 
     // Try to create another app with the same name
-    $this->artisan('noerd:create-app', [
+    $this->artisan('noerd:make-app', [
         '--title' => 'Duplicate App',
         '--name' => 'EXISTING_APP',
         '--icon' => 'icons.duplicate',
@@ -246,7 +246,7 @@ it('fails when app name already exists', function (): void {
 });
 
 it('scaffolds the app as a module and leaves the registration to its install command', function (): void {
-    $this->artisan('noerd:create-app', [
+    $this->artisan('noerd:make-app', [
         '--title' => 'Zz Probe Suite',
         '--name' => 'ZZ_PROBE',
         '--icon' => 'cube',
@@ -285,7 +285,7 @@ it('scaffolds the app as a module and leaves the registration to its install com
 });
 
 it('rejects module mode combined with an explicit route', function (): void {
-    $this->artisan('noerd:create-app', [
+    $this->artisan('noerd:make-app', [
         '--title' => 'Zz Routed',
         '--name' => 'ZZ_ROUTED',
         '--icon' => 'cube',
@@ -301,7 +301,7 @@ it('rejects module mode combined with an explicit route', function (): void {
 it('refuses to scaffold a module over an existing module directory', function (): void {
     File::ensureDirectoryExists(base_path('app-modules/zz-taken'));
 
-    $this->artisan('noerd:create-app', [
+    $this->artisan('noerd:make-app', [
         '--title' => 'Zz Taken',
         '--name' => 'ZZ_TAKEN',
         '--icon' => 'cube',
@@ -322,7 +322,7 @@ it('refuses module mode when the derived tenant app already exists', function ()
         'is_active' => true,
     ]);
 
-    $this->artisan('noerd:create-app', [
+    $this->artisan('noerd:make-app', [
         '--title' => 'Zz Existing',
         '--name' => 'ZZ_EXISTING',
         '--icon' => 'cube',

--- a/tests/Commands/MakeTenantCommandTest.php
+++ b/tests/Commands/MakeTenantCommandTest.php
@@ -10,7 +10,7 @@ uses(TestCase::class);
 uses(RefreshDatabase::class);
 
 it('creates a new tenant with command options', function (): void {
-    $this->artisan('noerd:create-tenant', [
+    $this->artisan('noerd:make-tenant', [
         '--name' => 'New Tenant',
     ])->assertExitCode(0);
 
@@ -21,8 +21,8 @@ it('creates a new tenant with command options', function (): void {
 });
 
 it('generates unique uuid for each tenant', function (): void {
-    $this->artisan('noerd:create-tenant', ['--name' => 'Tenant 1'])->assertExitCode(0);
-    $this->artisan('noerd:create-tenant', ['--name' => 'Tenant 2'])->assertExitCode(0);
+    $this->artisan('noerd:make-tenant', ['--name' => 'Tenant 1'])->assertExitCode(0);
+    $this->artisan('noerd:make-tenant', ['--name' => 'Tenant 2'])->assertExitCode(0);
 
     $tenant1 = Tenant::where('name', 'Tenant 1')->first();
     $tenant2 = Tenant::where('name', 'Tenant 2')->first();
@@ -32,7 +32,7 @@ it('generates unique uuid for each tenant', function (): void {
 
 it('rejects an invalid tenant name', function (string $name, string $error): void {
     // The error message is the behaviour: it tells the operator what to fix.
-    $this->artisan('noerd:create-tenant', ['--name' => $name])
+    $this->artisan('noerd:make-tenant', ['--name' => $name])
         ->expectsOutput($error)
         ->assertExitCode(1);
 

--- a/tests/Commands/NoerdInstallCommandTest.php
+++ b/tests/Commands/NoerdInstallCommandTest.php
@@ -198,7 +198,7 @@ describe('demo prompt', function (): void {
  | interactively, but a scripted run (CI, deploy) must NEVER inherit those
  | defaults — migrations, npm build, admin setup and the demo app all require
  | an explicit opt-in flag. Admin credentials cannot be prompted at all, so
- | that step is always skipped with a pointer to noerd:create-admin.
+ | that step is always skipped with a pointer to noerd:make-admin-user.
  */
 describe('non-interactive', function (): void {
     beforeEach(function (): void {


### PR DESCRIPTION
## Summary

- `noerd:create-app` → `noerd:make-app`, `noerd:create-tenant` → `noerd:make-tenant`, `noerd:create-admin` → `noerd:make-admin-user` (`noerd:make-admin` already exists and promotes an existing user). The former names stay registered as aliases so existing install scripts keep working.
- Classes, tests, docs (`docs/make-app.md`), the Boost guideline and skills follow the new names.

Follow-up to #105 (the rename was pushed after that PR had been merged).

## Test plan

- [x] `vendor/bin/pest tests/Commands tests/Feature/BoostGuidelineTest.php` (150 passed)
- [x] `vendor/bin/pint --test`
- [x] `php artisan list noerd` in a host project shows the new names with the old ones as aliases