### PR TITLE
Add a TenantAppAssigned event and keep pivot flags when copying tenant apps

### DIFF
--- a/resources/views/components/create-tenant-form.blade.php
+++ b/resources/views/components/create-tenant-form.blade.php
@@ -41,11 +41,19 @@ new class extends Component {
             'profile_key' => Profile::Admin->value,
         ]);
 
+        // The pivot flags are copied along: an app the source tenant hides is
+        // module-internal (it backs another app's screens rather than standing
+        // on its own), so a plain attach would surface it in the copy's app
+        // switcher. syncWithoutDetaching rather than attach so an app a module
+        // already assigned during creation does not hit the unique index.
         $selectedTenant = TenantHelper::getSelectedTenant();
         $apps = $selectedTenant?->tenantApps ?? collect();
-        foreach ($apps as $app) {
-            $tenant->tenantApps()->attach($app->id);
-        }
+        $tenant->tenantApps()->syncWithoutDetaching(
+            $apps->mapWithKeys(fn($app): array => [$app->id => [
+                'is_hidden' => (bool) $app->pivot->is_hidden,
+                'sort_order' => (int) $app->pivot->sort_order,
+            ]])->all(),
+        );
 
         TenantHelper::setSelectedTenantId($tenant->id);
 

--- a/resources/views/components/tenant-apps-page.blade.php
+++ b/resources/views/components/tenant-apps-page.blade.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\DB;
 use Livewire\Component;
+use Noerd\Events\TenantAppAssigned;
 use Noerd\Helpers\NoerdAuth;
 use Noerd\Helpers\TenantHelper;
 use Noerd\Models\TenantApp;
@@ -22,13 +23,15 @@ new class extends Component {
         $this->authorizeAdmin();
 
         $tenant = TenantHelper::getSelectedTenant();
-        $assignedIds = $tenant->tenantApps()->pluck('tenant_apps.id')->map(fn ($id): int => (int) $id)->all();
+        $assignedIds = $tenant->tenantApps()->pluck('tenant_apps.id')->map(fn($id): int => (int) $id)->all();
 
         if (in_array($appId, $assignedIds, true)) {
             $tenant->tenantApps()->detach($appId);
         } else {
             $maxSort = $tenant->tenantApps()->max('sort_order') ?? -1;
             $tenant->tenantApps()->attach($appId, ['sort_order' => $maxSort + 1]);
+
+            TenantAppAssigned::dispatch($tenant->id, (string) TenantApp::whereKey($appId)->value('name'));
         }
 
         $this->loadApps();

--- a/src/Commands/AssignAppsToTenantCommand.php
+++ b/src/Commands/AssignAppsToTenantCommand.php
@@ -11,6 +11,7 @@ use function Laravel\Prompts\multiselect;
 use function Laravel\Prompts\search;
 use function Laravel\Prompts\select;
 
+use Noerd\Events\TenantAppAssigned;
 use Noerd\Models\Tenant;
 use Noerd\Models\TenantApp;
 
@@ -162,6 +163,10 @@ class AssignAppsToTenantCommand extends Command
 
             $addedApps = array_diff($selectedAppIds, $currentAppIds);
             $removedApps = array_diff($currentAppIds, $selectedAppIds);
+
+            foreach (TenantApp::whereIn('id', $addedApps)->pluck('name') as $addedAppName) {
+                TenantAppAssigned::dispatch($tenant->id, (string) $addedAppName);
+            }
 
             $this->newLine();
             $this->info('App assignments updated successfully!');

--- a/src/Events/TenantAppAssigned.php
+++ b/src/Events/TenantAppAssigned.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noerd\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+/**
+ * A tenant app was newly assigned to a tenant. Modules listen for this to pull
+ * in whatever an app of theirs needs alongside it — the core itself must not
+ * know about any module, and a module must not patch the core's assignment
+ * screens. Fired only for an app the tenant did not hold before.
+ */
+class TenantAppAssigned
+{
+    use Dispatchable;
+
+    /**
+     * @param  string  $appName  tenant_apps.name as stored (canonically uppercase)
+     */
+    public function __construct(public int $tenantId, public string $appName) {}
+}

--- a/tests/Commands/AssignAppsToTenantTest.php
+++ b/tests/Commands/AssignAppsToTenantTest.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Noerd\Events\TenantAppAssigned;
 use Noerd\Models\Tenant;
 use Noerd\Models\TenantApp;
 use Noerd\Tests\TestCase;
@@ -75,4 +77,20 @@ it('syncs the selection onto the tenant, removing what was deselected', function
         ->assertExitCode(0);
 
     expect(($this->assignedAppIds)())->toBe([$this->noerdAppB->id]);
+});
+
+it('announces only the apps the sync newly assigned', function (): void {
+    Event::fake([TenantAppAssigned::class]);
+
+    $this->tenant->tenantApps()->attach($this->noerdAppA->id);
+
+    $this->artisan('noerd:assign-apps-to-tenant', ['--tenant-id' => $this->tenant->id])
+        ->expectsQuestion('Select apps to assign to this tenant:', [$this->noerdAppA->id, $this->noerdAppB->id])
+        ->assertExitCode(0);
+
+    Event::assertDispatchedTimes(TenantAppAssigned::class, 1);
+    Event::assertDispatched(
+        TenantAppAssigned::class,
+        fn(TenantAppAssigned $event): bool => $event->tenantId === $this->tenant->id && $event->appName === 'NOERD_APP_B',
+    );
 });

--- a/tests/Feature/TenantAppsListTest.php
+++ b/tests/Feature/TenantAppsListTest.php
@@ -3,8 +3,10 @@
 declare(strict_types=1);
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
 use Livewire\Livewire;
 use Noerd\Enums\Profile;
+use Noerd\Events\TenantAppAssigned;
 use Noerd\Helpers\TenantHelper;
 use Noerd\Models\NoerdUser;
 use Noerd\Models\Tenant;
@@ -85,6 +87,24 @@ it('toggleApp sets correct sort_order when adding', function (): void {
 
     $pivot = $this->tenant->tenantApps()->where('tenant_apps.id', $this->appC->id)->first()->pivot;
     expect($pivot->sort_order)->toBe(2);
+});
+
+it('toggleApp announces a newly assigned app, but not a detached one', function (): void {
+    Event::fake([TenantAppAssigned::class]);
+
+    $this->tenant->tenantApps()->attach($this->appA->id, ['sort_order' => 0]);
+
+    $this->actingAs($this->admin);
+
+    Livewire::test('noerd::tenant-apps-page')
+        ->call('toggleApp', $this->appB->id)
+        ->call('toggleApp', $this->appA->id);
+
+    Event::assertDispatchedTimes(TenantAppAssigned::class, 1);
+    Event::assertDispatched(
+        TenantAppAssigned::class,
+        fn(TenantAppAssigned $event): bool => $event->tenantId === $this->tenant->id && $event->appName === 'APP_B',
+    );
 });
 
 it('appSort updates sort_order correctly', function (): void {


### PR DESCRIPTION
## TenantAppAssigned

The core has no point at which a module can react to "this tenant was just given app X": Eloquent fires no model events for a pivot `attach()`, so a module either patches the core's assignment screens or misses the change entirely. Both are ruled out by the architecture guardrails.

`Noerd\Events\TenantAppAssigned($tenantId, $appName)` closes that gap. It is dispatched only for an app the tenant did not hold before, from the two places the core assigns apps:

- `tenant-apps-page` — the add branch of `toggleApp()`, not the detach branch.
- `AssignAppsToTenantCommand` — for the difference `$addedApps` of the sync, not the whole selection.

A module that has to pull something in alongside one of its apps now listens for it instead of duplicating the logic at every creation path.

## Pivot flags when copying a tenant

`create-tenant-form` copies the source tenant's apps onto the new tenant. It did so with a bare `attach($app->id)`, which drops the pivot columns: `is_hidden` and `sort_order` were lost. An app the source tenant deliberately hides — one that backs another app's screens rather than standing on its own — reappeared in the copy's app switcher, and the ordering reset. The flags are now copied along, via `syncWithoutDetaching` so an app a module already assigned during creation does not hit the unique index.

## Tests

- `TenantAppsListTest`: `toggleApp` announces exactly the newly assigned app and stays silent when detaching.
- `AssignAppsToTenantTest`: the command announces only what the sync added.