### PR TITLE
Drop the noerd:create-* command aliases

### DIFF
--- a/src/Commands/MakeAdminUserCommand.php
+++ b/src/Commands/MakeAdminUserCommand.php
@@ -31,13 +31,6 @@ class MakeAdminUserCommand extends Command
      *
      * @var string
      */
-    /**
-     * The former command name, kept so existing install scripts keep working.
-     *
-     * @var array<int, string>
-     */
-    protected $aliases = ['noerd:create-admin'];
-
     protected $description = 'Create a new user and make them an admin';
 
     /**

--- a/src/Commands/MakeAppCommand.php
+++ b/src/Commands/MakeAppCommand.php
@@ -46,13 +46,6 @@ class MakeAppCommand extends Command
      *
      * @var string
      */
-    /**
-     * The former command name, kept so existing install scripts keep working.
-     *
-     * @var array<int, string>
-     */
-    protected $aliases = ['noerd:create-app'];
-
     protected $description = 'Create a new app with its own dashboard that can be assigned to tenants';
 
     /**

--- a/src/Commands/MakeTenantCommand.php
+++ b/src/Commands/MakeTenantCommand.php
@@ -27,13 +27,6 @@ class MakeTenantCommand extends Command
      *
      * @var string
      */
-    /**
-     * The former command name, kept so existing install scripts keep working.
-     *
-     * @var array<int, string>
-     */
-    protected $aliases = ['noerd:create-tenant'];
-
     protected $description = 'Create a new tenant';
 
     /**


### PR DESCRIPTION
## Summary

- Removes the `noerd:create-app`, `noerd:create-tenant` and `noerd:create-admin` aliases introduced in #106. The commands are `noerd:make-app`, `noerd:make-tenant` and `noerd:make-admin-user` only; docs, guideline and skills already use the new names.

## Test plan

- [x] `vendor/bin/pest tests/Commands/MakeAppCommandTest.php tests/Commands/MakeTenantCommandTest.php tests/Commands/MakeAdminUserCommandTest.php tests/Commands/NoerdInstallCommandTest.php` (43 passed)
- [x] `vendor/bin/pint --test`