### PR TITLE
Release v0.16.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
             "name": "Johannes Brock"
         }
     ],
-    "version": "v0.16.0",
+    "version": "v0.16.1",
     "license": "MIT",
     "require": {
         "php": "^8.3",


### PR DESCRIPTION
Bump `composer.json` version to v0.16.1 so the tagged commit carries the released version.

Contains since v0.16.0:
- Keep the first quick-create field clear of the tab panel's clip edge (#115)
- README demo GIF fixes (#112, #113, #114)