### PR TITLE
Bump version to v0.16.10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
             "name": "Johannes Brock"
         }
     ],
-    "version": "v0.16.9",
+    "version": "v0.16.10",
     "license": "MIT",
     "require": {
         "php": "^8.3",


### PR DESCRIPTION
Release v0.16.10: the install/update commands register the package in the host boost.json (#135).