### PR TITLE
Configure the trait naming hooks via protected properties

### DIFF
--- a/docs/detail-view.md
+++ b/docs/detail-view.md
@@ -667,8 +667,8 @@ custom `mount()` that replaces `$detailData` wholesale.
 - **Properties:** `$detailData` (array) for form binding, `$modelId` (from trait) for the record ID
 - **mount() / store() / delete():** Provided by the trait — only override for custom behavior
 - **validateFromLayout():** Validates against the `required:` flags of the YAML (plus relation-form rules)
-- **getListComponent():** Derives the list refreshed on close from the component name (`item-detail` → `items-list`, namespace kept); override `protected function getListComponent(): string` when the list does not follow the plural convention
-- **componentName():** The name the YAML, session keys and trait events resolve by (Livewire's component name, `NoerdComponentShared`); `getDetailComponent()` is the overridable hook for a component that renders another component's detail YAML
+- **getListComponent():** Derives the list refreshed on close from the component name (`item-detail` → `items-list`, namespace kept); declare `protected string $listComponent = 'inventory::stock-list';` when the list does not follow the plural convention (overriding the method stays possible for a dynamic target and wins over the property)
+- **componentName():** The name the YAML, session keys and trait events resolve by (Livewire's component name, `NoerdComponentShared`); `getDetailComponent()` is the hook for a component that renders another component's detail YAML — declare `protected string $detailConfigComponent = 'item-detail';` (NOT `$detailComponent`, which on lists names the modal a row click opens). The trait declares neither property; keep them `protected`
 - The Eloquent model is **never** stored as a component property
 - **tenant_id:** Do not set `tenant_id` manually in `store()`. Models using the `BelongsToTenant` trait have `tenant_id` assigned automatically on creation.
 

--- a/docs/list-view.md
+++ b/docs/list-view.md
@@ -357,7 +357,7 @@ the YAML hides the row):
 - **listData():** Builds the list config; override it for custom queries, always ending in `return $this->buildList($rows);`
 - **listAction(mixed $modelId = null, array $relations = []):** Trait default opens `$detailRoute` (else `$detailComponent`) as a modal with `['modelId' => $modelId, 'relations' => $relations]`; only override it for custom behavior (extra modal arguments, no modal, …)
 - **buildList():** Generates the list configuration from the YAML
-- **Deep links:** `?{entity}Id=5` opens that record's modal over the list, `?create=1` the create modal. `mountList()` reads them once on mount; the parameter name derives from the component name (`items-list` → `itemId`, via `getDeepLinkParam()`) — no override needed
+- **Deep links:** `?{entity}Id=5` opens that record's modal over the list, `?create=1` the create modal. `mountList()` reads them once on mount; the parameter name derives from the component name (`items-list` → `itemId`, via `getDeepLinkParam()`) — no override needed. A list whose name does not follow the `{entities}-list` convention declares `protected string $listEntity = 'item';` (select event and deep-link parameter derive from it) or `protected string $deepLinkParam = 'itemId';` directly
 - **`<x-noerd::list />`:** Renders the table
 - **Object permissions:** Read/write/delete denial via the optional `noerd.object-*` gates (see
   `AccessHelper` in extension-registries.md) hides rows, header actions and the delete bulk action. The permission target is the model resolved
@@ -376,7 +376,28 @@ the YAML hides the row):
 | `refreshList()` | Re-renders the list (`$refresh`). Listens to `refreshList-{component}` (the full name incl. namespace, e.g. `inventory::items-list`) and to the name after the last dot; a detail's `closeModalProcess()` dispatches it for its paired list |
 | `exportCsv()` | Streams the CSV download (see CSV Export) |
 | `componentName()` (protected) | The name the YAML config, session keys and events resolve by — Livewire's component name; override only in unregistered test fixtures |
-| `listConfigComponent()` (protected) | The name the list YAML resolves under — override when a component renders another list's YAML |
+| `listConfigComponent()` (protected) | The name the list YAML resolves under — declare `protected string $listConfigComponent = 'other-list';` when a component renders another list's YAML |
+| `getListEntity()`, `getSelectEvent()`, `getDeepLinkParam()` (protected) | The singular entity (`items-list` → `item`), the picker event (`itemSelected`) and the deep-link parameter (`itemId`), all derived from the component name — configure them with `protected string $listEntity` / `$selectEvent` / `$deepLinkParam` |
+
+The naming hooks (`listConfigComponent()`, `getListEntity()`, `getSelectEvent()`, `getDeepLinkParam()`)
+resolve in a fixed order: a method override wins over the configured property, the property wins
+over the derivation from the component name. Declare the properties `protected` — the trait
+declares none of them itself (a class redeclaring a trait property with another default is a PHP
+fatal), and a public one would be client-writable:
+
+```php
+new class extends Component {
+    use NoerdList;
+
+    public $listModel = Item::class;
+
+    // Renders the YAML of items-list under another component name
+    protected string $listConfigComponent = 'items-list';
+
+    // 'inventory-stock-list' would otherwise derive 'inventoryStock'
+    protected string $listEntity = 'item';
+};
+```
 | `getAllowedListFilterColumns()` (protected) | Whitelist of header `listFilters` keys (see [List Filters](list-filters.md#security)) |
 | `mountList()` / `loadListFilters()` (protected) | Mount-time setup (per-page, filters, view, sort, deep links) — call `mountList()` first in a custom `mount()` |
 

--- a/docs/page-view.md
+++ b/docs/page-view.md
@@ -132,8 +132,11 @@ new class extends Component {
   chrome-less (no header/footer/scroll wrapper), the page owns all chrome.
 - The list refreshed when the page closes is derived from the component name with its namespace
   kept (`inventory::warehouse-page` → `inventory::warehouses-list`; `getListComponent()` strips
-  `-page` and `-detail` alike). A list that does not follow the plural convention overrides
-  `protected function getListComponent(): string` and returns the list's component name.
+  `-page` and `-detail` alike). A list that does not follow the plural convention is declared as
+  `protected string $listComponent = 'inventory::stock-list';` on the page (the trait declares no
+  such property itself — keep it `protected`); overriding `getListComponent()` stays the escape
+  hatch for a dynamic target and wins over the property. The same shape configures the YAML the
+  page's detail resolves under: `protected string $detailConfigComponent` / `getDetailComponent()`.
 - `$detailPrimary` binds `$modelId` (`int|string|null`) to the page's URL parameter
   (`?warehouseId=5`) via the trait's `queryStringNoerdPage()` — never redeclare `$modelId` or add
   a `#[Url]` attribute. The embedded detail may declare the SAME alias (it does, for standalone

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -162,6 +162,7 @@ or `NoerdPage` (and therefore `NoerdDetail`).
 | `objectPermissionModel` | Have the object gates checked against a different class |
 | `detailComponent`, `detailRoute` | Swap the modal target of a row click |
 | `showMoreComponent`, `showMoreRoute` | Swap the "show more" target |
+| `listConfigComponent`, `detailConfigComponent`, `listComponent`, `listEntity`, `selectEvent`, `deepLinkParam`, `showFromDateColumn`, `showUntilDateColumn` | Repoint the naming hooks (which YAML renders, which event/list a save or selection targets) or the columns the ShowFrom/ShowUntil filters write into the query — declared `protected` by convention, vetoed here in case a component makes one public |
 | `listActionMethod` | Redirect the picker callback |
 | `listView`, `listViewApp` | Render another app's list view |
 | `settingsModels` | Repoint which model `persistSettings()` writes and which property it reads |

--- a/docs/traits.md
+++ b/docs/traits.md
@@ -96,7 +96,9 @@ The preview modal is `noerd::email-preview-modal`; the test mail is `Noerd\Mail\
 | `one_year` | One year ago |
 | anything else | Parsed as a date via `resolveCustomDate()` (`null` when unparseable) |
 
-**Customizing the columns** — override the protected hooks (both default to `created_at`):
+**Customizing the columns** — declare the two properties on the component (both default to
+`created_at`). Set BOTH: "Show From" and "Show Until" are independent filters, and a list that
+moves only one of them keeps comparing the other boundary against the import timestamp:
 
 ```php
 use Noerd\Traits\NoerdList;
@@ -106,12 +108,17 @@ new class extends Component {
     use NoerdList;
     use ShowFromFilterTrait;
 
-    protected function getShowFromDateColumn(): string
-    {
-        return 'published_at';
-    }
+    protected string $showFromDateColumn = 'published_at';
+    protected string $showUntilDateColumn = 'published_at';
 };
 ```
+
+The properties must be `protected`: a public property is part of the Livewire client payload, and
+these values are written into the query as raw column names. The trait deliberately declares
+neither property — PHP fatals when a class redeclares a trait property with a different default —
+so the hooks `getShowFromDateColumn()` / `getShowUntilDateColumn()` read them through `??`. The
+methods stay overridable as the escape hatch for a column that is only known at runtime; a method
+override wins over the property.
 
 ## TenantFilterTrait (list components)
 

--- a/src/Support/LockedPropertiesHook.php
+++ b/src/Support/LockedPropertiesHook.php
@@ -38,6 +38,19 @@ final class LockedPropertiesHook extends ComponentHook
         'listViewApp',
         'showMoreComponent',
         'showMoreRoute',
+        // The naming hooks' configuration properties. Declared protected by
+        // convention (then never part of the client payload) — listed here so
+        // a public declaration cannot repoint the YAML source, the select
+        // event, the deep-link parameter, the paired list or the columns the
+        // ShowFrom/ShowUntil filters write into the query either.
+        'listConfigComponent',
+        'detailConfigComponent',
+        'listComponent',
+        'listEntity',
+        'selectEvent',
+        'deepLinkParam',
+        'showFromDateColumn',
+        'showUntilDateColumn',
         // A settings page's model map decides WHICH model persistSettings()
         // writes and WHICH property it reads the payload from — repointing it
         // from the client is an arbitrary-model write.

--- a/src/Traits/NoerdList.php
+++ b/src/Traits/NoerdList.php
@@ -1013,52 +1013,58 @@ trait NoerdList
         }
     }
 
+    /*
+     | The naming hooks below derive their value from the component name and
+     | may be configured per component through a PROTECTED property of the same
+     | name ($listConfigComponent, $selectEvent, $deepLinkParam, $listEntity).
+     | The trait declares none of them — PHP fatals when a class redeclares a
+     | trait property with a different default — so each hook reads the
+     | property through `??` and falls back to the derivation. Overriding the
+     | method itself stays possible for dynamic cases.
+     */
+
     /**
      * The name this list's YAML config resolves under — the component's own
-     * name. Override when a component renders another list's YAML.
+     * name. Configure `protected string $listConfigComponent` when a component
+     * renders another list's YAML.
      */
     protected function listConfigComponent(): string
     {
-        return $this->componentName();
+        return $this->listConfigComponent ?? $this->componentName();
     }
 
     /**
      * Get the event name for select mode.
      * Derives from COMPONENT: 'customers-list' -> 'customerSelected'
      * Strips any Livewire namespace prefix: 'booking-members::customers-list' -> 'customerSelected'
+     * Configure `protected string $selectEvent` to dispatch another name.
      */
     protected function getSelectEvent(): string
     {
-        return Str::camel($this->getListEntity()) . 'Selected';
+        return $this->selectEvent ?? Str::camel($this->getListEntity()) . 'Selected';
     }
 
     /**
      * Get the URL query parameter that deep-links a record of this list.
      * Derives from COMPONENT: 'products-list' -> 'productId'
+     * Configure `protected string $deepLinkParam` for another parameter name.
      */
     protected function getDeepLinkParam(): string
     {
-        return Str::camel($this->getListEntity()) . 'Id';
+        return $this->deepLinkParam ?? Str::camel($this->getListEntity()) . 'Id';
     }
 
     /**
      * Get the singular entity name of this list.
      * Derives from COMPONENT: 'customers-list' -> 'customer'
      * Strips any Livewire namespace prefix: 'booking-members::customers-list' -> 'customer'
+     * Configure `protected string $listEntity` when the list name does not
+     * follow the `{entities}-list` convention — the select event and the deep
+     * link parameter derive from it.
      */
     protected function getListEntity(): string
     {
-        $name = $this->componentName();
-
-        if (str_contains($name, '::')) {
-            $name = Str::afterLast($name, '::');
-        }
-
-        if (str_contains($name, '.')) {
-            $name = Str::afterLast($name, '.');
-        }
-
-        return Str::singular(Str::before($name, '-list'));
+        return $this->listEntity ?? $this->deriveListEntity();
     }
 
     protected function dispatchSelectionEvents(mixed $modelId = null): void
@@ -1714,6 +1720,21 @@ trait NoerdList
         }
 
         return $listeners;
+    }
+
+    private function deriveListEntity(): string
+    {
+        $name = $this->componentName();
+
+        if (str_contains($name, '::')) {
+            $name = Str::afterLast($name, '::');
+        }
+
+        if (str_contains($name, '.')) {
+            $name = Str::afterLast($name, '.');
+        }
+
+        return Str::singular(Str::before($name, '-list'));
     }
 
     /**

--- a/src/Traits/NoerdPage.php
+++ b/src/Traits/NoerdPage.php
@@ -498,37 +498,36 @@ trait NoerdPage
         }
     }
 
+    /*
+     | Both naming hooks below may be configured per component through a
+     | PROTECTED property ($detailConfigComponent, $listComponent). The trait
+     | declares neither — PHP fatals when a class redeclares a trait property
+     | with a different default — so each hook reads the property through `??`
+     | and falls back to the derivation. Overriding the method itself stays
+     | possible for dynamic cases. The property is NOT named $detailComponent:
+     | on lists that name already means "the detail modal a row click opens".
+     */
+
     /**
      * The name this component's detail YAML resolves under — the component's
-     * own name. Override when a component renders another component's YAML.
+     * own name. Configure `protected string $detailConfigComponent` when a
+     * component renders another component's YAML.
      */
     protected function getDetailComponent(): string
     {
-        return $this->componentName();
+        return $this->detailConfigComponent ?? $this->componentName();
     }
 
     /**
      * The list this record belongs to (refreshed when the modal closes), derived
      * from the component name with its namespace kept: 'customer-detail' →
-     * 'customers-list', 'crm::account-page' → 'crm::accounts-list'. Override
-     * when the list name does not follow the plural convention.
+     * 'customers-list', 'crm::account-page' → 'crm::accounts-list'. Configure
+     * `protected string $listComponent` when the list name does not follow the
+     * plural convention.
      */
     protected function getListComponent(): string
     {
-        $name = $this->componentName();
-
-        // If this is already a list component, return as-is
-        if (Str::endsWith($name, '-list')) {
-            return $name;
-        }
-
-        // Extract entity: 'customer-detail' → 'customer', 'account-page' → 'account'
-        $entity = Str::endsWith($name, '-page')
-            ? Str::beforeLast($name, '-page')
-            : Str::before($name, '-detail');
-
-        // Pluralize and add -list: 'customer' → 'customers-list'
-        return Str::plural($entity) . '-list';
+        return $this->listComponent ?? $this->deriveListComponent();
     }
 
     protected function setPreselect(string $key, mixed $value): void
@@ -583,5 +582,23 @@ trait NoerdPage
         }
 
         return $listeners;
+    }
+
+    private function deriveListComponent(): string
+    {
+        $name = $this->componentName();
+
+        // If this is already a list component, return as-is
+        if (Str::endsWith($name, '-list')) {
+            return $name;
+        }
+
+        // Extract entity: 'customer-detail' → 'customer', 'account-page' → 'account'
+        $entity = Str::endsWith($name, '-page')
+            ? Str::beforeLast($name, '-page')
+            : Str::before($name, '-detail');
+
+        // Pluralize and add -list: 'customer' → 'customers-list'
+        return Str::plural($entity) . '-list';
     }
 }

--- a/src/Traits/ShowFromFilterTrait.php
+++ b/src/Traits/ShowFromFilterTrait.php
@@ -7,16 +7,26 @@ namespace Noerd\Traits;
 use Carbon\Carbon;
 use Exception;
 
+/**
+ * The date columns the ShowFrom/ShowUntil filters compare against are
+ * configured on the component as `protected string $showFromDateColumn` /
+ * `protected string $showUntilDateColumn` (both default to `created_at`).
+ * The trait deliberately declares NEITHER property: PHP fatals when a class
+ * redeclares a trait property with a different default, so the hooks read
+ * them through `??`. Override the hook method itself only when the column is
+ * dynamic. Keep the properties protected — a public one would be part of the
+ * Livewire client payload and end up as a raw column name in the query.
+ */
 trait ShowFromFilterTrait
 {
     protected function getShowFromDateColumn(): string
     {
-        return 'created_at';
+        return $this->showFromDateColumn ?? 'created_at';
     }
 
     protected function getShowUntilDateColumn(): string
     {
-        return 'created_at';
+        return $this->showUntilDateColumn ?? 'created_at';
     }
 
     protected function resolveShowDate(string $value): ?string

--- a/tests/Feature/HookPropertiesTest.php
+++ b/tests/Feature/HookPropertiesTest.php
@@ -1,0 +1,373 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Component;
+use Livewire\Livewire;
+use Noerd\Tests\TestCase;
+use Noerd\Traits\NoerdDetail;
+use Noerd\Traits\NoerdList;
+use Noerd\Traits\NoerdPage;
+use Noerd\Traits\ShowFromFilterTrait;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+/*
+ | The naming hooks of the component traits (list config name, select event,
+ | deep-link parameter, list entity, detail config name, paired list, and the
+ | ShowFrom/ShowUntil date columns) resolve in a fixed order: a method override
+ | wins over a configured property, the property wins over the derivation.
+ | The traits declare none of the properties (a class redeclaring a trait
+ | property with another default is a PHP fatal), so every hook must survive
+ | the property being absent.
+ */
+
+function zzInvokeHook(object $component, string $method): mixed
+{
+    $reflection = new ReflectionMethod($component, $method);
+    $reflection->setAccessible(true);
+
+    return $reflection->invoke($component);
+}
+
+function zzListComponent(string $name): Component
+{
+    return new class ($name) extends Component {
+        use NoerdList;
+
+        public function __construct(private readonly string $fixtureName) {}
+
+        public function render(): string
+        {
+            return '<div></div>';
+        }
+
+        protected function componentName(): string
+        {
+            return $this->fixtureName;
+        }
+    };
+}
+
+dataset('list naming hooks', [
+    'listConfigComponent' => ['listConfigComponent', 'listConfigComponent', 'zz-gadgets-list', 'zz-other-list'],
+    'selectEvent' => ['getSelectEvent', 'selectEvent', 'zzGadgetSelected', 'zzPartSelected'],
+    'deepLinkParam' => ['getDeepLinkParam', 'deepLinkParam', 'zzGadgetId', 'zzPartId'],
+    'listEntity' => ['getListEntity', 'listEntity', 'zz-gadget', 'zz-part'],
+]);
+
+it('derives the list naming hooks from the component name without a property', function (string $method, string $property, string $derived): void {
+    $component = zzListComponent('zz-gadgets-list');
+
+    expect(property_exists($component, $property))->toBeFalse()
+        ->and(zzInvokeHook($component, $method))->toBe($derived);
+})->with('list naming hooks');
+
+it('lets a configured property win over the derivation of the list naming hooks', function (string $method, string $property, string $derived, string $configured): void {
+    $component = new class extends Component {
+        use NoerdList;
+
+        protected string $listConfigComponent = 'zz-other-list';
+
+        protected string $selectEvent = 'zzPartSelected';
+
+        protected string $deepLinkParam = 'zzPartId';
+
+        protected string $listEntity = 'zz-part';
+
+        public function render(): string
+        {
+            return '<div></div>';
+        }
+
+        protected function componentName(): string
+        {
+            return 'zz-gadgets-list';
+        }
+    };
+
+    expect(zzInvokeHook($component, $method))->toBe($configured);
+})->with('list naming hooks');
+
+it('lets a method override win over the configured property of the list naming hooks', function (string $method, string $property): void {
+    $component = new class extends Component {
+        use NoerdList;
+
+        protected string $listConfigComponent = 'zz-ignored-list';
+
+        protected string $selectEvent = 'zzIgnoredSelected';
+
+        protected string $deepLinkParam = 'zzIgnoredId';
+
+        protected string $listEntity = 'zz-ignored';
+
+        public function render(): string
+        {
+            return '<div></div>';
+        }
+
+        protected function componentName(): string
+        {
+            return 'zz-gadgets-list';
+        }
+
+        protected function listConfigComponent(): string
+        {
+            return 'zz-method';
+        }
+
+        protected function getSelectEvent(): string
+        {
+            return 'zz-method';
+        }
+
+        protected function getDeepLinkParam(): string
+        {
+            return 'zz-method';
+        }
+
+        protected function getListEntity(): string
+        {
+            return 'zz-method';
+        }
+    };
+
+    expect(zzInvokeHook($component, $method))->toBe('zz-method');
+})->with('list naming hooks');
+
+it('derives the select event and deep-link parameter from a configured list entity', function (): void {
+    $component = new class extends Component {
+        use NoerdList;
+
+        protected string $listEntity = 'zz-widget';
+
+        public function render(): string
+        {
+            return '<div></div>';
+        }
+
+        protected function componentName(): string
+        {
+            return 'zz-gadgets-list';
+        }
+    };
+
+    expect(zzInvokeHook($component, 'getSelectEvent'))->toBe('zzWidgetSelected')
+        ->and(zzInvokeHook($component, 'getDeepLinkParam'))->toBe('zzWidgetId');
+});
+
+dataset('page naming hooks', [
+    'detailConfigComponent' => ['getDetailComponent', 'detailConfigComponent', 'zz-gadget-detail', 'zz-other-detail'],
+    'listComponent' => ['getListComponent', 'listComponent', 'zz-gadgets-list', 'zz-other-list'],
+]);
+
+it('derives the page naming hooks from the component name without a property', function (string $method, string $property, string $derived): void {
+    $component = new class extends Component {
+        use NoerdDetail;
+
+        public function render(): string
+        {
+            return '<div></div>';
+        }
+
+        protected function componentName(): string
+        {
+            return 'zz-gadget-detail';
+        }
+    };
+
+    expect(property_exists($component, $property))->toBeFalse()
+        ->and(zzInvokeHook($component, $method))->toBe($derived);
+})->with('page naming hooks');
+
+it('lets a configured property win over the derivation of the page naming hooks', function (string $method, string $property, string $derived, string $configured): void {
+    $component = new class extends Component {
+        use NoerdPage;
+
+        protected string $detailConfigComponent = 'zz-other-detail';
+
+        protected string $listComponent = 'zz-other-list';
+
+        public function render(): string
+        {
+            return '<div></div>';
+        }
+
+        protected function componentName(): string
+        {
+            return 'zz-gadget-page';
+        }
+    };
+
+    expect(zzInvokeHook($component, $method))->toBe($configured);
+})->with('page naming hooks');
+
+it('lets a method override win over the configured property of the page naming hooks', function (string $method): void {
+    $component = new class extends Component {
+        use NoerdDetail;
+
+        protected string $detailConfigComponent = 'zz-ignored-detail';
+
+        protected string $listComponent = 'zz-ignored-list';
+
+        public function render(): string
+        {
+            return '<div></div>';
+        }
+
+        protected function componentName(): string
+        {
+            return 'zz-gadget-detail';
+        }
+
+        protected function getDetailComponent(): string
+        {
+            return 'zz-method';
+        }
+
+        protected function getListComponent(): string
+        {
+            return 'zz-method';
+        }
+    };
+
+    expect(zzInvokeHook($component, $method))->toBe('zz-method');
+})->with('page naming hooks');
+
+it('refreshes the paired list a page configures when it closes', function (): void {
+    $component = new class extends Component {
+        use NoerdPage;
+
+        protected string $listComponent = 'zz-configured-list';
+
+        public function render(): string
+        {
+            return '<div></div>';
+        }
+
+        public function closePaired(): void
+        {
+            $this->closeModalProcess($this->getListComponent());
+        }
+
+        protected function componentName(): string
+        {
+            return 'zz-gadget-page';
+        }
+    };
+
+    Livewire::test($component)
+        ->call('closePaired')
+        ->assertDispatched('refreshList-zz-configured-list')
+        ->assertNotDispatched('refreshList-zz-gadgets-list');
+});
+
+dataset('show filter columns', [
+    'from' => ['getShowFromDateColumn', 'showFromDateColumn'],
+    'until' => ['getShowUntilDateColumn', 'showUntilDateColumn'],
+]);
+
+it('compares the ShowFrom/ShowUntil filters against created_at without a property', function (string $method, string $property): void {
+    $component = new class extends Component {
+        use NoerdList;
+        use ShowFromFilterTrait;
+
+        public function render(): string
+        {
+            return '<div></div>';
+        }
+    };
+
+    expect(property_exists($component, $property))->toBeFalse()
+        ->and(zzInvokeHook($component, $method))->toBe('created_at');
+})->with('show filter columns');
+
+it('compares the ShowFrom/ShowUntil filters against the configured columns', function (string $method): void {
+    $component = new class extends Component {
+        use NoerdList;
+        use ShowFromFilterTrait;
+
+        protected string $showFromDateColumn = 'valuta_date';
+
+        protected string $showUntilDateColumn = 'valuta_date';
+
+        public function render(): string
+        {
+            return '<div></div>';
+        }
+    };
+
+    expect(zzInvokeHook($component, $method))->toBe('valuta_date');
+})->with('show filter columns');
+
+it('lets a method override win over the configured ShowFrom/ShowUntil columns', function (string $method): void {
+    $component = new class extends Component {
+        use NoerdList;
+        use ShowFromFilterTrait;
+
+        protected string $showFromDateColumn = 'ignored';
+
+        protected string $showUntilDateColumn = 'ignored';
+
+        public function render(): string
+        {
+            return '<div></div>';
+        }
+
+        protected function getShowFromDateColumn(): string
+        {
+            return 'booked_at';
+        }
+
+        protected function getShowUntilDateColumn(): string
+        {
+            return 'booked_at';
+        }
+    };
+
+    expect(zzInvokeHook($component, $method))->toBe('booked_at');
+})->with('show filter columns');
+
+it('writes the configured ShowFrom/ShowUntil columns into the list query', function (): void {
+    $component = new class extends Component {
+        use NoerdList;
+        use ShowFromFilterTrait;
+
+        protected string $showFromDateColumn = 'valuta_date';
+
+        protected string $showUntilDateColumn = 'booked_at';
+
+        public function render(): string
+        {
+            return '<div></div>';
+        }
+
+        public function exposedApplyListFilters(mixed $query): void
+        {
+            $this->applyListFilters($query);
+        }
+    };
+
+    $component->listFilters = ['show_from' => '2026-01-01', 'show_until' => '2026-03-31'];
+    $query = \Noerd\Models\Tenant::query();
+    $component->exposedApplyListFilters($query);
+
+    $wheres = collect($query->getQuery()->wheres)->map(fn(array $where): string => "{$where['column']} {$where['operator']} {$where['value']}");
+
+    expect($wheres->all())->toBe(['valuta_date >= 2026-01-01', 'booked_at <= 2026-03-31']);
+});
+
+it('keeps the naming-hook properties out of the client-writable surface', function (): void {
+    $properties = ['listConfigComponent', 'detailConfigComponent', 'listComponent', 'listEntity', 'selectEvent', 'deepLinkParam', 'showFromDateColumn', 'showUntilDateColumn'];
+
+    $hook = new \Noerd\Support\LockedPropertiesHook();
+    $hook->setComponent(new class {
+        use NoerdList;
+    });
+
+    foreach ($properties as $property) {
+        expect(fn(): mixed => $hook->update($property, $property, 'tampered'))
+            ->toThrow(\Livewire\Features\SupportLockedProperties\CannotUpdateLockedPropertyException::class, $property);
+    }
+});


### PR DESCRIPTION
## Summary

The overridable string hooks of the component traits can now be configured through a **protected property** instead of a method override. The methods stay as the internal accessor and as the escape hatch for dynamic cases — purely additive, no breaking change.

| Trait | Hook | Property | Default (unchanged fallback) |
|---|---|---|---|
| `ShowFromFilterTrait` | `getShowFromDateColumn()` | `$showFromDateColumn` | `created_at` |
| `ShowFromFilterTrait` | `getShowUntilDateColumn()` | `$showUntilDateColumn` | `created_at` |
| `NoerdList` | `listConfigComponent()` | `$listConfigComponent` | `componentName()` |
| `NoerdList` | `getSelectEvent()` | `$selectEvent` | `{entity}Selected` |
| `NoerdList` | `getDeepLinkParam()` | `$deepLinkParam` | `{entity}Id` |
| `NoerdList` | `getListEntity()` | `$listEntity` | derived from the component name |
| `NoerdPage` | `getDetailComponent()` | `$detailConfigComponent` | `componentName()` |
| `NoerdPage` | `getListComponent()` | `$listComponent` | plural derivation |

Resolution order: method override → property → derivation.

## Design notes

- The traits declare **none** of the properties: PHP fatals when a class redeclares a trait property with a different default. Each hook reads the property via `??` (Livewire's `__isset` swallows the missing-property case), the derivations moved into private `derive*()` methods.
- `$detailConfigComponent` instead of `$detailComponent` — on lists that name already means "the detail modal a row click opens" (`listAction()`, resource generator).
- The properties must be `protected`: the ShowFrom/ShowUntil columns flow into `$query->where($column, …)` as raw column names, and public properties are part of the client payload. As defence in depth all eight names were added to `LockedPropertiesHook::PROTECTED_PROPERTIES`, so even a public declaration cannot be updated from the browser.

## Tests

`tests/Feature/HookPropertiesTest.php` covers every hook with the three cases (no property → derivation, property wins, method override wins), proves that the configured columns reach the query and the configured list receives `refreshList-*`, and asserts the locked surface. Full standalone suite: 1388 passed.

## Docs

`traits.md` (ShowFrom/ShowUntil now shows the property form and warns to set both columns), `list-view.md`, `detail-view.md`, `page-view.md`, `permissions.md`.
