### PR TITLE
Render the README demo GIF at full width

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Zero intrusion: noerd brings its own auth guard, routes and tables, and never modifies your
 `config/auth.php` or `.env`. Screens are slim Livewire components driven by YAML configs.
 
-![Noerd](https://noerd.dev/assets/Noerd.gif)
+<img src="https://noerd.dev/assets/Noerd.gif" alt="noerd" width="100%">
 
 ## Quickstart
 


### PR DESCRIPTION
The demo GIF on noerd.dev was replaced with a new 1200x679 recording (the old one was 720px wide, narrower than the GitHub README column).

Switches the markdown image to an `<img width="100%">` tag so it spans the full README width regardless of the source resolution.