### PR TITLE
Flush Livewire's process-static component hook list before each test app boots

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,6 +8,7 @@ use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Testing\RefreshDatabaseState;
 use Illuminate\Support\Facades\File;
+use Livewire\ComponentHookRegistry;
 use Livewire\Livewire;
 use Livewire\LivewireServiceProvider;
 use Noerd\Models\NoerdUser;
@@ -54,6 +55,7 @@ abstract class TestCase extends BaseTestCase
     protected function setUp(): void
     {
         self::flushGuardableColumnsCache();
+        self::flushLivewireComponentHooks();
         $this->swapInTestbenchRefreshDatabaseState();
 
         try {
@@ -162,6 +164,24 @@ abstract class TestCase extends BaseTestCase
         Closure::bind(static function (): void {
             Model::$guardableColumns = [];
         }, null, Model::class)();
+    }
+
+    /**
+     * Livewire keeps the registered component hooks in a process-global static
+     * list that survives app boots: every hook a provider ever registered stays
+     * on the list, and the next Livewire boot wires ALL of them into the new
+     * app. A host-application suite that ran earlier in the same PHPUnit
+     * process therefore leaks the hooks of every host package (e.g. noerd-plus'
+     * custom-attribute hooks) into this testbench app — which never booted
+     * those packages and has none of their tables. Flushed before the app is
+     * created, so only the hooks of the providers this app actually boots are
+     * attached; a host suite running afterwards re-registers its own on boot.
+     */
+    private static function flushLivewireComponentHooks(): void
+    {
+        Closure::bind(static function (): void {
+            ComponentHookRegistry::$componentHooks = [];
+        }, null, ComponentHookRegistry::class)();
     }
 
     private function swapInTestbenchRefreshDatabaseState(): void


### PR DESCRIPTION
## Why

Livewire keeps registered component hooks in a process-global static list (`ComponentHookRegistry::$componentHooks`) that survives application rebuilds and is never cleared. Every Livewire boot attaches **all** hooks on that list to the new app.

When a host-application suite and this package's testbench suite run in the same PHPUnit process, the hooks of every host package (e.g. noerd-plus' custom-attribute hooks) leak into the testbench app — which never booted those packages and has none of their tables. This became relevant once noerd-plus moved its hook registration into the provider's `register()` phase, where the hooks are actually attached.

## What

`Noerd\Tests\TestCase::setUp()` now flushes the static hook list before the application is created. Only the hooks of the providers the testbench app actually boots are attached; a host suite running afterwards re-registers its own hooks on boot.

Test-only change — `tests/TestCase.php` is never loaded in a production request. Hooks registered in a provider's `register()` phase (all core hooks) are unaffected because they are re-registered on every app boot; hooks registered in `boot()` now behave in tests exactly as they do in production.

## Verification

- `NoerdDetailStoreRoundtripTest` and the full core suite pass after a noerd-plus test in the same process with the flush in place.
- Note: in the current state the same combination also passes without the flush — no core test currently drives a leaked hook far enough to hit a missing table — so the change is preventive for the suite as it stands and fixes the mechanism rather than a reproducible red test.
