### PR TITLE
Bump version to v0.16.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
             "name": "Johannes Brock"
         }
     ],
-    "version": "v0.16.5",
+    "version": "v0.16.6",
     "license": "MIT",
     "require": {
         "php": "^8.3",


### PR DESCRIPTION
Release v0.16.6 — configure the trait naming hooks via protected properties (#125).