### PR TITLE
Keep the first quick-create field clear of the tab panel's clip edge

### DIFF
--- a/resources/views/components/tab-content.blade.php
+++ b/resources/views/components/tab-content.blade.php
@@ -25,7 +25,11 @@
         unset($quickLayout['tabs'], $quickLayout['title'], $quickLayout['description']);
     @endphp
 
-    <div class="[&>div>div]:py-0">
+    {{-- The theme's grid padding is replaced by a fixed 8px top gap: quick-create
+         drops the block heading, so the first field would otherwise sit flush
+         against the top edge of the hosting scroll container (x-noerd::tab-panel
+         clips there) and lose its top border and focus ring. --}}
+    <div class="[&>div>div]:pt-2 [&>div>div]:pb-0">
         @include('noerd::components.detail.block', array_merge($quickLayout, ['detailData' => $detailData]))
     </div>
 @else

--- a/tests/Components/PageChromeLayoutTest.php
+++ b/tests/Components/PageChromeLayoutTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ViewErrorBag;
 use Livewire\Livewire;
 use Noerd\Models\NoerdUser;
 use Noerd\Tests\TestCase;
@@ -111,5 +112,28 @@ describe('tab panel scrolling', function (): void {
         assertElementHasClasses(Livewire::test('noerd-test::page-chrome-detail')->html(), $bodyClasses);
 
         assertNoElementHasClasses(Livewire::test('noerd-test::page-chrome-list')->html(), $bodyClasses);
+    });
+});
+
+/*
+ | x-noerd::tab-panel clips at its top edge (overflow-y-auto), so the first form
+ | row must never start flush against it — a flush input loses its top border and
+ | its focus ring. Quick-create drops the block heading and replaces the theme's
+ | grid padding, which is where that gap would otherwise disappear.
+ */
+describe('quick create spacing', function (): void {
+
+    it('keeps the first quick-create field clear of the scroll container clip edge', function (): void {
+        // Form fields resolve $errors from the request; Blade::render has none.
+        view()->share('errors', new ViewErrorBag());
+
+        $html = Blade::render(<<<'BLADE'
+            <x-noerd::tab-content
+                :layout="['quickCreate' => true, 'fields' => [['name' => 'detailData.name', 'label' => 'Name', 'type' => 'text', 'required' => true]]]"
+                :modelId="null" />
+        BLADE);
+
+        assertElementHasClasses($html, ['[&>div>div]:pt-2']);
+        assertNoElementHasClasses($html, ['[&>div>div]:py-0']);
     });
 });


### PR DESCRIPTION
## Problem

In a quick-create dialog the first form field lost its top border and its focus ring — the line
was cut off flush at the top edge.

`x-noerd::tab-panel` is a scroll container (`overflow-y-auto`) and clips at its own top edge; it
already compensates for that horizontally (`-mx-6 px-6`) and at the bottom (`-mb-8 pb-8`), but not
at the top. Quick-create drops the block heading AND zeroed the theme's grid padding
(`[&>div>div]:py-0`), so the first input started exactly on that clip edge and its border/ring were
clipped away.

Reproduced on a page-hosted quick-create (`crm::lead-page`, `quickCreate: true`), where the page's
`x-noerd::tab-panel` is the clipping ancestor of the embedded detail.

## Fix

Replace the theme's grid padding with a fixed 8px top gap instead of zero:

```blade
<div class="[&>div>div]:pt-2 [&>div>div]:pb-0">
```

8px clears the widest shipped focus ring (default theme: `ring-2` + `ring-offset-2` = 4px outside
the border box) while keeping the dialog compact.

## Tests

New `quick create spacing` block in `tests/Components/PageChromeLayoutTest.php` — proves the
mechanic (the first quick-create row keeps a gap to the scroll container's clip edge), not the
shipped YAML.

`vendor/bin/pest tests/Components/PageChromeLayoutTest.php` — 10 passed.
