### PR TITLE
Register the package in the host boost.json from the install and update commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,11 +24,16 @@ and are NOT repeated here. Read that guideline first; it applies to code in this
 
 ## Workflow
 
-- **Never commit or push directly to `main`.** Create a feature branch, push it and open a GitHub
-  pull request against `main`. The only exception is the release version bump described below.
+- **Never commit or push directly to `main`** — the branch is protected on GitHub, a direct push
+  is rejected. Create a feature branch, push it and open a GitHub pull request against `main`;
+  squash-merge once the required checks are green.
 - **Release:** tagging a version requires the `composer.json` `"version"` field to equal the tag in
-  the tagged commit (`Bump version to vX.Y.Z`). That bump may be committed to `main` as part of the
-  tag flow.
+  the tagged commit. The bump is a PR like any other (`Bump version to vX.Y.Z`); tag the merged
+  commit, then publish the GitHub release with `### Added / Fixed / Changed / Docs` sections.
+- **Composer constraints:** when a framework constraint is tightened or loosened, check every
+  package of the ecosystem that depends on it (`noerd/modal`, the modules) — Composer silently
+  falls back to the newest tag that still satisfies the host, so an open range like `^0.3` keeps
+  resolving to an old version without any error. Raise the minimum along with the change.
 - **A pushed tag is immutable — never move it.** Packagist indexes a version once and keeps the
   commit it saw first, so re-pointing an existing tag keeps shipping the old code while the
   repository looks correct. Consumers see no reason to update, because the version number did not

--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -19,17 +19,25 @@ registration is involved.
 
 ## Enabling it in a project
 
-1. Install Boost: `composer require laravel/boost --dev` and run `php artisan boost:install`.
-   Boost lists `noerd/noerd` under the discovered third-party packages; select it (guideline and
-   skills).
-2. Alternatively edit `boost.json` by hand (`packages` lists the third-party packages whose guidelines and skills are installed; `skills` is filled by Boost with the installed skill names) and re-run the update:
+1. Install Boost: `composer require laravel/boost --dev` and run `php artisan boost:install` (it
+   writes `boost.json`; `noerd/noerd` may already be selected under the discovered third-party
+   packages).
+2. Run `php artisan noerd:install` (first installation) or `php artisan noerd:update` (after every
+   noerd upgrade). Both **register the package automatically**: `noerd/noerd` is added to the
+   `packages` array of `boost.json`, the shipped skill names to `skills`, and `php artisan
+   boost:update` is run so the rendered rules follow the installed version. The same happens for
+   every module through its `noerd:install-{module}` / `noerd:update-{module}` command (and thus
+   `noerd:update-all`) — the step is idempotent and never removes an entry.
+
+Without a `boost.json` the commands only print a hint — Boost stays optional. A package without an
+install command (e.g. `noerd/modal`) is registered by hand:
 
 ```json
 {
     "agents": ["claude_code"],
     "editors": ["claude_code"],
     "guidelines": true,
-    "packages": ["noerd/noerd"],
+    "packages": ["noerd/noerd", "noerd/modal"],
     "skills": []
 }
 ```
@@ -40,8 +48,12 @@ php artisan boost:update
 
 Boost writes the `=== noerd/noerd/core rules ===` block into `CLAUDE.md` (inside the
 `<laravel-boost-guidelines>` markers), `.cursor/rules/laravel-boost.mdc`, `.junie/guidelines.md`, …
-and copies the skills to `.claude/skills/noerd-*`. Re-run `php artisan boost:update`
-after every noerd upgrade so the rendered rules follow the installed version.
+and copies the skills to `.claude/skills/noerd-*`.
+
+Boost rewrites `packages` as "configured ∩ discovered" on every run, so a package is only kept
+while it is installed under `vendor/`; and it removes every tracked skill it cannot discover under
+`resources/boost/skills/` — never list a module's top-level `skills/` folder (published by noerd
+itself) in `boost.json`.
 
 Keep your own project rules outside the Boost markers — Boost overwrites only the block between
 them.
@@ -59,10 +71,12 @@ A module may additionally ship Claude Code skills in a top-level `skills/{skill-
 `noerd:install-{module}` / `noerd:update-{module}` (`HasModuleInstallation::publishSkills()`) link
 or copy every such folder into the project's `.claude/skills/` independently of Boost.
 
-Add `"noerd/{module}"` (the Composer package name) to the `packages` array of the host's
-`boost.json` (Boost ≥ 2; `boost:install` offers it interactively) and run `php artisan boost:update`. Skills are optional: create
-`resources/boost/skills/{skill-name}/SKILL.md` with a YAML front matter containing at least `name`
-(equal to the folder name) and `description`.
+The module's install and update commands (`HasModuleInstallation`) add the Composer package name
+to the `packages` array of the host's `boost.json` and run `php artisan boost:update` — as soon as
+the module ships a guideline or Boost skills, nothing has to be configured by hand (Boost ≥ 2).
+Boost skills are optional: create `resources/boost/skills/{skill-name}/SKILL.md` with a YAML front
+matter containing at least `name` (equal to the folder name) and `description`; those names are
+tracked in `boost.json` too.
 
 ## Writing a good guideline
 

--- a/docs/creating-modules.md
+++ b/docs/creating-modules.md
@@ -179,7 +179,7 @@ $this->detailData['custom_attributes']['my_key'];
 | `app-configs/{module}/` | YAML configuration templates (`lists/`, `details/`, `pages/`, `navigation.yml`) — copied into the project by the install command; the generators write both copies, keep them in sync |
 | `app-configs/stubs/add_{module}_tenant_app.php.stub` | The tenant-app migration published by the install command |
 | `database/migrations/`, `database/factories/`, `database/seeders/` | Database migrations, factories and seeders (module-owned) |
-| `resources/boost/guidelines/core.blade.php` | Module-specific rules for AI coding agents, rendered by Laravel Boost (see [AI Agents](ai-agents.md)) |
+| `resources/boost/guidelines/core.blade.php` | Module-specific rules for AI coding agents, rendered by Laravel Boost; the install/update command registers the package in the host's `boost.json` (see [AI Agents](ai-agents.md)) |
 | `skills/{name}/SKILL.md` | Claude Code skills shipped with the module — **top-level**, next to `src/` (the install/update command publishes every subfolder into the project's `.claude/skills/`). Only the noerd package itself keeps its skills in `resources/boost/skills/` |
 | `resources/lang/de.json` | Translations (English key → German) |
 | `resources/views/components/` | Livewire single-file components (`{module}-dashboard.blade.php`, `*-list.blade.php`, `*-detail.blade.php`, `*-page.blade.php`, `*-modal.blade.php`) — flat, no subfolders |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -141,6 +141,9 @@ itself. The brand palette is CSS-first, no `tailwind.config.js` is needed (see [
 - `theme.default` / `theme.enforced` — system-wide form theme (see [Themes](themes.md))
 - `brand.active` — color palette (see [Brand](brand.md))
 
+If [Laravel Boost](ai-agents.md) is installed, `noerd:install` and `noerd:update` also register
+`noerd/noerd` in `boost.json` and render the framework rules into your agent files.
+
 ## Verification
 
 You should now have access to `/noerd-apps` with your created user. If you installed the demo data, you will see a working Demo Customers app with a list and detail view — ready to explore and use as a reference for building your own apps.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -261,11 +261,27 @@ The package ships factories for its own models under `database/factories/`:
 | `NoerdSettingsFactory` | The per-tenant settings singleton (`currency`, `locale`, detail theme) — the fixture for formatting tests |
 | `SetupCollectionFactory`, `SetupLanguageFactory`, `UserSettingFactory`, `NoerdLoginFactory` | The remaining core models |
 
-## Shared databases
+## Shared databases and parallel runs
 
 Testbench's sqlite `:memory:` isolates the package suite. If you point module tests at a shared
 MySQL test database, never run two suites against it at the same time — a `migrate:fresh` of one
-run drops the tables under the other.
+run drops the tables under the other. Isolate a second session with its own database name
+(`DB_DATABASE=noerd_test_<name> php artisan test …`).
+
+- **Never `vendor/bin/pest --parallel` in a host that has Orchestra Testbench installed** (every
+  host running module suites has): Pest's Laravel parallel handler disables itself as soon as
+  Testbench is present, so all workers run `migrate:fresh` against the SAME database. Use
+  `php artisan test --parallel` for the host suites — Laravel derives one database per worker.
+- Testbench-bound suites (every suite built on `Noerd\Tests\TestCase`) share ONE skeleton for
+  their runtime-written fixtures and are therefore never run in parallel with each other; run them
+  sequentially (`--testsuite=Testbench` or per path).
+
+## Request-scoped memos
+
+`TenantHelper::getSelectedTenant()` memoizes the tenant (including its `tenantApps`) per request
+and is only flushed on boot. Several `Livewire::test()` calls in one test share that process: after
+attaching or detaching tenant apps (or any other tenant mutation) mid-test, call
+`TenantHelper::clearCache()` before the next component renders, otherwise it sees the stale relation.
 
 ## Next Steps
 

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -29,7 +29,10 @@ below points into that folder — read the referenced page before building the f
   filters from the YAML config — a manually built query gets none of these and renders no filter
   funnels in the header. A manual query (and no `$listModel`) is only acceptable when technically
   required (rows not backed by a single Eloquent model, repository/raw queries) — such lists
-  intentionally show no column filters.
+  intentionally show no column filters. A hand-written "contains" match always goes through
+  `ColumnFilterParser::applyLikeContains($query, $field, $value)` — never a bare
+  `->where($f, 'like', "%{$v}%")` with backslash-escaped wildcards: sqlite has no default LIKE
+  escape character, so such a query matches nothing there while it works on MySQL.
 - When creating new models/components, always follow the slim detail pattern (reference: `src/Commands/stubs/resource/detail.blade.stub` and `docs/detail-view.md`).
 - When creating new components, they must always be placed directly in the livewire folder. Not in subfolders like livewire/setup.
 - When creating lists/tables, they should always be named -list.blade.php. For models/components, they should always be named -detail.blade.php.
@@ -170,7 +173,9 @@ Example for user: users-list.blade.php (plural) and user-detail.blade.php (singu
   (which also re-publishes the frontend assets). Never read `env()` outside config files — use
   `config('noerd.…')`.
 - After upgrading the package run `php artisan noerd:update` (core) and `php artisan noerd:update-all`
-  (every installed module) — both are idempotent.
+  (every installed module) — both are idempotent. When Laravel Boost is installed they also
+  register the package(s) in `boost.json` and run `boost:update`, so the rendered agent rules
+  follow the installed version — never edit the generated `<laravel-boost-guidelines>` block by hand.
 
 ### Install Command Required for Every App Module
 - Every module that is a tenant app (has `app-configs/{module}/` with a `navigation.yml`) MUST ship a `noerd:install-{module}` command. New submodules always get one — never rely on the manual `noerd:make-app` flow.
@@ -190,6 +195,10 @@ Example for user: users-list.blade.php (plural) and user-detail.blade.php (singu
 - Never use `$fillable` in Eloquent models. Always use `$guarded` instead.
 - `$guarded` should either be an empty array `[]` (all fields mass-assignable) or contain only sensitive fields that must be protected (e.g., `is_admin`, `role`).
 - When reviewing or refactoring existing models, replace `$fillable` with the appropriate `$guarded` definition.
+- Never use Laravel's throwing `encrypted` cast for a stored third-party secret (API keys, tokens):
+  after an `APP_KEY` rotation the ciphertext is unreadable and every page that touches the row
+  dies. Use a `CastsAttributes` cast that catches `DecryptException` and returns `null`, so the
+  module degrades to "not configured" and the UI can offer re-entering the key.
 
 **Example:**
 ```php
@@ -244,7 +253,10 @@ Authorization is generic and two-staged (reference: `docs/permissions.md` and
   `boot()`. Route middleware (`setup`) does not cover the two dynamic-mount seams — the
   client-dispatchable `noerdModal` event and `/noerd/component-page/{componentName}` — so an
   unregistered admin screen is reachable there by any authenticated user of the tenant
-  (reference: `docs/extension-registries.md`, "ComponentAccessGuard").
+  (reference: `docs/extension-registries.md`, "ComponentAccessGuard"). The guard matches the BARE
+  component name (the `module::` prefix is stripped), so registering `toggl::settings-page` locks
+  EVERY module's `settings-page` — give an admin-only component a name that is unique across all
+  installed modules (`toggl-settings-page`) before registering it.
 - NEVER bind a locked component property to `wire:model` and never pass `detailModel`/`listModel`/
   `objectPermissionModel` as modal arguments: `LockedPropertiesHook` rejects client updates to the
   identity/config properties of every NoerdList/NoerdPage component with
@@ -845,7 +857,12 @@ Relation Box, the widget sidebar and optionally an embedded slim `*-detail`. The
   Live form sync runs via `detailDataUpdated-{detail}` (`syncPayload()` filters the payload).
 - Embed the detail in the page blade via
   `@livewire($pageLayout['detail'], ['modelId' => $modelId, 'embedded' => true], key('embedded-detail'))` —
-  `x-noerd::page` renders embedded components chrome-less automatically.
+  `x-noerd::page` renders embedded components chrome-less automatically. Two rules for EVERY
+  Livewire child embedded in another component: use the `@livewire()` directive for namespaced
+  components (the `<livewire:module::x>` tag rejects the `::`), and give the child's view ONE
+  unconditional root element — a root-level `@if` breaks Livewire's child tracking on the second
+  request. A component that can live inside a modal keeps its `mount()` free of side effects: the
+  modal stack re-mounts its children on every update.
 - Reference: `docs/page-view.md` and the `page.blade.stub` rendered by `noerd:make-page`
   (`src/Commands/stubs/resource/page.blade.stub`).
 
@@ -1141,8 +1158,12 @@ the default `store()`/`delete()` and the header actions; `$detailPrimary` binds 
 entity-scoped URL parameter and a missing declaration throws on mount). Never use a `DETAIL_CLASS`
 constant — that pattern is removed. Never redeclare `$modelId` and never add a `#[Url]` attribute to
 it: the binding comes from the trait (`queryStringNoerdPage()`) and is skipped automatically for
-`embedded: true` instances, so a hosting page may own the same URL parameter. `detailPrimary` must be
-a literal property default (never assigned in `mount()`). The trait methods (`mount()`, `store()`,
+`embedded: true` instances, so a hosting page may own the same URL parameter. `$detailModel`,
+`$detailPrimary` and `$listModel` must be LITERAL property defaults in the component's Blade source
+(never assigned in `mount()`, never inherited from a base class): the custom-attribute object catalog
+and the layout editor parse them out of the file with a regex, so a computed value silently drops the
+component from both. A shared form partial must not be named `*-detail.blade.php` — the catalog globs
+that pattern and would register it as a component. The trait methods (`mount()`, `store()`,
 `delete()`) are always used from `NoerdDetail` — a slim component contains nothing else besides
 `$detailModel` and `$detailPrimary`. Only when the logic deviates, override the method (call `$this->initDetail()`
 first in a custom `mount()`; end a custom `store()` with `$this->storeProcess($model)` and a custom

--- a/resources/boost/skills/noerd-module-development/SKILL.md
+++ b/resources/boost/skills/noerd-module-development/SKILL.md
@@ -116,8 +116,9 @@ payment payloads → `CurrencyHelper::codeForTenant()`. See `docs/formatting.md`
 
 - `resources/boost/guidelines/core.blade.php` — module rules (purpose, YAML locations, component
   names, commands, test call). Blade-rendered by Boost: wrap literal `{{ }}`/`@` in `@verbatim`.
-  The host enables it by adding `"noerd/{module}"` to the `packages` array in `boost.json` and
-  running `php artisan boost:update`.
+  `noerd:install-{module}` / `noerd:update-{module}` register the package in the host's
+  `boost.json` and run `php artisan boost:update` — no manual step. A module's own Claude skills
+  live in the top-level `skills/` folder (published by noerd), never in `boost.json`.
 - `AGENTS.md` (+ `CLAUDE.md` containing `@AGENTS.md`) — contributor workflow for the module repo.
 - Keep both current when the module gains features.
 

--- a/resources/boost/skills/noerd-testing/SKILL.md
+++ b/resources/boost/skills/noerd-testing/SKILL.md
@@ -82,7 +82,11 @@ in the test that needs them.
 - Host project: `php artisan test --compact app-modules/{module}/tests/Feature/ThingTest.php`
   (or `--filter=`). Run the smallest relevant subset, then `vendor/bin/pint --dirty`.
 - Do not run suites in parallel against one shared MySQL test database — `migrate:fresh` of one run
-  destroys the other. Package-only suites run on Testbench sqlite `:memory:`.
+  destroys the other. Package-only suites run on Testbench sqlite `:memory:`. Never
+  `vendor/bin/pest --parallel` in a host with Testbench installed (its workers share ONE database);
+  `php artisan test --parallel` is the parallel runner, and Testbench-bound suites run sequentially.
+- After attaching/detaching tenant apps mid-test call `TenantHelper::clearCache()` before the next
+  `Livewire::test()` — the selected tenant is memoized per process.
 - Module test traits (`CreatesModuleUser`, …) live in `app-modules/{module}/tests/Traits/`.
 
 ## Done when

--- a/src/Commands/Concerns/PublishesNoerdContent.php
+++ b/src/Commands/Concerns/PublishesNoerdContent.php
@@ -19,6 +19,7 @@ use Noerd\Services\FrontendScaffolder;
 trait PublishesNoerdContent
 {
     use PublishesConfigDirectory;
+    use RegistersBoostPackage;
 
     /**
      * Copy directory contents recursively (see PublishesConfigDirectory).
@@ -49,6 +50,14 @@ trait PublishesNoerdContent
             '--force' => true,
             '--no-interaction' => true,
         ]);
+    }
+
+    /**
+     * Enable the noerd guideline and skills in the host's boost.json and render them.
+     */
+    protected function registerNoerdBoostPackage(): void
+    {
+        $this->registerBoostPackage(dirname(__DIR__, 3));
     }
 
     /**

--- a/src/Commands/Concerns/RegistersBoostPackage.php
+++ b/src/Commands/Concerns/RegistersBoostPackage.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noerd\Commands\Concerns;
+
+use Noerd\Support\BoostConfig;
+use Symfony\Component\Yaml\Yaml;
+use Throwable;
+
+/**
+ * Enable a package's Laravel Boost guideline and skills in the host project.
+ *
+ * Boost only renders the guideline (`resources/boost/guidelines/core.blade.php`)
+ * and the skills (`resources/boost/skills/{name}/SKILL.md`) of a third-party
+ * package when the package is listed under `packages` in the host's boost.json.
+ * That step was easy to forget, so every noerd install/update command registers
+ * its own package and refreshes the rendered agent files (`boost:update`).
+ *
+ * Nothing here ever fails the calling command: without a boost.json (Boost not
+ * installed) a hint is printed and that is all.
+ */
+trait RegistersBoostPackage
+{
+    /**
+     * @param  string  $packageRoot  The package directory holding composer.json and resources/boost
+     */
+    protected function registerBoostPackage(string $packageRoot): void
+    {
+        try {
+            $name = $this->boostPackageName($packageRoot);
+            $skills = $this->boostSkillNames($packageRoot);
+
+            if ($name === null || (! $this->shipsBoostGuideline($packageRoot) && $skills === [])) {
+                return;
+            }
+
+            $config = $this->boostConfig();
+
+            if (! $config->exists()) {
+                $this->line("<comment>Laravel Boost is not set up (no boost.json): add \"{$name}\" to its packages after php artisan boost:install to render the agent guidelines.</comment>");
+
+                return;
+            }
+
+            if (! $config->isValid()) {
+                $this->warn('boost.json is not valid JSON; left untouched.');
+
+                return;
+            }
+
+            if (! $this->boostPackageInstalled($name)) {
+                $this->warn("{$name} is not installed via Composer (vendor/{$name} missing); Boost would drop it from boost.json again.");
+
+                return;
+            }
+
+            $added = $config->ensure([$name], $skills);
+
+            if ($added['packages'] !== []) {
+                $this->line("<info>Boost package registered:</info> {$name}");
+            } else {
+                $this->line("<comment>Boost package already registered:</comment> {$name}");
+            }
+
+            if ($added['skills'] !== []) {
+                $this->line('<info>Boost skills registered:</info> ' . implode(', ', $added['skills']));
+            }
+
+            $this->refreshBoostGuidelines(force: $added['packages'] !== [] || $added['skills'] !== []);
+        } catch (Throwable $e) {
+            $this->warn('Could not register the package in boost.json: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * Re-render the agent files. Runs once per process unless a new entry was
+     * added — `noerd:update-all` chains many commands and must not repeat it.
+     */
+    protected function refreshBoostGuidelines(bool $force): void
+    {
+        if (! $this->boostUpdateAvailable()) {
+            $this->line('<comment>Run php artisan boost:update to render the agent guidelines.</comment>');
+
+            return;
+        }
+
+        if (! $force && BoostConfig::wasRefreshedInProcess()) {
+            return;
+        }
+
+        BoostConfig::markRefreshedInProcess();
+        $this->runBoostUpdate();
+    }
+
+    protected function boostConfig(): BoostConfig
+    {
+        return BoostConfig::forProject();
+    }
+
+    /**
+     * Boost writes `packages` back as "configured ∩ discovered", and discovery
+     * requires the package under vendor/ (a path-repository symlink qualifies).
+     */
+    protected function boostPackageInstalled(string $name): bool
+    {
+        return is_dir(base_path('vendor/' . $name));
+    }
+
+    protected function boostUpdateAvailable(): bool
+    {
+        return $this->getApplication()?->has('boost:update') ?? false;
+    }
+
+    protected function runBoostUpdate(): void
+    {
+        $exitCode = $this->call('boost:update', ['--no-interaction' => true]);
+
+        if ($exitCode !== 0) {
+            $this->warn('boost:update did not complete; run php artisan boost:update to render the agent guidelines.');
+        }
+    }
+
+    /**
+     * The Composer package name from the package's composer.json.
+     */
+    protected function boostPackageName(string $packageRoot): ?string
+    {
+        $composerFile = $packageRoot . '/composer.json';
+
+        if (! is_file($composerFile)) {
+            return null;
+        }
+
+        $composer = json_decode((string) file_get_contents($composerFile), true);
+        $name = is_array($composer) ? ($composer['name'] ?? null) : null;
+
+        return is_string($name) && $name !== '' ? $name : null;
+    }
+
+    protected function shipsBoostGuideline(string $packageRoot): bool
+    {
+        return is_file($packageRoot . '/resources/boost/guidelines/core.blade.php');
+    }
+
+    /**
+     * The `name` of every skill Boost will discover: only resources/boost/skills
+     * counts (a module's top-level skills/ folder is published by noerd itself and
+     * must never be tracked in boost.json — Boost would remove it as stale), and
+     * only a SKILL.md whose front matter carries name + description is a skill.
+     *
+     * @return string[]
+     */
+    protected function boostSkillNames(string $packageRoot): array
+    {
+        $names = [];
+
+        foreach (glob($packageRoot . '/resources/boost/skills/*', GLOB_ONLYDIR) ?: [] as $dir) {
+            $file = is_file($dir . '/SKILL.md') ? $dir . '/SKILL.md' : $dir . '/SKILL.blade.php';
+
+            if (! is_file($file)) {
+                continue;
+            }
+
+            if (preg_match('/^\s*---\s*\n(.*?)\n---\s*\n/s', (string) file_get_contents($file), $matches) !== 1) {
+                continue;
+            }
+
+            try {
+                $frontmatter = Yaml::parse($matches[1]);
+            } catch (Throwable) {
+                continue;
+            }
+
+            $name = is_array($frontmatter) ? ($frontmatter['name'] ?? null) : null;
+            $description = is_array($frontmatter) ? ($frontmatter['description'] ?? null) : null;
+
+            if (is_string($name) && $name !== '' && is_string($description) && $description !== '') {
+                $names[] = $name;
+            }
+        }
+
+        sort($names);
+
+        return $names;
+    }
+}

--- a/src/Commands/MakeModuleCommand.php
+++ b/src/Commands/MakeModuleCommand.php
@@ -126,7 +126,7 @@ class MakeModuleCommand extends Command
             $this->line("  1. composer update noerd/{$this->moduleName}");
             $this->line("  2. php artisan noerd:install-{$this->moduleName}");
             $this->line("  3. Create a model + migration in the module, then php artisan noerd:make-resource {Model} --app={$this->moduleName}");
-            $this->line("  4. Add \"noerd/{$this->moduleName}\" to the packages in boost.json and run php artisan boost:update (optional, for AI agents)");
+            $this->line("  4. With Laravel Boost installed, noerd:install-{$this->moduleName} registers the module guideline in boost.json for AI agents");
 
             return self::SUCCESS;
         } catch (Exception $e) {

--- a/src/Commands/NoerdInstallCommand.php
+++ b/src/Commands/NoerdInstallCommand.php
@@ -74,6 +74,9 @@ class NoerdInstallCommand extends Command
             // Publish fonts + built Vite assets to public/vendor/noerd
             $this->publishNoerdAssets();
 
+            // Register the package in boost.json and render the agent guidelines
+            $this->registerNoerdBoostPackage();
+
             // Run migrations and setup admin user
             $this->runMigrationsAndSetupAdmin();
 

--- a/src/Commands/NoerdUpdateCommand.php
+++ b/src/Commands/NoerdUpdateCommand.php
@@ -56,7 +56,10 @@ class NoerdUpdateCommand extends Command
             // 4. Refresh published fonts + built Vite assets
             $this->publishNoerdAssets();
 
-            // 5. Optional: npm build (only if --build flag is set)
+            // 5. Register the package in boost.json and render the agent guidelines
+            $this->registerNoerdBoostPackage();
+
+            // 6. Optional: npm build (only if --build flag is set)
             if ($this->option('build')) {
                 $this->runNpmBuildWithoutPrompt();
             }

--- a/src/Commands/stubs/module/agents.stub
+++ b/src/Commands/stubs/module/agents.stub
@@ -31,4 +31,5 @@ by `php artisan boost:update` (add `noerd/{{module-name}}` to the `packages` arr
 - Keep the module independent of other optional modules; project-specific fields go into
   `custom_attributes`, never into module code or module YAML
 - When a feature changes: update the YAML in both places, `resources/lang/de.json`, the tests and
-  `resources/boost/guidelines/core.blade.php`
+  `resources/boost/guidelines/core.blade.php` (including its "Reference implementations" section —
+  the module, not a host project, names the components agents should copy from)

--- a/src/Commands/stubs/module/boost-guideline.stub
+++ b/src/Commands/stubs/module/boost-guideline.stub
@@ -34,4 +34,9 @@ to this module.
 ### Tests
 - Pest tests in `tests/`; run with `php artisan test --compact app-modules/{{module-name}}/tests`
 - Prove mechanics, never the current YAML configuration (see the `noerd-testing` skill)
+
+### Reference implementations
+- List the components of this module that show a pattern well (e.g. a list with a custom
+  `listData()`, a page with a relation box, a component modal with a result event) — agents use
+  them as the starting point instead of a host project's notes.
 @endverbatim

--- a/src/Support/BoostConfig.php
+++ b/src/Support/BoostConfig.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noerd\Support;
+
+/**
+ * The host project's `boost.json` — the file Laravel Boost reads to decide
+ * WHICH third-party packages get their guidelines and skills rendered into the
+ * agent files (`packages`) and which skills it currently tracks (`skills`).
+ *
+ * This class only ever ADDS entries. It never removes anything, never creates
+ * the file (a missing boost.json means Boost is not set up — that is the
+ * developer's call) and writes in Boost's own format (4-space pretty print,
+ * unescaped slashes, trailing newline) while keeping the existing key order.
+ * Boost itself is not a dependency of noerd, so nothing here references it.
+ */
+final class BoostConfig
+{
+    private static bool $refreshedInProcess = false;
+
+    public function __construct(private readonly string $path) {}
+
+    public static function forProject(): self
+    {
+        return new self(base_path('boost.json'));
+    }
+
+    /**
+     * Whether `boost:update` already ran in this PHP process — `noerd:update-all`
+     * chains a dozen commands that would otherwise each re-render the agent
+     * files; a rerun is only needed when a command added a new entry.
+     */
+    public static function wasRefreshedInProcess(): bool
+    {
+        return self::$refreshedInProcess;
+    }
+
+    public static function markRefreshedInProcess(bool $refreshed = true): void
+    {
+        self::$refreshedInProcess = $refreshed;
+    }
+
+    public function path(): string
+    {
+        return $this->path;
+    }
+
+    public function exists(): bool
+    {
+        return is_file($this->path);
+    }
+
+    /**
+     * Whether the file decodes to a JSON object (Boost refuses anything else).
+     */
+    public function isValid(): bool
+    {
+        return $this->exists() && $this->read() !== null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function all(): array
+    {
+        return $this->read() ?? [];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function packages(): array
+    {
+        return $this->stringList('packages');
+    }
+
+    /**
+     * @return string[]
+     */
+    public function skills(): array
+    {
+        return $this->stringList('skills');
+    }
+
+    /**
+     * Add the given packages and skill names when they are missing and return
+     * what was actually added. Nothing is written when nothing changed, when the
+     * file is missing, or when it does not hold a JSON object.
+     *
+     * @param  string[]  $packages
+     * @param  string[]  $skills
+     * @return array{packages: string[], skills: string[]}
+     */
+    public function ensure(array $packages, array $skills): array
+    {
+        $added = ['packages' => [], 'skills' => []];
+
+        $config = $this->read();
+        if ($config === null) {
+            return $added;
+        }
+
+        foreach (['packages' => $packages, 'skills' => $skills] as $key => $wanted) {
+            $current = $this->stringList($key, $config);
+
+            foreach ($wanted as $name) {
+                if (! in_array($name, $current, true)) {
+                    $current[] = $name;
+                    $added[$key][] = $name;
+                }
+            }
+
+            if ($added[$key] !== []) {
+                $config[$key] = array_values($current);
+            }
+        }
+
+        if ($added['packages'] !== [] || $added['skills'] !== []) {
+            $this->write($config);
+        }
+
+        return $added;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function read(): ?array
+    {
+        if (! $this->exists()) {
+            return null;
+        }
+
+        $decoded = json_decode((string) file_get_contents($this->path), true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $config
+     * @return string[]
+     */
+    private function stringList(string $key, ?array $config = null): array
+    {
+        $value = ($config ?? $this->all())[$key] ?? [];
+
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_filter($value, 'is_string'));
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    private function write(array $config): void
+    {
+        file_put_contents(
+            $this->path,
+            json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . PHP_EOL,
+        );
+    }
+}

--- a/src/Traits/HasModuleInstallation.php
+++ b/src/Traits/HasModuleInstallation.php
@@ -15,6 +15,7 @@ use Symfony\Component\Yaml\Yaml;
 trait HasModuleInstallation
 {
     use \Noerd\Commands\Concerns\PublishesConfigDirectory;
+    use \Noerd\Commands\Concerns\RegistersBoostPackage;
     use \Noerd\Commands\Concerns\RunsNpmBuild;
 
     /** @var array{created_dirs: int, copied_files: int, skipped_files: int, overwritten_files: int} */
@@ -155,6 +156,7 @@ trait HasModuleInstallation
             }
 
             $this->publishSkills(refreshCopies: true);
+            $this->registerBoostPackage($this->getModuleRoot());
 
             $this->displayInstallSummary();
 
@@ -267,6 +269,7 @@ trait HasModuleInstallation
             $this->installAsNewApp($sourceDir, $targetDir, $isHidden);
 
             $this->publishSkills(refreshCopies: false);
+            $this->registerBoostPackage($this->getModuleRoot());
 
             $this->displayInstallSummary();
 
@@ -336,6 +339,7 @@ trait HasModuleInstallation
                 }
 
                 $this->publishSkills(refreshCopies: true);
+                $this->registerBoostPackage($this->getModuleRoot());
             });
         } catch (Exception $e) {
             $this->error("Error installing {$this->getModuleName()}: " . $e->getMessage());
@@ -545,6 +549,15 @@ trait HasModuleInstallation
     }
 
     /**
+     * The module root (composer.json, resources/boost, skills/): the source dir
+     * is always {module}/app-configs/{key}.
+     */
+    protected function getModuleRoot(): string
+    {
+        return dirname($this->getSourceDir(), 2);
+    }
+
+    /**
      * Publish all bundled Claude Code skills (every subdir of {module}/skills/)
      * into base_path('.claude/skills'). Prefers a relative symlink so the
      * skill auto-updates with the module; falls back to a recursive copy.
@@ -554,7 +567,7 @@ trait HasModuleInstallation
      */
     protected function publishSkills(bool $refreshCopies = false): void
     {
-        $skillsRoot = dirname($this->getSourceDir(), 2) . '/skills';
+        $skillsRoot = $this->getModuleRoot() . '/skills';
 
         if (! is_dir($skillsRoot)) {
             return;

--- a/tests/Commands/ModuleInstallationTest.php
+++ b/tests/Commands/ModuleInstallationTest.php
@@ -31,6 +31,8 @@ class ZzModuleInstallFixtureCommand extends Command
     use HasModuleInstallation;
     use RequiresNoerdInstallation;
 
+    public static int $boostUpdateCalls = 0;
+
     protected $signature = 'noerd:install-zz-install-fixture {--force : Overwrite existing files without asking} {--scaffold : Silent post-scaffold run}';
 
     protected $description = 'Test fixture install command';
@@ -70,6 +72,21 @@ class ZzModuleInstallFixtureCommand extends Command
         // Nested so that publishSkills() (dirname twice + /skills) lands inside the
         // disposable tests-tmp tree and finds nothing to publish.
         return base_path('tests-tmp/module/app-configs/' . ZZ_MODULE_KEY);
+    }
+
+    protected function boostUpdateAvailable(): bool
+    {
+        return true;
+    }
+
+    protected function boostPackageInstalled(string $name): bool
+    {
+        return true;
+    }
+
+    protected function runBoostUpdate(): void
+    {
+        static::$boostUpdateCalls++;
     }
 }
 
@@ -216,5 +233,53 @@ describe('scaffold mode', function (): void {
             ->and($app->tenants()->pluck('tenants.id')->all())->toBe([$tenant->id])
             ->and(File::exists(base_path('app-configs/' . ZZ_MODULE_KEY . '/navigation.yml')))->toBeTrue()
             ->and(File::exists(base_path('app-configs/' . ZZ_MODULE_KEY . '/settings/zz-fixture-settings-page.yml')))->toBeTrue();
+    });
+});
+
+describe('boost registration', function (): void {
+    beforeEach(function (): void {
+        ZzModuleInstallFixtureCommand::$boostUpdateCalls = 0;
+        \Noerd\Support\BoostConfig::markRefreshedInProcess(false);
+
+        $this->boostJson = base_path('boost.json');
+        $this->boostJsonBackup = File::exists($this->boostJson) ? File::get($this->boostJson) : null;
+    });
+
+    afterEach(function (): void {
+        if ($this->boostJsonBackup === null) {
+            File::delete($this->boostJson);
+        } else {
+            File::put($this->boostJson, $this->boostJsonBackup);
+        }
+    });
+
+    it('registers a module that ships a boost guideline in the host boost.json', function (): void {
+        $moduleRoot = base_path('tests-tmp/module');
+        File::put($moduleRoot . '/composer.json', json_encode(['name' => 'zz/install-fixture']));
+        File::ensureDirectoryExists($moduleRoot . '/resources/boost/guidelines');
+        File::put($moduleRoot . '/resources/boost/guidelines/core.blade.php', "## Zz\n");
+        File::put($this->boostJson, json_encode(['agents' => ['claude_code'], 'guidelines' => true, 'packages' => ['noerd/noerd'], 'skills' => []], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL);
+
+        runZzModuleInstall($this);
+
+        expect((new \Noerd\Support\BoostConfig($this->boostJson))->packages())->toBe(['noerd/noerd', 'zz/install-fixture'])
+            ->and(ZzModuleInstallFixtureCommand::$boostUpdateCalls)->toBe(1);
+
+        // The update path is idempotent: nothing new, no second render.
+        $this->artisan('noerd:install-' . ZZ_MODULE_KEY, ['--force' => true])
+            ->expectsConfirmation('Would you like to assign the app to tenants now?', 'no')
+            ->assertExitCode(0);
+
+        expect((new \Noerd\Support\BoostConfig($this->boostJson))->packages())->toBe(['noerd/noerd', 'zz/install-fixture'])
+            ->and(ZzModuleInstallFixtureCommand::$boostUpdateCalls)->toBe(1);
+    });
+
+    it('leaves boost.json alone for a module without agent guidelines', function (): void {
+        File::put($this->boostJson, "{\n    \"packages\": [\n        \"noerd/noerd\"\n    ]\n}\n");
+
+        runZzModuleInstall($this);
+
+        expect(File::get($this->boostJson))->toBe("{\n    \"packages\": [\n        \"noerd/noerd\"\n    ]\n}\n")
+            ->and(ZzModuleInstallFixtureCommand::$boostUpdateCalls)->toBe(0);
     });
 });

--- a/tests/Commands/NoerdInstallCommandTest.php
+++ b/tests/Commands/NoerdInstallCommandTest.php
@@ -107,6 +107,11 @@ class ZzInstallFixtureCommand extends NoerdInstallCommand
         $this->step('publishNoerdAssets', fn() => parent::publishNoerdAssets());
     }
 
+    protected function registerNoerdBoostPackage(): void
+    {
+        $this->step('registerNoerdBoostPackage', fn() => parent::registerNoerdBoostPackage());
+    }
+
     protected function runMigrationsAndSetupAdmin(): void
     {
         $this->step('runMigrationsAndSetupAdmin', fn() => parent::runMigrationsAndSetupAdmin());
@@ -184,7 +189,7 @@ describe('demo prompt', function (): void {
         // flow — behind every other step that asks something.
         $demoStep = array_search('installDemoApp', $steps, true);
 
-        foreach (['publishNoerdConfig', 'setupFrontendAssets', 'runMigrationsAndSetupAdmin', 'runNpmBuild'] as $earlierStep) {
+        foreach (['publishNoerdConfig', 'setupFrontendAssets', 'registerNoerdBoostPackage', 'runMigrationsAndSetupAdmin', 'runNpmBuild'] as $earlierStep) {
             $earlierStepIndex = array_search($earlierStep, $steps, true);
 
             expect($earlierStepIndex)->not->toBeFalse("Step {$earlierStep} did not run")
@@ -328,5 +333,19 @@ describe('config publishing', function (): void {
 
         expect(File::exists($this->configPath . '.bak'))->toBeFalse()
             ->and(File::get($this->configPath))->not->toContain("'prefix' => 'custom'");
+    });
+});
+
+describe('boost registration', function (): void {
+    it('registers the package before the migration prompt so a scripted run needs no extra step', function (): void {
+        ZzInstallFixtureCommand::$recordStepsOnly = true;
+
+        $this->artisan('test:noerd-install')->assertExitCode(0);
+
+        $steps = ZzInstallFixtureCommand::$steps;
+
+        expect(array_search('registerNoerdBoostPackage', $steps, true))
+            ->toBeGreaterThan(array_search('publishNoerdAssets', $steps, true))
+            ->toBeLessThan(array_search('runMigrationsAndSetupAdmin', $steps, true));
     });
 });

--- a/tests/Commands/NoerdUpdateCommandTest.php
+++ b/tests/Commands/NoerdUpdateCommandTest.php
@@ -21,6 +21,7 @@ uses(TestCase::class);
  */
 class ZzNoerdUpdateFixtureCommand extends NoerdUpdateCommand
 {
+    public static int $boostUpdateCalls = 0;
     protected $signature = 'test:noerd-update
                             {--force : Overwrite existing files without asking}
                             {--build : Run npm build after update}';
@@ -28,10 +29,27 @@ class ZzNoerdUpdateFixtureCommand extends NoerdUpdateCommand
     protected function setupFrontendAssets(): void {}
 
     protected function publishNoerdAssets(): void {}
+
+    protected function boostUpdateAvailable(): bool
+    {
+        return true;
+    }
+
+    protected function boostPackageInstalled(string $name): bool
+    {
+        return true;
+    }
+
+    protected function runBoostUpdate(): void
+    {
+        static::$boostUpdateCalls++;
+    }
 }
 
 beforeEach(function (): void {
     $this->app[Kernel::class]->registerCommand(new ZzNoerdUpdateFixtureCommand());
+    ZzNoerdUpdateFixtureCommand::$boostUpdateCalls = 0;
+    \Noerd\Support\BoostConfig::markRefreshedInProcess(false);
 
     $this->originalBasePath = $this->app->basePath();
     $this->hostPath = storage_path('framework/testing/zz-noerd-update');
@@ -100,4 +118,31 @@ it('fails when the target directory cannot be created', function (): void {
     }
 
     expect(File::exists($this->hostPath . '/config/noerd.php'))->toBeFalse();
+});
+
+describe('boost registration', function (): void {
+    it('registers noerd and its skills in the host boost.json and re-renders the agent files', function (): void {
+        File::put($this->hostPath . '/boost.json', json_encode(['agents' => ['claude_code'], 'guidelines' => true, 'packages' => [], 'skills' => []], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL);
+
+        $this->artisan('test:noerd-update', ['--force' => true, '--no-interaction' => true])
+            ->expectsOutputToContain('Boost package registered: noerd/noerd')
+            ->assertExitCode(0);
+
+        $config = new \Noerd\Support\BoostConfig($this->hostPath . '/boost.json');
+        $shippedSkills = array_map('basename', File::directories(dirname(__DIR__, 2) . '/resources/boost/skills'));
+        sort($shippedSkills);
+
+        expect($config->packages())->toBe(['noerd/noerd'])
+            ->and($config->skills())->toBe($shippedSkills)
+            ->and(ZzNoerdUpdateFixtureCommand::$boostUpdateCalls)->toBe(1);
+    });
+
+    it('only hints at Boost when the host has no boost.json', function (): void {
+        $this->artisan('test:noerd-update', ['--force' => true, '--no-interaction' => true])
+            ->expectsOutputToContain('Laravel Boost is not set up (no boost.json)')
+            ->assertExitCode(0);
+
+        expect(File::exists($this->hostPath . '/boost.json'))->toBeFalse()
+            ->and(ZzNoerdUpdateFixtureCommand::$boostUpdateCalls)->toBe(0);
+    });
 });

--- a/tests/Commands/RegistersBoostPackageTest.php
+++ b/tests/Commands/RegistersBoostPackageTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Support\Facades\File;
+use Noerd\Commands\Concerns\RegistersBoostPackage;
+use Noerd\Support\BoostConfig;
+use Noerd\Tests\TestCase;
+
+uses(TestCase::class);
+
+/*
+ | Every noerd install/update command registers its package in the host's
+ | boost.json so Laravel Boost renders the package's guideline and skills. The
+ | concern is exercised through a fixture command against a throwaway base path
+ | holding a fake package root — boost:update itself is only recorded: in a host
+ | run the real command exists and would render agent files into the temp path.
+ */
+class ZzBoostRegistrationFixtureCommand extends Command
+{
+    use RegistersBoostPackage;
+
+    public static bool $updateAvailable = true;
+
+    public static int $updateCalls = 0;
+
+    protected $signature = 'test:register-boost {root}';
+
+    public function handle(): int
+    {
+        $this->registerBoostPackage((string) $this->argument('root'));
+
+        return 0;
+    }
+
+    protected function boostUpdateAvailable(): bool
+    {
+        return static::$updateAvailable;
+    }
+
+    protected function runBoostUpdate(): void
+    {
+        static::$updateCalls++;
+    }
+}
+
+beforeEach(function (): void {
+    ZzBoostRegistrationFixtureCommand::$updateAvailable = true;
+    ZzBoostRegistrationFixtureCommand::$updateCalls = 0;
+    BoostConfig::markRefreshedInProcess(false);
+
+    $this->app[Kernel::class]->registerCommand(new ZzBoostRegistrationFixtureCommand());
+
+    $this->originalBasePath = $this->app->basePath();
+    $this->hostPath = storage_path('framework/testing/zz-boost-registration');
+    File::deleteDirectory($this->hostPath);
+    File::ensureDirectoryExists($this->hostPath);
+    $this->app->setBasePath($this->hostPath);
+
+    $this->packageRoot = $this->hostPath . '/packages/boost-fixture';
+    File::ensureDirectoryExists($this->packageRoot . '/resources/boost/guidelines');
+    File::ensureDirectoryExists($this->packageRoot . '/resources/boost/skills/zz-skill');
+    File::put($this->packageRoot . '/composer.json', json_encode(['name' => 'zz/boost-fixture']));
+    File::put($this->packageRoot . '/resources/boost/guidelines/core.blade.php', "## Zz\n");
+    File::put($this->packageRoot . '/resources/boost/skills/zz-skill/SKILL.md', "---\nname: zz-skill\ndescription: Fixture skill\n---\n# Zz\n");
+    File::ensureDirectoryExists($this->hostPath . '/vendor/zz/boost-fixture');
+
+    $this->boostJson = $this->hostPath . '/boost.json';
+    File::put($this->boostJson, json_encode(['agents' => ['claude_code'], 'guidelines' => true, 'packages' => ['vendor/other'], 'skills' => []], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL);
+});
+
+afterEach(function (): void {
+    $this->app->setBasePath($this->originalBasePath);
+    File::deleteDirectory($this->hostPath);
+    BoostConfig::markRefreshedInProcess(false);
+});
+
+it('registers the package and its skills and refreshes the agent files', function (): void {
+    $this->artisan('test:register-boost', ['root' => $this->packageRoot])
+        ->expectsOutputToContain('Boost package registered: zz/boost-fixture')
+        ->expectsOutputToContain('Boost skills registered: zz-skill')
+        ->assertExitCode(0);
+
+    $config = new BoostConfig($this->boostJson);
+
+    expect($config->packages())->toBe(['vendor/other', 'zz/boost-fixture'])
+        ->and($config->skills())->toBe(['zz-skill'])
+        ->and(ZzBoostRegistrationFixtureCommand::$updateCalls)->toBe(1);
+});
+
+it('refreshes only once per process unless a new entry was added', function (): void {
+    $this->artisan('test:register-boost', ['root' => $this->packageRoot])->assertExitCode(0);
+    $this->artisan('test:register-boost', ['root' => $this->packageRoot])
+        ->expectsOutputToContain('Boost package already registered: zz/boost-fixture')
+        ->assertExitCode(0);
+
+    expect(ZzBoostRegistrationFixtureCommand::$updateCalls)->toBe(1);
+
+    // A second package registered later in the same process (noerd:update-all) re-renders.
+    File::put($this->packageRoot . '/composer.json', json_encode(['name' => 'zz/second']));
+    File::ensureDirectoryExists($this->hostPath . '/vendor/zz/second');
+    $this->artisan('test:register-boost', ['root' => $this->packageRoot])->assertExitCode(0);
+
+    expect(ZzBoostRegistrationFixtureCommand::$updateCalls)->toBe(2);
+});
+
+it('prints a hint and writes nothing when Boost is not set up', function (): void {
+    File::delete($this->boostJson);
+
+    $this->artisan('test:register-boost', ['root' => $this->packageRoot])
+        ->expectsOutputToContain('Laravel Boost is not set up (no boost.json)')
+        ->assertExitCode(0);
+
+    expect(File::exists($this->boostJson))->toBeFalse()
+        ->and(ZzBoostRegistrationFixtureCommand::$updateCalls)->toBe(0);
+});
+
+it('stays silent for a package without guideline and skills', function (): void {
+    File::deleteDirectory($this->packageRoot . '/resources/boost');
+    $before = File::get($this->boostJson);
+
+    $this->artisan('test:register-boost', ['root' => $this->packageRoot])
+        ->doesntExpectOutputToContain('Boost')
+        ->assertExitCode(0);
+
+    expect(File::get($this->boostJson))->toBe($before)
+        ->and(ZzBoostRegistrationFixtureCommand::$updateCalls)->toBe(0);
+});
+
+it('stays silent for a package root without a composer name', function (): void {
+    File::put($this->packageRoot . '/composer.json', json_encode(['description' => 'nameless']));
+    $before = File::get($this->boostJson);
+
+    $this->artisan('test:register-boost', ['root' => $this->packageRoot])
+        ->doesntExpectOutputToContain('Boost')
+        ->assertExitCode(0);
+
+    expect(File::get($this->boostJson))->toBe($before);
+});
+
+it('tracks only skills Boost will discover', function (): void {
+    // A top-level skills/ folder is published by noerd itself — Boost would treat
+    // its name as stale and delete the published link; a SKILL.md without front
+    // matter name is not a skill for Boost either.
+    File::ensureDirectoryExists($this->packageRoot . '/skills/zz-top-level');
+    File::put($this->packageRoot . '/skills/zz-top-level/SKILL.md', "---\nname: zz-top-level\ndescription: Published by noerd\n---\n");
+    File::ensureDirectoryExists($this->packageRoot . '/resources/boost/skills/zz-nameless');
+    File::put($this->packageRoot . '/resources/boost/skills/zz-nameless/SKILL.md', "# No front matter\n");
+
+    $this->artisan('test:register-boost', ['root' => $this->packageRoot])->assertExitCode(0);
+
+    expect((new BoostConfig($this->boostJson))->skills())->toBe(['zz-skill']);
+});
+
+it('warns and writes nothing when the package is not installed under vendor', function (): void {
+    File::deleteDirectory($this->hostPath . '/vendor/zz/boost-fixture');
+    $before = File::get($this->boostJson);
+
+    $this->artisan('test:register-boost', ['root' => $this->packageRoot])
+        ->expectsOutputToContain('zz/boost-fixture is not installed via Composer')
+        ->assertExitCode(0);
+
+    expect(File::get($this->boostJson))->toBe($before)
+        ->and(ZzBoostRegistrationFixtureCommand::$updateCalls)->toBe(0);
+});
+
+it('leaves an invalid boost.json untouched', function (): void {
+    File::put($this->boostJson, "{ broken\n");
+
+    $this->artisan('test:register-boost', ['root' => $this->packageRoot])
+        ->expectsOutputToContain('boost.json is not valid JSON')
+        ->assertExitCode(0);
+
+    expect(File::get($this->boostJson))->toBe("{ broken\n");
+});
+
+it('points to boost:update when the command is not available', function (): void {
+    ZzBoostRegistrationFixtureCommand::$updateAvailable = false;
+
+    $this->artisan('test:register-boost', ['root' => $this->packageRoot])
+        ->expectsOutputToContain('Run php artisan boost:update')
+        ->assertExitCode(0);
+
+    expect((new BoostConfig($this->boostJson))->packages())->toContain('zz/boost-fixture')
+        ->and(ZzBoostRegistrationFixtureCommand::$updateCalls)->toBe(0);
+});

--- a/tests/Unit/BoostConfigTest.php
+++ b/tests/Unit/BoostConfigTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\File;
+use Noerd\Support\BoostConfig;
+use Noerd\Tests\TestCase;
+
+uses(TestCase::class);
+
+/*
+ | BoostConfig is the only writer noerd has for the host's boost.json. It must
+ | only ever ADD entries — Boost reads the file as its package selection, so a
+ | lost entry silently drops a package's rendered guidelines.
+ */
+beforeEach(function (): void {
+    $this->dir = storage_path('framework/testing/zz-boost-config');
+    File::deleteDirectory($this->dir);
+    File::ensureDirectoryExists($this->dir);
+    $this->path = $this->dir . '/boost.json';
+});
+
+afterEach(function (): void {
+    File::deleteDirectory($this->dir);
+});
+
+function zzWriteBoostJson(string $path, array $config): void
+{
+    File::put($path, json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL);
+}
+
+it('appends missing packages and skills and reports what it added', function (): void {
+    zzWriteBoostJson($this->path, ['guidelines' => true, 'packages' => ['spatie/laravel-pdf'], 'skills' => ['laravel-pdf']]);
+
+    $added = (new BoostConfig($this->path))->ensure(['noerd/noerd'], ['noerd-testing', 'laravel-pdf']);
+
+    expect($added)->toBe(['packages' => ['noerd/noerd'], 'skills' => ['noerd-testing']]);
+
+    $config = new BoostConfig($this->path);
+    expect($config->packages())->toBe(['spatie/laravel-pdf', 'noerd/noerd'])
+        ->and($config->skills())->toBe(['laravel-pdf', 'noerd-testing']);
+});
+
+it('is idempotent and leaves the file bytes untouched on a repeated call', function (): void {
+    zzWriteBoostJson($this->path, ['packages' => ['noerd/noerd'], 'skills' => ['noerd-testing']]);
+    $before = File::get($this->path);
+
+    $added = (new BoostConfig($this->path))->ensure(['noerd/noerd'], ['noerd-testing']);
+
+    expect($added)->toBe(['packages' => [], 'skills' => []])
+        ->and(File::get($this->path))->toBe($before);
+});
+
+it('never removes entries it does not know and keeps the key order', function (): void {
+    // Deliberately NOT alphabetical: Boost's own writer ksorts, a hand-edited file may not.
+    File::put($this->path, "{\n    \"skills\": [\n        \"foreign-skill\"\n    ],\n    \"agents\": [\n        \"claude_code\"\n    ],\n    \"packages\": [\n        \"vendor/other\"\n    ]\n}\n");
+
+    (new BoostConfig($this->path))->ensure(['noerd/noerd'], []);
+
+    $config = new BoostConfig($this->path);
+    expect($config->packages())->toBe(['vendor/other', 'noerd/noerd'])
+        ->and($config->skills())->toBe(['foreign-skill'])
+        ->and(array_keys($config->all()))->toBe(['skills', 'agents', 'packages']);
+});
+
+it('writes in the format Boost uses: four-space pretty print, unescaped slashes, trailing newline', function (): void {
+    zzWriteBoostJson($this->path, ['guidelines' => true, 'packages' => []]);
+
+    (new BoostConfig($this->path))->ensure(['noerd/noerd'], ['noerd-testing']);
+
+    $expected = ['guidelines' => true, 'packages' => ['noerd/noerd'], 'skills' => ['noerd-testing']];
+
+    expect(File::get($this->path))->toBe(json_encode($expected, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL);
+});
+
+it('creates a missing list key but never a missing file', function (): void {
+    zzWriteBoostJson($this->path, ['guidelines' => true]);
+    (new BoostConfig($this->path))->ensure(['noerd/noerd'], []);
+    expect((new BoostConfig($this->path))->packages())->toBe(['noerd/noerd']);
+
+    $missing = new BoostConfig($this->dir . '/nope.json');
+    expect($missing->exists())->toBeFalse()
+        ->and($missing->ensure(['noerd/noerd'], []))->toBe(['packages' => [], 'skills' => []])
+        ->and(File::exists($this->dir . '/nope.json'))->toBeFalse();
+});
+
+it('does not overwrite a file that is not a JSON object', function (): void {
+    File::put($this->path, "{ not json\n");
+
+    $config = new BoostConfig($this->path);
+
+    expect($config->exists())->toBeTrue()
+        ->and($config->isValid())->toBeFalse()
+        ->and($config->ensure(['noerd/noerd'], []))->toBe(['packages' => [], 'skills' => []])
+        ->and(File::get($this->path))->toBe("{ not json\n");
+});


### PR DESCRIPTION
## Summary
- `noerd:install` / `noerd:update` and every module command built on `HasModuleInstallation` now add their Composer package (and the `resources/boost/skills` names) to the host's `boost.json` and run `boost:update --no-interaction`, so the Boost guideline and skills reach every host without a manual step. Idempotent: entries are only ever added, nothing is written without a `boost.json`, a package missing under `vendor/` is skipped with a warning (Boost would drop it again), and `boost:update` runs once per process unless a new entry was added (`noerd:update-all`).
- New `Noerd\Support\BoostConfig` (JSON handling in Boost's own format) and `Noerd\Commands\Concerns\RegistersBoostPackage`.
- Guideline, docs and skills carry the rules that so far lived only in one host project: never `vendor/bin/pest --parallel` with Testbench, `TenantHelper::clearCache()` between component tests, embedded Livewire child rules, `applyLikeContains()` for sqlite-portable LIKE, unique names for admin-only components, no throwing `encrypted` cast for secrets, literal `$detailModel`/`$detailPrimary`/`$listModel`.
- `AGENTS.md`: the release bump goes through a PR like every change (`main` is protected); Composer fallback trap documented. Module stubs gain a "Reference implementations" section.

## Tests
- `tests/Unit/BoostConfigTest.php`, `tests/Commands/RegistersBoostPackageTest.php` (new), `NoerdInstallCommandTest`, `NoerdUpdateCommandTest`, `ModuleInstallationTest` extended.
- Full package suite: 1416 passed.