### PR TITLE
Drop the intl and mbstring extension notes from the requirements lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ the Demo Customers app into your project (see the Example Application page of th
 
 ## Requirements
 
-- PHP 8.3+ with the `intl` and `mbstring` extensions
+- PHP 8.3+
 - Laravel 12 or 13
 - Livewire 4+
 - Node.js `^20.19 || >=22.12` and npm (for the frontend build)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,8 +15,7 @@ noerd is a Laravel Livewire boilerplate for building admin panels and business a
 
 ## Requirements
 
-- PHP 8.3+ with the `intl` and `mbstring` extensions (`intl` drives every date, number and currency
-  format — see [Currency, Numbers & Dates](formatting.md))
+- PHP 8.3+
 - Laravel 12 or 13
 - Livewire 4+
 - Node.js `^20.19 || >=22.12` and npm (for the frontend build)


### PR DESCRIPTION
Both requirement lists (README and `docs/installation.md`) singled out `intl` and `mbstring`.

- `ext-mbstring` is not a noerd requirement: `laravel/framework` requires it itself, together with ctype, filter, hash, openssl, session and tokenizer — none of which the list mentions.
- `composer.json` already declares `ext-intl` and `ext-mbstring`, so a missing extension aborts `composer require noerd/noerd` with a precise message. The prose prevented nothing Composer does not prevent.
- The parenthesis in `installation.md` was wrong on top of that: dates are formatted through Carbon (`FormatHelper::date/dateTime/time` → `isoFormat('L')`), not through ICU. `intl` is used for numbers and currencies (`Number::currency/format/percentage`, `NumberFormatter`) and for the locale picker labels (`Locale::getDisplayName`).

The requirements list now names only what a reader cannot learn from the Composer run. No code or `composer.json` change.