### PR TITLE
Fix the auth guard, provider and user model to the noerd defaults

### DIFF
--- a/config/noerd.php
+++ b/config/noerd.php
@@ -15,24 +15,6 @@ declare(strict_types=1);
 */
 
 return [
-    'auth' => [
-        // Guard noerd registers and authenticates against. Set to 'web' to
-        // run on the host's default guard instead of a dedicated one.
-        'guard' => env('NOERD_AUTH_GUARD', 'noerd'),
-
-        // Authenticatable model backing the noerd user provider.
-        'model' => env('NOERD_AUTH_MODEL', Noerd\Models\NoerdUser::class),
-
-        // Provider / password-broker names registered into auth.providers
-        // and auth.passwords at runtime (skipped when the host defines them).
-        'provider' => 'noerd_users',
-        'passwords' => 'noerd_users',
-
-        // When true, noerd also becomes the app's DEFAULT guard at runtime —
-        // escape hatch for hosts with unmigrated bare-'auth' routes.
-        'set_as_default' => env('NOERD_AUTH_DEFAULT', false),
-    ],
-
     'routes' => [
         // URL prefix for the noerd core routes (login, apps, user, ...).
         // Route NAMES are unaffected — only the URLs carry the prefix.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -11,29 +11,17 @@ registers three things **at runtime** (your `config/auth.php` and `.env` are nev
 | `auth.passwords.noerd_users` | `['provider' => 'noerd_users', 'table' => 'password_reset_tokens', 'expire' => 60, 'throttle' => 60]` |
 
 **A key your application already defines always wins** — the runtime registration only fills in
-keys that are absent. To override any part (a different session driver, your own broker table,
-another user model), define the key in your `config/auth.php` and noerd will use it as-is.
+keys that are absent. To override a part (a different session driver, your own broker table),
+define the key in your `config/auth.php` and noerd will use it as-is. The user model behind the
+provider is always `Noerd\Models\NoerdUser` on the `noerd_users` table — the framework internals
+(tenant scoping, profiles, super admin, settings) are methods of that model, so neither the model
+nor the table is configurable.
 
-## Configuration (`config/noerd.php`)
-
-```php
-'auth' => [
-    'guard' => env('NOERD_AUTH_GUARD', 'noerd'),
-    'model' => env('NOERD_AUTH_MODEL', Noerd\Models\NoerdUser::class),
-    'provider' => 'noerd_users',
-    'passwords' => 'noerd_users',
-    'set_as_default' => env('NOERD_AUTH_DEFAULT', false),
-],
-```
-
-- `guard` — the guard noerd registers and authenticates against. Setting `NOERD_AUTH_GUARD=web`
-  makes noerd run on the host's `web` guard: that guard already exists, so nothing is injected and
-  noerd authenticates against the host's user provider.
-- `model` — the Authenticatable backing the noerd user provider.
-- `set_as_default` — when `true`, noerd also flips `auth.defaults.guard` / `auth.defaults.passwords`
-  to the noerd guard at runtime. This is an escape hatch for hosts that still protect routes with
-  the bare `auth` middleware alias (which resolves the default guard). Leave it `false` when noerd
-  coexists with another auth stack (Nova, Breeze, ...) that owns the default guard.
+The names are fixed: the guard is `noerd`, the provider and the password broker are `noerd_users`
+(`NoerdAuth::GUARD`, `NoerdAuth::PROVIDER`, `NoerdAuth::BROKER`). There is no auth section in
+`config/noerd.php`. noerd never changes `auth.defaults.guard` / `auth.defaults.passwords`: the
+noerd route groups select the noerd guard per request (see below), so routes protected by the
+bare `auth` middleware alias keep resolving the host's default guard.
 
 ## Routes & URL prefix
 
@@ -131,8 +119,7 @@ A host that already owns the `web` guard (Nova admin users in a `users` table, B
 login) needs no special setup:
 
 1. Install noerd as usual — `config/auth.php` keeps the host's `users` provider and default guard.
-2. Keep `NOERD_AUTH_DEFAULT` unset (or `false`).
-3. noerd users live in `noerd_users` and log in via noerd's `/noerd/login` against the `noerd`
+2. noerd users live in `noerd_users` and log in via noerd's `/noerd/login` against the `noerd`
    guard; host users keep logging in via their own stack (e.g. their own `/login`) against `web`.
 
 Both guards share the session cookie but store independent login keys

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -139,8 +139,6 @@ itself. The brand palette is CSS-first, no `tailwind.config.js` is needed (see [
   pins `date`, `datetime`, `decimal_separator`, `thousands_separator` (`NOERD_FORMAT_*`) and
   `csv_delimiter` (`NOERD_CSV_DELIMITER`, default `;`) — see
   [Currency, Numbers & Dates](formatting.md)
-- `auth.guard` (`NOERD_AUTH_GUARD`) / `auth.set_as_default` (`NOERD_AUTH_DEFAULT`) — noerd's
-  dedicated auth guard (see [Authentication](auth.md))
 - `theme.default` / `theme.enforced` — system-wide form theme (see [Themes](themes.md))
 - `brand.active` — color palette (see [Brand](brand.md))
 

--- a/src/Helpers/NoerdAuth.php
+++ b/src/Helpers/NoerdAuth.php
@@ -9,7 +9,6 @@ use Illuminate\Contracts\Auth\PasswordBroker;
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Password;
-use Noerd\Models\NoerdUser;
 
 /**
  * Resolves noerd's dedicated auth guard, user provider and password broker.
@@ -17,13 +16,22 @@ use Noerd\Models\NoerdUser;
  * Noerd never relies on the host application's default guard: all framework
  * internals (tenant scoping, middleware, permission resolvers) resolve the
  * current user through this helper, so noerd coexists with any host auth
- * stack (Nova, Breeze, ...) that owns the default guard.
+ * stack (Nova, Breeze, ...) that owns the default guard. The guard, provider
+ * and broker names are fixed — a host tunes their definitions (driver, broker
+ * table) in config/auth.php, where an existing key always wins over the
+ * runtime registration.
  */
 final class NoerdAuth
 {
+    public const GUARD = 'noerd';
+
+    public const PROVIDER = 'noerd_users';
+
+    public const BROKER = 'noerd_users';
+
     public static function guardName(): string
     {
-        return config('noerd.auth.guard', 'noerd');
+        return self::GUARD;
     }
 
     public static function guard(): StatefulGuard
@@ -49,21 +57,16 @@ final class NoerdAuth
 
     public static function providerName(): string
     {
-        return config('noerd.auth.provider', 'noerd_users');
+        return self::PROVIDER;
     }
 
     public static function brokerName(): string
     {
-        return config('noerd.auth.passwords', 'noerd_users');
+        return self::BROKER;
     }
 
     public static function broker(): PasswordBroker
     {
         return Password::broker(self::brokerName());
-    }
-
-    public static function userModel(): string
-    {
-        return config('noerd.auth.model', NoerdUser::class);
     }
 }

--- a/src/Providers/NoerdServiceProvider.php
+++ b/src/Providers/NoerdServiceProvider.php
@@ -58,6 +58,7 @@ use Noerd\Middleware\NoerdRedirectIfAuthenticated;
 use Noerd\Middleware\SetupMiddleware;
 use Noerd\Middleware\SetUserLocale;
 use Noerd\Models\NoerdSettings;
+use Noerd\Models\NoerdUser;
 use Noerd\Models\SetupLanguage;
 use Noerd\Models\Tenant;
 use Noerd\Models\TenantApp;
@@ -462,7 +463,10 @@ class NoerdServiceProvider extends ServiceProvider
     /**
      * Register noerd's dedicated auth guard, user provider and password
      * broker at runtime. The host's config/auth.php is never written to,
-     * and any key the host already defines wins over the injection.
+     * and any key the host already defines wins over the injection. The
+     * application's DEFAULT guard is never touched: noerd routes select the
+     * noerd guard per request (NoerdAuthenticate), everything else keeps
+     * resolving the host's guard.
      */
     private function registerNoerdGuard(): void
     {
@@ -480,7 +484,7 @@ class NoerdServiceProvider extends ServiceProvider
         if (config("auth.providers.{$provider}") === null) {
             config(["auth.providers.{$provider}" => [
                 'driver' => 'eloquent',
-                'model' => NoerdAuth::userModel(),
+                'model' => NoerdUser::class,
             ]]);
         }
 
@@ -491,15 +495,6 @@ class NoerdServiceProvider extends ServiceProvider
                 'expire' => 60,
                 'throttle' => 60,
             ]]);
-        }
-
-        // Escape hatch for hosts whose routes still use the bare 'auth'
-        // middleware: make the noerd guard the application default.
-        if (config('noerd.auth.set_as_default')) {
-            config([
-                'auth.defaults.guard' => $guard,
-                'auth.defaults.passwords' => $broker,
-            ]);
         }
     }
 

--- a/stubs/noerd.php.stub
+++ b/stubs/noerd.php.stub
@@ -3,33 +3,6 @@
 return [
     /*
     |--------------------------------------------------------------------------
-    | Authentication
-    |--------------------------------------------------------------------------
-    |
-    | Noerd registers its own auth guard, user provider and password broker
-    | at runtime — config/auth.php is never modified. Any of the keys that
-    | already exist in the host's auth config are left untouched, so a host
-    | can override every part by defining it itself.
-    |
-    | 'guard'          Guard noerd authenticates against. Set to 'web' to
-    |                  run on the host's default guard instead of a dedicated one.
-    | 'model'          Authenticatable model backing the noerd user provider.
-    | 'set_as_default' When true, noerd also becomes the app's DEFAULT guard
-    |                  at runtime — escape hatch for hosts with unmigrated
-    |                  bare-'auth' routes. Leave false when noerd coexists
-    |                  with another auth stack (Nova, Breeze, ...).
-    |
-    */
-    'auth' => [
-        'guard' => env('NOERD_AUTH_GUARD', 'noerd'),
-        'model' => env('NOERD_AUTH_MODEL', Noerd\Models\NoerdUser::class),
-        'provider' => 'noerd_users',
-        'passwords' => 'noerd_users',
-        'set_as_default' => env('NOERD_AUTH_DEFAULT', false),
-    ],
-
-    /*
-    |--------------------------------------------------------------------------
     | Routes
     |--------------------------------------------------------------------------
     |

--- a/tests/Feature/GuardResolutionTest.php
+++ b/tests/Feature/GuardResolutionTest.php
@@ -16,10 +16,10 @@ use Noerd\Tests\TestCase;
 uses(TestCase::class, RefreshDatabase::class);
 
 /*
- | noerd authenticates against its OWN guard, and `noerd.auth.set_as_default`
- | is false by default — a host application keeps the default guard. Components
- | must therefore resolve the user through NoerdAuth, never through Auth::user()
- | / auth()->user().
+ | noerd authenticates against its OWN guard and never claims the application
+ | default guard — a host application keeps it. Components must therefore
+ | resolve the user through NoerdAuth, never through Auth::user() /
+ | auth()->user().
  |
  | The rest of the suite pins auth.defaults.guard to 'noerd' (see TestCase), so
  | it CANNOT observe this distinction. These tests deliberately point the

--- a/tests/Feature/NoerdGuardTest.php
+++ b/tests/Feature/NoerdGuardTest.php
@@ -62,9 +62,8 @@ describe('runtime guard registration', function (): void {
         expect(config('auth.passwords.noerd_users'))->toBe($hostBroker);
     });
 
-    it('leaves the default guard untouched when set_as_default is false', function (): void {
+    it('never touches the application default guard', function (): void {
         config([
-            'noerd.auth.set_as_default' => false,
             'auth.defaults.guard' => 'web',
             'auth.defaults.passwords' => 'users',
         ]);
@@ -75,17 +74,12 @@ describe('runtime guard registration', function (): void {
         expect(config('auth.defaults.passwords'))->toBe('users');
     });
 
-    it('takes over the default guard when set_as_default is true', function (): void {
-        config([
-            'noerd.auth.set_as_default' => true,
-            'auth.defaults.guard' => 'web',
-            'auth.defaults.passwords' => 'users',
-        ]);
+    it('always backs the noerd provider with the NoerdUser model', function (): void {
+        config(['auth.providers.noerd_users' => null]);
 
         reRunGuardRegistration();
 
-        expect(config('auth.defaults.guard'))->toBe('noerd');
-        expect(config('auth.defaults.passwords'))->toBe('noerd_users');
+        expect(config('auth.providers.noerd_users.model'))->toBe(NoerdUser::class);
     });
 });
 

--- a/tests/Feature/ProfileLocaleFormTest.php
+++ b/tests/Feature/ProfileLocaleFormTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
 use Noerd\Helpers\FormatHelper;
+use Noerd\Helpers\NoerdAuth;
 use Noerd\Helpers\TenantHelper;
 use Noerd\Middleware\SetUserLocale;
 use Noerd\Models\NoerdUser;
@@ -81,7 +82,7 @@ it('offers exactly the supported locales', function (): void {
 it('keeps the interface language separate from the formatting locale', function (): void {
     $user = zzProfileLocaleUser();
     $user->setting->update(['locale' => 'de', 'format_locale' => 'en-US']);
-    $this->actingAs($user, config('noerd.auth.guard'));
+    $this->actingAs($user, NoerdAuth::guardName());
 
     (new SetUserLocale())->handle(request(), fn() => response(''));
 

--- a/tests/Helpers/CurrencyHelperTest.php
+++ b/tests/Helpers/CurrencyHelperTest.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Noerd\Helpers\CurrencyHelper;
 use Noerd\Helpers\FormatHelper;
+use Noerd\Helpers\NoerdAuth;
 use Noerd\Helpers\TenantHelper;
 use Noerd\Models\NoerdSettings;
 use Noerd\Models\NoerdUser;
@@ -35,7 +36,7 @@ function zzCurrencyUser(?string $formatLocale = null): NoerdUser
         $user->setting->update(['format_locale' => $formatLocale]);
     }
 
-    test()->actingAs($user, config('noerd.auth.guard'));
+    test()->actingAs($user, NoerdAuth::guardName());
 
     return $user;
 }

--- a/tests/Helpers/FormatHelperTest.php
+++ b/tests/Helpers/FormatHelperTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
 use Noerd\Helpers\FormatHelper;
+use Noerd\Helpers\NoerdAuth;
 use Noerd\Helpers\TenantHelper;
 use Noerd\Models\NoerdSettings;
 use Noerd\Models\NoerdUser;
@@ -34,7 +35,7 @@ function zzFormatUser(?string $formatLocale = null): NoerdUser
         $user->setting->update(['format_locale' => $formatLocale]);
     }
 
-    test()->actingAs($user, config('noerd.auth.guard'));
+    test()->actingAs($user, NoerdAuth::guardName());
 
     return $user;
 }

--- a/tests/Unit/ListCellFormatterTest.php
+++ b/tests/Unit/ListCellFormatterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Noerd\Helpers\CurrencyHelper;
 use Noerd\Helpers\FormatHelper;
+use Noerd\Helpers\NoerdAuth;
 use Noerd\Helpers\TenantHelper;
 use Noerd\Models\NoerdSettings;
 use Noerd\Models\NoerdUser;
@@ -43,7 +44,7 @@ function zzCellFormatterUser(string $currency = 'EUR', string $tenantLocale = 'd
         $user->setting->update(['format_locale' => $formatLocale]);
     }
 
-    test()->actingAs($user, config('noerd.auth.guard'));
+    test()->actingAs($user, NoerdAuth::guardName());
 
     return $user;
 }


### PR DESCRIPTION
## Summary

- The noerd guard, user provider and password broker names are now fixed (`NoerdAuth::GUARD`, `NoerdAuth::PROVIDER`, `NoerdAuth::BROKER`), and the provider is always backed by `Noerd\Models\NoerdUser` on the `noerd_users` table. `NoerdAuth::userModel()` is removed.
- noerd never touches `auth.defaults.guard` / `auth.defaults.passwords` any more; noerd routes keep selecting the guard per request through `NoerdAuthenticate`.
- The `auth` section of `config/noerd.php` (`NOERD_AUTH_GUARD`, `NOERD_AUTH_MODEL`, `NOERD_AUTH_DEFAULT`) is dropped from the module config and the install stub. A host still overrides the guard driver or the broker table by defining the key in its own `config/auth.php`, where an existing key wins over the runtime registration.
- Docs (`auth.md`, `installation.md`) describe the fixed names; tests prove the default guard stays untouched and the provider always carries `NoerdUser`.

## Test plan

- [x] `vendor/bin/pest` in the package: 1353 passed