### PR TITLE
Mark prefilled fields with a highlight ring and their previous value

### DIFF
--- a/docs/detail-view.md
+++ b/docs/detail-view.md
@@ -172,6 +172,51 @@ expression for reactive visibility on top of the tab switch:
 | `tab` | Tab number (defaults to 1) |
 | `theme` | Per-field theme override (see [Themes](themes.md)) |
 | `number` | Explicit row number in the `numbered` theme (defaults to auto-increment) |
+| `highlight` | Render the field with a highlight ring (see [Highlighted Fields](#highlighted-fields)); normally stamped at runtime, not written in YAML |
+| `previousValue` | Render `was: …` under the field (see [Highlighted Fields](#highlighted-fields)) |
+
+## Highlighted Fields
+
+A form can mark individual fields as carrying a value the reader did not enter themselves — a
+proposal from an AI agent, a value copied from another record. Two optional field keys drive it:
+
+| Key | Effect |
+|-----|--------|
+| `highlight` | Renders the field with a ring and a tooltip on the label ("This value was proposed for you") |
+| `previousValue` | Renders `was: …` under the field — what it held before the proposal replaced it |
+
+Both are normally **stamped onto the layout at runtime** rather than written into the YAML: a
+component that renders a proposal walks its `$pageLayout` with `Noerd\Support\LayoutFields::map()`
+and sets the keys on the fields it filled.
+
+```php
+$this->pageLayout['fields'] = LayoutFields::map(
+    $this->pageLayout['fields'],
+    function (array $field) use ($proposed): array {
+        $key = Str::after((string) ($field['name'] ?? ''), 'detailData.');
+
+        if (array_key_exists($key, $proposed)) {
+            $field['highlight'] = true;
+        }
+
+        return $field;
+    },
+);
+```
+
+The ring is drawn on the field wrapper in `noerd::components.detail.block`, so it works for every
+field type in every theme without an element template of its own; the label marker reads the flag
+out of `FieldContext`, exactly like `helpText`.
+
+**Rendering another component's form.** A component may render a FOREIGN detail YAML — that is what
+makes a generic review screen possible: load it with
+`StaticConfigHelper::getComponentFields('accounting::expense-detail', Expense::class)` and bind the
+values into your own `$detailData`. The layout resolves by component name regardless of the session
+app (see `componentOwnerApp()`), and `validateFromLayout()` picks up its `required:` fields. Two
+things do NOT come along, because they live in the original component's PHP rather than its YAML:
+a `picklistField:` naming a method on that component renders empty (put such providers in the
+`PicklistRegistry` when a generic host has to render them), and its `#[On('...Selected')]` side
+effects do not run.
 
 ## Relation Forms
 

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -1079,6 +1079,38 @@ declared in the YAML and applied generically by `NoerdDetail::applyLayoutDefault
 ```
 - Reference: `docs/field-types.md` ("Default Values")
 
+### A Form May Render ANOTHER Component's Detail YAML
+
+A screen that shows a record's form without being that record's detail — a review screen for an AI
+proposal, a preview, a wizard step — renders the TARGET's detail YAML instead of duplicating it, and
+NEVER by changing the target component:
+
+```php
+$this->pageLayout = StaticConfigHelper::getComponentFields('accounting::expense-detail', Expense::class);
+```
+
+- The layout resolves by component name from any app (`componentOwnerApp()` searches the owning
+  module last but unconditionally), so a screen in one module can render another module's form.
+- `validateFromLayout()` reads `$pageLayout`, so the target's `required:` fields validate as usual.
+- Relation fields work: they are mounted with the HOST's Livewire id and write back through
+  `setFieldValue` into `detailData.*` — the host only has to use `NoerdDetail`.
+- Override `canReadObject()`/`canCreateObject()`/`canWriteObject()`/`canDeleteObject()` to gate on
+  the TARGET model. `objectPermissionModel` is a list-only property; details have no equivalent.
+- What does NOT come along, because it lives in the target's PHP and not in its YAML: a
+  `picklistField:`/`optionsMethod:` naming a method on that component (renders empty — such providers
+  belong in the `PicklistRegistry`), its `#[On('...Selected')]` side effects, and any value
+  formatting its own `mount()`/`store()` performs. A host that renders money fields must convert the
+  reader's notation back itself.
+
+### Mark Values the Reader Did Not Enter
+
+A field holding a proposed value gets the layout key `highlight: true` (ring + label tooltip) and
+optionally `previousValue` (renders `was: …` underneath). Both are stamped onto `$pageLayout` at
+runtime with `Noerd\Support\LayoutFields::map()` — never written into the shipped YAML, and never
+rebuilt per module: the ring lives once in `noerd::components.detail.block`.
+
+- Reference: `docs/detail-view.md` ("Highlighted Fields")
+
 ### Empty Spacer Columns in Detail/Block Layouts
 Fields in a detail/block layout flow into a 12-column grid via auto-placement, so removing a field makes
 the following field move up into the freed slot. To keep a deliberate empty column (e.g. leave the right

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -299,6 +299,7 @@
     "The file must be one of the following formats: :values": "Die Datei muss eines der folgenden Formate haben: :values",
     "The required configuration file was not found:": "Die erforderliche Konfigurationsdatei wurde nicht gefunden:",
     "This field is translatable. The value belongs to the language selected in the language switcher.": "Dieses Feld ist übersetzbar. Der Wert gehört zu der Sprache, die oben im Sprachumschalter gewählt ist.",
+    "This value was proposed for you. Check it before saving.": "Dieser Wert wurde vorgeschlagen. Vor dem Speichern prüfen.",
     "This is how the email will be displayed with sample data": "So wird die E-Mail mit Beispieldaten angezeigt",
     "This language is set as the default language and cannot be deleted.": "Diese Sprache ist als Standardsprache festgelegt und kann nicht gelöscht werden.",
     "This Month": "Diesen Monat",
@@ -343,5 +344,6 @@
     "You currently have no access to tenants.": "Sie haben derzeit keinen Zugriff auf Mandanten.",
     "You do not have permission to view this area.": "Sie haben keine Berechtigung, diesen Bereich anzuzeigen.",
     "Your email address is unverified.": "Ihre E-Mail-Adresse ist nicht verifiziert.",
-    "Zip Code": "PLZ"
+    "Zip Code": "PLZ",
+    "was: :value": "vorher: :value"
 }

--- a/resources/views/components/detail/block.blade.php
+++ b/resources/views/components/detail/block.blade.php
@@ -93,11 +93,20 @@
                         $field['readonly'] = true;
                     }
 
+                    // The `highlight` field key marks a value the reader did not enter
+                    // themselves (a prefilled proposal). The ring sits on the field
+                    // wrapper, so it works for every field type in every theme —
+                    // element templates build their own control classes and share no
+                    // partial to hook into.
+                    $highlightClasses = ($field['highlight'] ?? false)
+                        ? ' rounded-lg p-2 -m-2 ring-2 ring-amber-400/70'
+                        : '';
+
                     // Set unconditionally so optional keys (helpText) never leak into
                     // the next field; cleared again after the loop.
                     \Noerd\Support\FieldContext::set($field);
                 @endphp
-                <div class="{{ $fieldThemeDefinition->fullWidthRows ? 'col-span-full' : 'col-span-1 sm:col-span-' . ($field['colspan'] ?? '3') }}" {!! $getShowIfDirective($field) !!}>
+                <div class="{{ $fieldThemeDefinition->fullWidthRows ? 'col-span-full' : 'col-span-1 sm:col-span-' . ($field['colspan'] ?? '3') }}{{ $highlightClasses }}" {!! $getShowIfDirective($field) !!}>
                     @php
                         $fieldTypeDefinition = $fieldTypeRegistry->resolve($field['type'] ?? '');
                         $resolvedRendererProps = $fieldTypeDefinition?->resolveProps(
@@ -175,6 +184,16 @@
                         @else
                             @include(\Noerd\Support\ThemeElementResolver::resolveFallbackInput($fieldTheme), ['field' => $field])
                         @endif
+                    @endif
+
+                    {{-- What the field held before a proposal replaced it, so the
+                         reader can weigh the suggestion against the current value.
+                         Rendered inside the wrapper, under whatever control the
+                         theme drew. --}}
+                    @if (array_key_exists('previousValue', $field))
+                        <p class="mt-1 text-xs text-gray-500">
+                            {{ __('was: :value', ['value' => ($field['previousValue'] ?? '') === '' || $field['previousValue'] === null ? '—' : $field['previousValue']]) }}
+                        </p>
                     @endif
                 </div>
             @endif

--- a/resources/views/components/input-label.blade.php
+++ b/resources/views/components/input-label.blade.php
@@ -2,12 +2,14 @@
      from FieldContext (set per field by noerd::components.detail.block), so element
      templates need not forward it; pass the prop explicitly where there is no block
      context, e.g. the relation-field Livewire views. The same applies to
-     `translatable`, which marks a field holding one value per language. --}}
-@props(['value' => null, 'required' => false, 'helpText' => null, 'translatable' => null])
+     `translatable`, which marks a field holding one value per language, and to
+     `highlighted`, which marks a prefilled value the reader did not enter. --}}
+@props(['value' => null, 'required' => false, 'helpText' => null, 'translatable' => null, 'highlighted' => null])
 
 @php
     $resolvedHelpText = $helpText ?: \Noerd\Support\FieldContext::helpText();
     $resolvedTranslatable = $translatable ?? \Noerd\Support\FieldContext::isTranslatable();
+    $resolvedHighlighted = $highlighted ?? \Noerd\Support\FieldContext::isHighlighted();
 @endphp
 
 <label {{ $attributes->merge(['class' => 'block font-semibold text-sm leading-6 text-gray-700 pb-2']) }}>
@@ -23,6 +25,13 @@
             icon="language"
             iconClass="text-sky-500 hover:text-sky-700"
             :text="__('This field is translatable. The value belongs to the language selected in the language switcher.')"
+        />
+    @endif
+    @if ($resolvedHighlighted)
+        <x-noerd::help-tooltip
+            icon="sparkles"
+            iconClass="text-amber-500 hover:text-amber-600"
+            :text="__('This value was proposed for you. Check it before saving.')"
         />
     @endif
 </label>

--- a/src/Support/FieldContext.php
+++ b/src/Support/FieldContext.php
@@ -51,6 +51,16 @@ final class FieldContext
         return is_string($type) && str_starts_with($type, 'translatable');
     }
 
+    /**
+     * Whether the field currently being rendered holds a prefilled value the
+     * reader did not enter themselves (see NoerdDetail::$prefill). Read by
+     * `x-noerd::input-label`, so the marker needs no element template of its own.
+     */
+    public static function isHighlighted(): bool
+    {
+        return (bool) (self::$current['highlight'] ?? false);
+    }
+
     public static function clear(): void
     {
         self::$current = null;

--- a/src/Support/LayoutFields.php
+++ b/src/Support/LayoutFields.php
@@ -42,4 +42,32 @@ final class LayoutFields
 
         return true;
     }
+
+    /**
+     * Rewrite every non-block field, depth-first through nested `type: block`
+     * groups, and return the new field list. The counterpart of walk() for
+     * features that decorate the layout instead of reading from it.
+     *
+     * @param  array<int, array<string, mixed>>  $fields
+     * @param  callable(array<string, mixed>): array<string, mixed>  $mapper
+     * @return array<int, array<string, mixed>>
+     */
+    public static function map(array $fields, callable $mapper): array
+    {
+        foreach ($fields as $index => $field) {
+            if (! is_array($field)) {
+                continue;
+            }
+
+            if (($field['type'] ?? null) === 'block') {
+                $fields[$index]['fields'] = self::map($field['fields'] ?? [], $mapper);
+
+                continue;
+            }
+
+            $fields[$index] = $mapper($field);
+        }
+
+        return $fields;
+    }
 }

--- a/tests/Feature/DetailHighlightTest.php
+++ b/tests/Feature/DetailHighlightTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Noerd\Models\NoerdUser;
+use Noerd\Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->actingAs(NoerdUser::factory()->adminUser()->withSelectedApp('setup')->create());
+});
+
+it('rings the fields marked highlight and leaves the others plain', function (): void {
+    $html = Livewire::test('noerd-test::highlight-test')->assertSuccessful()->html();
+
+    // Two of the three fields are marked — the nested block is walked too.
+    expect(mb_substr_count($html, 'ring-amber-400/70'))->toBe(2);
+});
+
+it('marks the label of a highlighted field', function (): void {
+    Livewire::test('noerd-test::highlight-test')
+        ->assertSee(__('This value was proposed for you. Check it before saving.'));
+});
+
+it('shows what the field held before, only where a previous value was recorded', function (): void {
+    Livewire::test('noerd-test::highlight-test')
+        ->assertDontSee(__('was: :value', ['value' => 'the old value']));
+
+    Livewire::test('noerd-test::highlight-test', ['withPrevious' => true])
+        ->assertSee(__('was: :value', ['value' => 'the old value']));
+});
+
+it('rings the field in every theme, not just the default one', function (): void {
+    foreach (['default', 'compact', 'numbered'] as $theme) {
+        $html = Livewire::test('noerd-test::highlight-test', ['theme' => $theme])->html();
+
+        expect(mb_substr_count($html, 'ring-amber-400/70'))->toBe(2, "theme {$theme}");
+    }
+});

--- a/tests/Feature/fixtures/components/highlight-test.blade.php
+++ b/tests/Feature/fixtures/components/highlight-test.blade.php
@@ -1,0 +1,33 @@
+<?php
+
+use Livewire\Component;
+
+/**
+ * Test-only component (DetailHighlightTest): renders a synthetic layout through
+ * the real detail block, so the highlight ring and the "was: …" line can be
+ * proven without asserting any shipped YAML configuration.
+ */
+new class extends Component {
+    public array $model = ['plain' => 'a', 'proposed' => 'b', 'changed' => 'c'];
+
+    public bool $withPrevious = false;
+
+    public string $theme = 'default';
+}; ?>
+
+<div>
+    @include('noerd::components.detail.block', [
+        'theme' => $theme,
+        'detailData' => $model,
+        'fields' => [
+            ['name' => 'model.plain', 'label' => 'Plain', 'type' => 'text', 'colspan' => 6],
+            ['name' => 'model.proposed', 'label' => 'Proposed', 'type' => 'text', 'colspan' => 6, 'highlight' => true],
+            ['type' => 'block', 'title' => 'Nested', 'colspan' => 12, 'fields' => [
+                array_merge(
+                    ['name' => 'model.changed', 'label' => 'Changed', 'type' => 'textarea', 'colspan' => 12, 'highlight' => true],
+                    $withPrevious ? ['previousValue' => 'the old value'] : [],
+                ),
+            ]],
+        ],
+    ])
+</div>


### PR DESCRIPTION
A form can now mark individual fields as carrying a value the reader did not enter themselves — an
AI proposal, a value copied from another record — so a proposal is visibly a proposal instead of
looking like saved data.

Two optional layout keys drive it:

- `highlight: true` — draws a ring around the field and a sparkles tooltip on its label
  ("This value was proposed for you. Check it before saving.")
- `previousValue` — renders `was: …` under the field, so the reader can weigh the suggestion
  against what the field held before

Both are meant to be stamped onto `$pageLayout` at runtime, not written into shipped YAML; the new
`LayoutFields::map()` walks a layout depth-first through nested `type: block` groups and returns the
rewritten field list, the counterpart of the existing `walk()`.

The ring is drawn on the field wrapper in `noerd::components.detail.block`, so it applies to every
field type in every theme without an element template of its own, and the label marker reads the
flag out of `FieldContext` exactly like `helpText` does.

Docs: `docs/detail-view.md` gains a "Highlighted Fields" section (plus the two field keys in the
field-property table) and a note on rendering another component's detail YAML; the Boost guideline
gains the matching rules.

`DetailHighlightTest` proves the mechanics against a synthetic layout in a test-only component —
the ring count including the nested block, the label marker, the conditional `was: …` line, and
that all three built-in themes ring the field.
