### PR TITLE
Bump version to v0.16.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
             "name": "Johannes Brock"
         }
     ],
-    "version": "v0.16.4",
+    "version": "v0.16.5",
     "license": "MIT",
     "require": {
         "php": "^8.3",


### PR DESCRIPTION
Release v0.16.5. Contains #123 (flush Livewire's process-static component hook list before each test app boots).