### PR TITLE
Scope the component access guard to the registering module's namespace

### DIFF
--- a/docs/extension-registries.md
+++ b/docs/extension-registries.md
@@ -319,10 +319,15 @@ public function boot(): void
 
 **Important:**
 
-- Matching ignores the namespace prefix and collapses every spelling Livewire resolves to the same
-  component (`noerd::tenants-list`, `tenants-list`, `.tenants-list`). Consequence: a host component
-  whose bare name collides with a registered one becomes admin-only too — the deliberate
-  fail-closed choice
+- Matching is namespace-aware and collapses every spelling Livewire resolves to the same component
+  within that namespace (`cms::settings-page`, `CMS::.Settings-Page`). Registering one module's
+  screen therefore never locks down a same-named screen of another module — `cms::settings-page`
+  and `hr::settings-page` are different components
+- A name written WITHOUT a namespace matches a registered entry by its bare name alone
+  (`tenants-list`, `.tenants-list`): it cannot be attributed to a module, and the core registers its
+  own screens under a bare component location as well (`Livewire::addLocation`). Consequence: a host
+  component mounted bare under a name that collides with a registered one becomes admin-only too —
+  the deliberate fail-closed choice
 - The guard only closes the admin bypass at the dynamic-mount seams; components that are not on the
   list are still governed by their own route middleware and the object gates
   (see [permissions.md](permissions.md))

--- a/src/Support/ComponentAccessGuard.php
+++ b/src/Support/ComponentAccessGuard.php
@@ -67,6 +67,17 @@ final class ComponentAccessGuard
     }
 
     /**
+     * Drop every module-contributed entry. The allow-list is process-global and
+     * survives an application boot, so a test process that boots several
+     * applications has to reset it — the providers of the new app register
+     * their own screens again.
+     */
+    public static function flushRegisteredComponents(): void
+    {
+        self::$registered = [];
+    }
+
+    /**
      * Abort with 403 when the current user may not mount the given component.
      */
     public static function authorize(?string $componentName): void
@@ -82,14 +93,14 @@ final class ComponentAccessGuard
      * own route middleware / object gates; this guard only closes the admin
      * bypass at the dynamic-mount seams.
      *
-     * Matching ignores the namespace prefix: noerd registers its components with
-     * BOTH a namespace and a bare location (Livewire::addLocation), so
-     * `noerd::tenants-list` and `tenants-list` mount the very same admin screen —
-     * comparing the full name alone let the bare alias walk straight past this
-     * guard. Consequence to be aware of: a host or module component whose bare
-     * name matches one of these becomes admin-only too. That is the deliberate
-     * fail-closed choice — such a component already collides with noerd's own
-     * registration.
+     * Matching is namespace-aware, with ONE deliberate exception: a name written
+     * WITHOUT a namespace matches an admin entry by its bare name alone. That
+     * exception is what keeps the guard closed for noerd's own screens, which
+     * are registered both namespaced and bare (Livewire::addLocation), so
+     * `noerd::tenants-list` and `tenants-list` mount the very same component.
+     * The namespace of a namespaced name is never dropped, though: modules
+     * register their screens under their own namespace only, so `cms::settings-page`
+     * being admin-only must not lock down `hr::settings-page` as well.
      */
     public static function allows(?string $componentName): bool
     {
@@ -97,36 +108,56 @@ final class ComponentAccessGuard
             return true;
         }
 
-        $restricted = array_map(
-            static fn(string $name): string => self::normalize($name),
-            array_merge(self::ADMIN_COMPONENTS, self::$registered),
-        );
+        $candidateNamespace = self::namespaceOf($componentName);
+        $candidateName = self::normalizeName($componentName);
 
-        if (in_array(self::normalize($componentName), $restricted, true)) {
-            return (bool) NoerdAuth::user()?->isAdmin();
+        foreach (array_merge(self::ADMIN_COMPONENTS, self::$registered) as $restricted) {
+            if (self::normalizeName($restricted) !== $candidateName) {
+                continue;
+            }
+
+            if ($candidateNamespace === null || $candidateNamespace === self::namespaceOf($restricted)) {
+                return (bool) NoerdAuth::user()?->isAdmin();
+            }
         }
 
         return true;
     }
 
     /**
-     * The comparable identity of a component name — it must collapse EVERY
-     * spelling Livewire resolves to the same component file, or the guard is
+     * The Livewire namespace of a component name, or null when it carries none
+     * (a bare component location). Lowercased so `NOERD::x` and `noerd::x`
+     * compare equal; an empty prefix (`::x`) counts as no namespace, which
+     * matches bare entries and therefore stays fail-closed.
+     */
+    private static function namespaceOf(string $componentName): ?string
+    {
+        $name = self::stripMarker($componentName);
+
+        if (! str_contains($name, '::')) {
+            return null;
+        }
+
+        $namespace = mb_trim(Str::beforeLast($name, '::'));
+
+        return $namespace === '' ? null : mb_strtolower($namespace);
+    }
+
+    /**
+     * The comparable identity of the name behind the namespace — it must collapse
+     * EVERY spelling Livewire resolves to the same component file, or the guard is
      * bypassable by writing the name differently.
      *
      * Livewire's Finder strips the ⚡ marker and rewrites '/' to '.'
      * (Finder::normalizeName), then builds the view path from the dot segments,
      * where empty segments simply vanish — so 'x', '.x', '..x' and '/x' all
-     * load the same component. The namespace is dropped as well, because noerd
-     * registers its components both namespaced and bare (Livewire::addLocation).
+     * load the same component.
      */
-    private static function normalize(string $componentName): string
+    private static function normalizeName(string $componentName): string
     {
-        $name = Str::afterLast($componentName, '::');
+        $name = Str::afterLast(self::stripMarker($componentName), '::');
 
-        // Mirror Finder::normalizeName(): drop the ⚡ marker (with either
-        // variation selector) and treat slashes as dot separators.
-        $name = preg_replace('/\x{26A1}[\x{FE0E}\x{FE0F}]?/u', '', $name) ?? $name;
+        // Mirror Finder::normalizeName(): treat slashes as dot separators.
         $name = str_replace(['/', '\\'], '.', $name);
 
         // Empty segments carry no meaning for the resolver — dropping them is
@@ -137,5 +168,14 @@ final class ComponentAccessGuard
         ));
 
         return mb_strtolower(implode('.', $segments));
+    }
+
+    /**
+     * Drop the ⚡ marker (with either variation selector) Livewire allows in
+     * front of a component name.
+     */
+    private static function stripMarker(string $componentName): string
+    {
+        return preg_replace('/\x{26A1}[\x{FE0E}\x{FE0F}]?/u', '', $componentName) ?? $componentName;
     }
 }

--- a/tests/Feature/DynamicMountTest.php
+++ b/tests/Feature/DynamicMountTest.php
@@ -312,6 +312,30 @@ describe('component access guard', function (): void {
 
         expect(ComponentAccessGuard::allows('plus::user-role-detail'))->toBeFalse();
     });
+
+    it('keeps a module registration inside its own namespace', function (): void {
+        // Several modules ship a component of the same name — every module that
+        // has a settings screen calls it `settings-page`. Registering one of
+        // them as admin-only must not lock down the others; only the namespace
+        // makes them different components.
+        ComponentAccessGuard::registerAdminComponents(['cms::settings-page']);
+
+        expect(ComponentAccessGuard::allows('cms::settings-page'))->toBeFalse()
+            ->and(ComponentAccessGuard::allows('CMS::.Settings-Page'))->toBeFalse()
+            ->and(ComponentAccessGuard::allows('hr::settings-page'))->toBeTrue()
+            ->and(ComponentAccessGuard::allows('accounting::.settings-page'))->toBeTrue();
+    });
+
+    it('stays fail-closed for a bare name that matches an admin component', function (): void {
+        // A name written without a namespace cannot be attributed to a module,
+        // and noerd registers its own screens under a bare location as well —
+        // so the bare spelling keeps matching every admin entry by name alone.
+        ComponentAccessGuard::registerAdminComponents(['cms::settings-page']);
+
+        expect(ComponentAccessGuard::allows('settings-page'))->toBeFalse()
+            ->and(ComponentAccessGuard::allows('::settings-page'))->toBeFalse()
+            ->and(ComponentAccessGuard::allows('tenants-list'))->toBeFalse();
+    });
 });
 
 describe('audit list target validation', function (): void {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,6 +13,7 @@ use Livewire\Livewire;
 use Livewire\LivewireServiceProvider;
 use Noerd\Models\NoerdUser;
 use Noerd\Providers\NoerdServiceProvider;
+use Noerd\Support\ComponentAccessGuard;
 use NoerdModal\Providers\NoerdModalServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 use PDO;
@@ -56,6 +57,7 @@ abstract class TestCase extends BaseTestCase
     {
         self::flushGuardableColumnsCache();
         self::flushLivewireComponentHooks();
+        self::flushRegisteredAdminComponents();
         $this->swapInTestbenchRefreshDatabaseState();
 
         try {
@@ -182,6 +184,18 @@ abstract class TestCase extends BaseTestCase
         Closure::bind(static function (): void {
             ComponentHookRegistry::$componentHooks = [];
         }, null, ComponentHookRegistry::class)();
+    }
+
+    /**
+     * The admin allow-list modules contribute through
+     * ComponentAccessGuard::registerAdminComponents() is process-global too, so
+     * a host suite that ran earlier leaks the registrations of packages this
+     * testbench app never boots. Flushed before the app is created; the
+     * providers this app does boot register their own again.
+     */
+    private static function flushRegisteredAdminComponents(): void
+    {
+        ComponentAccessGuard::flushRegisteredComponents();
     }
 
     private function swapInTestbenchRefreshDatabaseState(): void


### PR DESCRIPTION
`ComponentAccessGuard` compared component names by their bare name only, dropping the
Livewire namespace. Every module that ships a `settings-page` therefore became admin-only
as soon as one of them registered its own — `cms::settings-page` locked down
`hr::settings-page` and `accounting::settings-page` too.

Matching is now namespace-aware, with one deliberate exception: a name written WITHOUT a
namespace still matches an admin entry by its bare name alone. That keeps the guard closed
for noerd's own screens, which are registered both namespaced and bare
(`Livewire::addLocation`), so `noerd::tenants-list` and `tenants-list` mount the same
component.

Also adds `ComponentAccessGuard::flushRegisteredComponents()` and calls it from the
testbench `TestCase`: the allow-list is process-global and survives an application boot, so
a host suite that ran earlier leaked registrations of packages the testbench app never
boots.

Docs (`docs/extension-registries.md`) and the tests in `DynamicMountTest` cover both
behaviours.
