### PR TITLE
Cache-bust the README demo GIF URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Zero intrusion: noerd brings its own auth guard, routes and tables, and never modifies your
 `config/auth.php` or `.env`. Screens are slim Livewire components driven by YAML configs.
 
-<img src="https://noerd.dev/assets/Noerd.gif" alt="noerd" width="100%">
+<img src="https://noerd.dev/assets/Noerd.gif?v=2" alt="noerd" width="100%">
 
 ## Quickstart
 


### PR DESCRIPTION
GitHub proxies external README images through camo.githubusercontent.com and caches them per URL. Since the GIF was replaced under an unchanged URL, the old recording keeps being served.

Appending `?v=2` gives camo a fresh URL to fetch.