### PR TITLE
Require list row clicks to open the record by route

### DIFF
--- a/docs/list-view.md
+++ b/docs/list-view.md
@@ -275,6 +275,46 @@ reload reopens the record over the previously visited page. `$detailComponent` s
 fallback — keep both, so a list may reference a detail route owned by an optional module.
 See [Modal System](modal.md#route-modals).
 
+### Row click always opens the record by route
+
+Declaring `$detailRoute` is not optional: every list whose rows open a record opens it by
+route, so the address bar points at the record after the click, the link is shareable and
+a reload brings it back. Never override `listAction()` to open a component modal, a list
+narrowed by the clicked row, or anything else that has no URL.
+
+A record without an editable form — mirrored or read-only data such as a synced Toggl
+client or an import log line — still gets its own `*-detail`:
+
+- the detail YAML marks the fields `readonly: true` and embeds the related rows through
+  `lists:` (the narrowed list the row used to open directly);
+- the component renders no save bar and overrides `store()` / `delete()` as no-ops;
+- the module registers `Route::livewire('{app}/{entity}/{modelId}', 'module::{entity}-detail')`
+  and the list opens it via `$detailRoute` (+ `$detailComponent` as fallback).
+
+```php
+// clients-list.blade.php — the row opens the read-only client, not its time entries
+public ?string $detailRoute = 'toggl-integration.client.detail';
+public $detailComponent = 'toggl-integration::client-detail';
+```
+
+```yaml
+# details/client-detail.yml — the narrowed list moves INTO the record
+title: Toggl Client
+fields:
+  - name: detailData.name
+    label: Name
+    type: text
+    readonly: true
+lists:
+  - title: Time Entries
+    component: toggl-integration::time-entries-list
+    arguments:
+      clientId: $modelId
+```
+
+Component modals opened from a list row are reserved for pickers (`selectAction`, see
+[Multi-Select](#multi-select--bulk-actions)) — a selection is not a URL.
+
 ### Custom Query Logic
 
 When the list needs its own query (eager loads, extra wheres, row transformations),
@@ -355,7 +395,7 @@ the YAML hides the row):
 - **$detailRoute:** Named detail route opened by `listAction()` — rewrites the browser URL to the record (preferred)
 - **$detailComponent:** The detail component opened by `listAction()` when no `$detailRoute` is registered
 - **listData():** Builds the list config; override it for custom queries, always ending in `return $this->buildList($rows);`
-- **listAction(mixed $modelId = null, array $relations = []):** Trait default opens `$detailRoute` (else `$detailComponent`) as a modal with `['modelId' => $modelId, 'relations' => $relations]`; only override it for custom behavior (extra modal arguments, no modal, …)
+- **listAction(mixed $modelId = null, array $relations = []):** Trait default opens `$detailRoute` (else `$detailComponent`) as a modal with `['modelId' => $modelId, 'relations' => $relations]`; only override it to add modal arguments — never to open a component modal or a narrowed list instead of the record (see "Row click always opens the record by route")
 - **buildList():** Generates the list configuration from the YAML
 - **Deep links:** `?{entity}Id=5` opens that record's modal over the list, `?create=1` the create modal. `mountList()` reads them once on mount; the parameter name derives from the component name (`items-list` → `itemId`, via `getDeepLinkParam()`) — no override needed. A list whose name does not follow the `{entities}-list` convention declares `protected string $listEntity = 'item';` (select event and deep-link parameter derive from it) or `protected string $deepLinkParam = 'itemId';` directly
 - **`<x-noerd::list />`:** Renders the table

--- a/docs/modal.md
+++ b/docs/modal.md
@@ -221,9 +221,12 @@ longer hard-code a foreign module's component name.
   they perform one operation and close, they have no identity.
 - **Pickers** — anything opened with `listActionMethod`, `selectMode`, `selectContext`,
   `multiSelect`, `returnsSelection` or `context`. The selection is not a URL.
-- **Filtered lists** — a list narrowed by a parent record (`categoryId`, `folderId`).
-  A route may be used here for decoupling, but the URL is deliberately NOT rewritten
-  (see below).
+- **Filtered lists** — a list narrowed by a parent record (`categoryId`, `folderId`),
+  opened from a relation-box tile, a widget or a detail action. A route may be used here
+  for decoupling, but the URL is deliberately NOT rewritten (see below). A narrowed list
+  is never what a LIST ROW opens: a row click always opens its record by route — a record
+  without an editable form gets a read-only detail that embeds the narrowed list (see
+  [Row click](list-view.md#row-click-always-opens-the-record-by-route)).
 
 Reviewer's test: *paste the resulting URL into a fresh tab — does it show the same
 thing?* Yes → route. No → component.

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -14,9 +14,9 @@ below points into that folder — read the referenced page before building the f
 ### Core Rules
 - When creating new lists/tables, always follow the slim list pattern below (reference: the `noerd:make-resource` stub `src/Commands/stubs/resource/list.blade.stub` and `docs/list-view.md`).
 - List components declare their model as `public $listModel = Model::class;` and their detail target
-  as `public ?string $detailRoute = '{app}.{entity}.detail';` (preferred — opens the record as a
-  route modal and rewrites the URL) plus `public $detailComponent = 'module::x-detail';` as the
-  fallback, at the top of the class. The trait
+  as `public ?string $detailRoute = '{app}.{entity}.detail';` (mandatory for every list whose rows
+  open a record — opens it as a route modal and rewrites the URL) plus
+  `public $detailComponent = 'module::x-detail';` as the fallback, at the top of the class. The trait
   methods (`mount()`, `listAction()`, `listData()`, `renderingNoerdList()`) are always used from `NoerdList` —
   a slim component contains nothing else (reference: `src/Commands/stubs/resource/list.blade.stub`). Only when custom
   query logic is needed, override `listData()` (reference: `docs/list-view.md`, "Custom Query Logic"): build the query
@@ -74,9 +74,17 @@ Example for user: users-list.blade.php (plural) and user-detail.blade.php (singu
   (`/setup/object-manager/{table}`); `relations`/`quickCreate` are chrome.
   **Everything else stays `Noerd::modal()`/`$modal()`:** action dialogs (`*-modal`, `*-confirmation`,
   `*-review`, `*-import`, `*-editor`), pickers (`listActionMethod`, `selectMode`, `selectContext`,
-  `multiSelect`, `returnsSelection`, `context`) and lists narrowed by a parent record. A narrowed
-  list MAY use a route for decoupling, but then with `rewriteUrl: false` — a reload of the plain list
-  route would show the unfiltered list.
+  `multiSelect`, `returnsSelection`, `context`) and lists narrowed by a parent record, opened from
+  a relation-box tile, a widget or a detail action. A narrowed list MAY use a route for decoupling,
+  but then with `rewriteUrl: false` — a reload of the plain list route would show the unfiltered list.
+  **A list row click ALWAYS opens its record by route** — `$detailRoute` + `$detailComponent`, URL
+  rewritten — never override `listAction()` to open a component modal, a narrowed list or anything
+  else without a URL instead. A record that has no editable form (mirrored/read-only data such as a
+  synced Toggl client, an import log line) still gets its own `*-detail`: fields with `readonly: true`,
+  no save bar, `store()`/`delete()` overridden as no-ops, the related rows embedded through `lists:`
+  in the detail YAML, and a `Route::livewire('{app}/{entity}/{modelId}', …)` route the row opens.
+  Reviewer's test for a list: *after the row click, does the address bar point at the record?*
+  No → wrong.
   **Always keep the component key as the fallback** (`route:` + `modalComponent:`, `$detailRoute` +
   `$detailComponent`, `newRoute:` + `newComponent:`): the route wins when registered, the component
   opens when the owning module is not installed. `Noerd::modalFor($route, $component, $args)` is the

--- a/resources/boost/skills/noerd-list-development/SKILL.md
+++ b/resources/boost/skills/noerd-list-development/SKILL.md
@@ -53,6 +53,11 @@ new class extends Component {
 
 - Nothing else goes into a slim component. `mount()`, `listAction()`, `listData()`,
   `renderingNoerdList()` come from the trait.
+- `$detailRoute` is mandatory for every list whose rows open a record: the row click ALWAYS
+  opens the record by route (URL rewritten). Never override `listAction()` to open a component
+  modal or a list narrowed by the clicked row. A record without an editable form (mirrored data)
+  gets a read-only `*-detail` (`readonly: true` fields, no save bar, `store()`/`delete()` no-ops)
+  that embeds the narrowed list through `lists:` — and the row opens THAT route.
 - Default sort: a `defaultSort:` block in the list YAML (`field:` + optional
   `direction: asc|desc`, `desc` when omitted) — both synced copies, never component code. A
   user-picked sort persists in the session and wins; never set `$sortField`/`$sortAsc` directly.
@@ -112,6 +117,6 @@ Checklist of optional YAML features (all generic, never re-implement in the comp
 
 - [ ] component is slim (or the `listData()` override ends in `buildList()`)
 - [ ] YAML exists in both locations and is block style
-- [ ] row click opens the detail (route with component fallback)
+- [ ] row click opens the record by route (URL rewritten) with component fallback — no `listAction()` override opening something without a URL
 - [ ] navigation + routes + `de.json` updated
 - [ ] Pest test added and green, `vendor/bin/pint --dirty` run

--- a/resources/boost/skills/noerd-modal-development/SKILL.md
+++ b/resources/boost/skills/noerd-modal-development/SKILL.md
@@ -21,7 +21,8 @@ Ask: *paste the resulting URL into a fresh tab — does it show the same thing?*
 |---|---|
 | ONE addressable record (`*-detail`, `*-page`, or a list that IS a record, e.g. an object manager) | action dialogs (`*-modal`, `*-confirmation`, `*-review`, `*-import`, `*-editor`) |
 | `Noerd::modalRoute('{app}.{entity}.detail', ['modelId' => $id])` / `$modalRoute(...)` | `Noerd::modal('{module}::{component}', ['key' => $value])` / `$modal(...)` |
-| URL rewritten to the record `+ ?modal=true`, restored on close, reload reopens the modal | pickers (`multiSelect`, `returnsSelection`, `context`, `selectMode`, …) and lists narrowed by a parent record (route allowed with `rewriteUrl: false`) |
+| URL rewritten to the record `+ ?modal=true`, restored on close, reload reopens the modal | pickers (`multiSelect`, `returnsSelection`, `context`, `selectMode`, …) and lists narrowed by a parent record opened from a tile, widget or action (route allowed with `rewriteUrl: false`) |
+| A LIST ROW always opens its record this way — a record without an editable form gets a read-only `*-detail` that embeds the narrowed list (`lists:`) | never what a list row click opens |
 | Requirements: target uses `NoerdDetail`/`NoerdPage` (or `NoerdList` for record-lists), a named `Route::livewire('{app}/{entity}/{modelId}', …)` exists, every identity argument is a route parameter | |
 
 **Always keep the component as fallback** — `Noerd::modalFor($route, $component, $args)` in PHP;


### PR DESCRIPTION
## Summary

- A list row click now ALWAYS opens its record by route (`$detailRoute` + `$detailComponent`, URL rewritten). Overriding `listAction()` to open a component modal or a list narrowed by the clicked row is no longer allowed.
- A record without an editable form (mirrored/read-only data such as a synced Toggl client) gets its own read-only `*-detail` (`readonly: true` fields, no save bar, `store()`/`delete()` as no-ops) that embeds the narrowed list through `lists:` in the detail YAML, plus a `{app}/{entity}/{modelId}` route the row opens.
- Narrowed lists opened as component modals remain valid only from relation-box tiles, widgets and detail actions.

Updated: Boost guideline (`core.blade.php`), `docs/list-view.md` (new section "Row click always opens the record by route"), `docs/modal.md`, and the `noerd-list-development` / `noerd-modal-development` skills.

Trigger: the Toggl clients list opened the client's time entries as a component modal, so the URL never changed. The module fix ships separately in `noerd-dev/toggl-integration`.

## Test plan

- Documentation-only change, no code touched.
- Hosts pick the new text up with `php artisan boost:update`.