### PR TITLE
Split the list header into a title row and a scrolling filter row with shared pagination

### DIFF
--- a/docs/header-actions.md
+++ b/docs/header-actions.md
@@ -4,7 +4,7 @@ Header actions let a module contribute small Livewire components to the header o
 
 ## Concept
 
-- **Separate slots for lists and details.** The registry keeps two independent lists: list actions render among the list header controls (`table/list-controls-primary` in the standard list header; injected by `modal-title` for a `NoerdList` host with a custom header slot), detail actions render in the header of every `*-detail` component (`modal-title`). An action that should appear in both contexts must be registered twice — there is no shared slot.
+- **Separate slots for lists and details.** The registry keeps two independent lists: list actions render among the list header controls (`table/list-controls-registry`: in the right group of the filter row in the standard list header; injected next to the buttons by `modal-title` for a `NoerdList` host with a custom header slot), detail actions render in the header of every `*-detail` component (`modal-title`). An action that should appear in both contexts must be registered twice — there is no shared slot.
 - **One action, one function, one Livewire component.** Every action is its own minimal Livewire component. It renders exactly one button (or nothing) and contains no logic for the other context.
 - **Actions own their visibility.** The core always mounts every registered action. The action itself decides in `mount()` whether it has something to show (permissions, current app, available configuration) and renders an empty root when hidden.
 

--- a/docs/list-filters.md
+++ b/docs/list-filters.md
@@ -79,57 +79,56 @@ The chip resolves both parts for display via `NoerdList::activeColumnFilterChips
 The type resolution (explicit YAML type → DB schema type) mirrors `applyColumnFilters()`, so a chip
 always describes the filter the query actually applies.
 
-### Responsive header (the filter drawer)
+### Header layout (title row + filter row)
 
-The generic list header is **one non-wrapping row at every viewport width** — it never breaks onto a
-second line, not even on a phone. Only two things are guaranteed a place on that row: the list title
-(with its record count and, where present, the view switcher) and the primary YAML actions. Everything
-else is *collapsible*:
+The generic list header is **two rows at every viewport width** — and neither of them ever wraps:
 
-- the header filters and the active-filter chips
-- the search field
-- CSV export and every YAML action marked `style: secondary`
+- **The title row** holds the list title with its record count (and the view switcher when the list
+  ships several YAML views) on the left, and every button on the right: the `style: secondary`
+  actions, CSV export and the primary "New …" actions. `x-noerd::modal-title` draws the grey
+  separator below it.
+- **The filter row** renders only when something belongs in it — a search field, header filters
+  or active-filter chips, or registry list actions (e.g. a module's layout and object
+  managers). Pagination alone never opens it. It has three zones:
+  1. the search field, left, at a fixed width (`w-40 sm:w-56`), OUTSIDE the scrolling strip;
+  2. the filters — YAML picklist/date filters, one chip per active column filter, the clear-all
+     button — inside a horizontally **scrolling strip** (`flex-1 min-w-0 overflow-x-scroll`);
+  3. on the right, the registry list actions followed by the pagination summary (`1-50 of 150`)
+     with icon-only previous/next buttons — the same partial the footer renders
+     (`noerd::components.table.list-pagination-nav`).
 
-Below `xl` the collapsible controls move into a drawer behind a funnel button next to the title;
-from `xl` on they sit inline on the header row.
+The strip is built exactly like the quick-menu: `overflow-x-scroll` (not `auto`) keeps the 6px
+scrollbar track permanently reserved and `-mb-[6px]` pulls it out of the layout, so nothing shifts
+when scrolling becomes possible; `noerd-scrollbar-idle` hides the thumb while nothing overflows,
+kept in sync by the `noerdScrollShadow` Alpine data (a `ResizeObserver` that only toggles that
+class — it never measures widths to position anything). Every control in the strip is `shrink-0`,
+so an overflowing filter set scrolls rather than squeezing, wrapping or collapsing.
 
-The switch is **pure CSS**. The controls are rendered exactly once: one container is the inline row
-from `xl` on (`xl:flex-row`) and the drawer panel below it (`max-xl:fixed max-xl:inset-y-0
-max-xl:right-0 max-xl:flex-col`). There is no second copy, so nothing has to keep two sets of
-`wire:key`s, Alpine states or keyboard shortcuts apart — the only JavaScript involved is
-`x-data="{ drawer: false }"`.
+Popovers are safe inside the strip: the picklist filter is a native `<select>`, the date dropdown
+anchors its panels with `x-anchor.fixed` (a scroll container clips absolutely positioned children on
+both axes), and chips have none. The view switcher sits on the title row.
 
-- The order differs per layout and is expressed with flex `order-*`: in the drawer the search comes
-  first, then the filters, then the buttons; on the header row the filters lead and the search plus
-  buttons are pushed right.
-- The individual controls go full-width in the drawer through `max-xl:w-full`. `x-noerd::button`
-  centres itself with `my-auto` for the header ROW, so a stacked button cancels it with
-  `max-xl:!my-0` — in a flex COLUMN that auto margin would absorb the free vertical space.
-- The funnel carries a count badge of everything the drawer is hiding: active header filters, active
-  column-filter chips, and a non-empty search.
-- A header with nothing collapsible renders no funnel button and no drawer.
-- From `xl` on, a filter row that still outgrows its space scrolls horizontally
-  (`xl:overflow-x-auto`) rather than being hidden.
-
-What each list header actually renders is resolved ONCE by `NoerdList::headerControls()` (with
-`hasCollapsibleControls()` / `hasHeaderControls()` on top). The header, the drawer and
+There is no drawer, no funnel button and no breakpoint-specific stacking at any width. What each
+list header actually renders is resolved ONCE by `NoerdList::headerControls()` (with
+`hasCollapsibleControls()` / `hasHeaderControls()` on top). The header rows and
 `x-noerd::modal-title` all read that — never re-derive "does this list have a search field / a
 secondary action" from `$listSettings` at a call site.
 
-This is a single generic feature of `list-header.blade.php` — never rebuild a responsive header per
-module, and never add breakpoint-specific stacking to a list header.
+This is a single generic feature of `list-header.blade.php` — never rebuild a list header per
+module, never add breakpoint stacking or a drawer to one, and never position header controls with
+JavaScript.
 
 ### Architecture
 
 - Expression parsing + query application: `Noerd\Services\ColumnFilterParser` (fixed operator set, values only ever bound as parameters — user input never reaches SQL text)
 - State + whitelist: `NoerdList::$listColumnFilters`, `setColumnFilter()`, `clearColumnFilter()`, `filterableColumnFields()`, `applyColumnFilters()` (hooked inside `listQuery()`)
 - Header UI: `noerd::components.table.column-filter`, included from `table-sort.blade.php`; active-filter chips: `NoerdList::activeColumnFilterChips()`, rendered in `noerd::components.table.list-header`
-- Responsive header: `noerd::components.table.list-header` (row + drawer) including `list-filters`,
-  `list-search` and `list-controls-secondary` (the collapsing half) plus `list-controls-primary`
-  (always visible); `NoerdList::headerControls()` resolves which of them exist. A list host with its
-  own custom header slot gets the non-collapsing `list-controls` injected by `x-noerd::modal-title`
-  instead
-- Tests: `tests/Unit/ColumnFilterParserTest.php`, `tests/Feature/NoerdListColumnFilterTest.php`, `tests/Components/ListHeaderTest.php` (package root)
+- Header rows: `noerd::components.table.list-header` (title row + filter row) including
+  `list-controls-secondary` and `list-controls-primary` (title row), `list-search`, `list-filters`,
+  `list-controls-registry` and `list-pagination-nav` (filter row); `NoerdList::headerControls()`
+  resolves which of them exist. A list host with its own custom header slot gets the one-row
+  `list-controls` injected by `x-noerd::modal-title` instead
+- Tests: `tests/Unit/ColumnFilterParserTest.php`, `tests/Feature/NoerdListColumnFilterTest.php`, `tests/Components/ListHeaderTest.php`, `tests/Components/ListPaginationTest.php` (package root)
 
 ## How Filters Work
 

--- a/docs/list-view.md
+++ b/docs/list-view.md
@@ -498,13 +498,15 @@ actions:
 - No `actions` key means no button is rendered
 
 **Where the controls render:** the standard list header (`noerd::components.table.list-header`,
-rendered by `<x-noerd::list />`) draws the search field, CSV export, registry list actions and the
-YAML action buttons itself — as one responsive row whose collapsible half moves into a filter
-drawer on small screens (owner: [List Filters](list-filters.md#responsive-header-the-filter-drawer)).
-A component with its OWN custom `<x-slot:header>` (e.g. a list nested in tab panels) gets the same
-controls injected by `x-noerd::modal-title` (`noerd::components.table.list-controls`): wrap the
-custom title in `<x-noerd::modal-title>` and they appear top right automatically — never hand-roll
-a search field or action buttons in a list header. Two props on `x-noerd::modal-title` tune the
+rendered by `<x-noerd::list />`) is two rows: the title row carries the title with its record
+count and, right-aligned, every button (CSV export, `style: secondary` and primary YAML actions);
+the filter row below carries the search field, the filters in a horizontally scrolling strip, the
+registry list actions and the pagination summary with its page buttons (owner:
+[List Filters](list-filters.md#header-layout-title-row--filter-row)). A component with its OWN
+custom `<x-slot:header>` (e.g. a list nested in tab panels) gets the same controls injected in one
+row by `x-noerd::modal-title` (`noerd::components.table.list-controls`): wrap the custom title in
+`<x-noerd::modal-title>` and they appear top right automatically — never hand-roll a search field
+or action buttons in a list header. Two props on `x-noerd::modal-title` tune the
 injection:
 
 | Prop | Description |
@@ -549,6 +551,19 @@ public function openImportModal(mixed $modelId = null, array $relations = []): v
 Requires the facade import: `use Noerd\Facades\Noerd;`
 
 Custom methods must accept `(mixed $modelId = null, array $relations = [])` parameters to match the expected signature.
+
+## Pagination
+
+Every list is paginated (`WithPagination`, page state kept out of the URL). The navigation —
+the summary `1-50 of 150` plus icon-only previous/next buttons — is ONE partial
+(`noerd::components.table.list-pagination-nav`, expecting a `$paginator`) rendered twice: in the
+right group of the header's filter row (only while the list has rows) and in the pagination footer
+(`noerd::pagination`). The two can therefore never drift apart; never render page buttons by hand.
+
+The rows-per-page select lives in the footer only. Its options are `10, 25, 50, 100, 200` — never
+above `NoerdList::MAX_PER_PAGE` (200), which `clampPerPage()` enforces on every update and on the
+session-restored value in `mountList()`. The chosen size is persisted per list in the session
+(`listPerPage.{component}`).
 
 ## Multi-Select & Bulk Actions
 
@@ -681,7 +696,7 @@ rendered below the form of a detail view. In compact mode the list renders only 
 
 - the list header (title, search field and action buttons such as "New …")
 - the inline list description
-- the pagination footer (the "Showing 1 to N of N results" row and the per-page select)
+- the pagination footer (the `1-50 of 150` summary, the per-page select and the page buttons)
 
 `compact` is a public property on the `NoerdList` trait, so it works exactly like `disableModal` —
 just add it as an attribute on the embedded Livewire component.
@@ -835,8 +850,8 @@ searchableColumns:
   - sku
 ```
 
-Grid mode swaps only the rows block (`noerd::components.list.grid`) — the list header (title,
-search, view switcher, actions, filter chips), the pagination footer, the picker/bulk footers and
+Grid mode swaps only the rows block (`noerd::components.list.grid`) — the list header rows (title,
+search, view switcher, actions, filter chips, pagination), the pagination footer, the picker/bulk footers and
 the object-permission handling stay exactly as in table mode.
 
 **Card content** is derived from the `columns` array: the first column with a non-empty value

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -491,8 +491,16 @@ public function openImportModal(mixed $modelId = null, array $relations = []): v
 - Custom methods must accept `(mixed $modelId = null, array $relations = [])` parameters
 - No `actions` key means no button is rendered
 - The `action` value must always be explicitly set (no implicit fallback to `listAction`)
+- The generic list header is TWO rows and never anything else: the title row (title + record
+  count, every button right-aligned) and the filter row (search field left, the filters in a
+  horizontally SCROLLING strip built like the quick-menu, registry actions and the pagination
+  summary `1-50 of 150` with icon-only page buttons right). The filter row renders only when a
+  search field, filters or registry actions exist. Never add breakpoint stacking, a drawer or
+  width-measuring JavaScript to a list header; the same page buttons and summary render again in
+  the footer through the one partial `noerd::components.table.list-pagination-nav`, next to the
+  footer-only rows-per-page select (options never above `NoerdList::MAX_PER_PAGE`)
 
-**Reference:** `docs/list-view.md` ("Actions")
+**Reference:** `docs/list-view.md` ("Actions", "Pagination"), `docs/list-filters.md` ("Header layout")
 
 ### Picklist Columns Render as Translated Badges in Lists
 When a list column displays a picklist/select value, it must ALWAYS be shown as a **badge** with the
@@ -619,7 +627,7 @@ related list rendered inside a detail view). In compact mode the list renders on
 
 - the list header is hidden (title, search field and action buttons / "New …")
 - the inline list description is hidden
-- the pagination footer is hidden (the "Showing 1 to N of N results" row and the per-page select)
+- the pagination footer is hidden (the `1-50 of 150` summary, the per-page select and the page buttons)
 
 **Enabling it** — pass the `compact` attribute when embedding the list Livewire component, exactly
 like `disableModal`:

--- a/resources/boost/skills/noerd-list-development/SKILL.md
+++ b/resources/boost/skills/noerd-list-development/SKILL.md
@@ -87,7 +87,10 @@ columns:
 ```
 
 Checklist of optional YAML features (all generic, never re-implement in the component):
-- `actions:` — several header buttons (`route:` / `action:`, `heroicon`, `style: secondary`)
+- `actions:` — several header buttons (`route:` / `action:`, `heroicon`, `style: secondary`); they
+  render on the header's title row, while search, filters and the pagination summary render on
+  the filter row below it (the filters scroll horizontally, nothing wraps) — never hand-build
+  either row
 - `multiSelect: true` + `bulkActions:` (`deleteSelected` is built in; custom bulk methods read
   `$this->selectedRecordIds`)
 - `displayMode: grid` + `gridColumns:` — card layout, row click unchanged

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -1,4 +1,5 @@
 {
+    ":from-:to of :total": ":from-:to von :total",
     "A collection with this filename already exists.": "Eine Collection mit diesem Dateinamen existiert bereits.",
     "A new tenant contains its own master and transactional data, but can be managed with the same users.": "Ein neuer Mandant enthält eigene Stamm- und Bewegungsdaten, kann aber mit denselben Benutzern verwaltet werden.",
     "A new verification link has been sent to your email address.": "Ein neuer Bestätigungslink wurde an Ihre E-Mail-Adresse versendet.",
@@ -215,6 +216,7 @@
     "Orders": "Bestellungen",
     "Overview of your current access rights to tenants and assigned profiles.": "Übersicht über Ihre aktuellen Zugriffsrechte auf Mandanten und zugewiesene Profile.",
     "Overwrites the user's password. Can only be set by administrators.": "Überschreibt das Passwort des Benutzers. Kann nur von Administratoren gesetzt werden.",
+    "Pagination Navigation": "Seitennavigation",
     "Paid": "Bezahlt",
     "Part": "Teil",
     "Password": "Passwort",
@@ -231,6 +233,7 @@
     "Profile Information": "Profilinformationen",
     "Read Only": "Nur Lesen",
     "Really delete this collection and all :count entries?": "Diese Collection und alle :count Einträge wirklich löschen?",
+    "Rows per page": "Zeilen pro Seite",
     "Remember me": "Angemeldet bleiben",
     "Remove all": "Alle entfernen",
     "Remove file": "Datei entfernen",

--- a/resources/views/components/filters/date-dropdown.blade.php
+++ b/resources/views/components/filters/date-dropdown.blade.php
@@ -1,5 +1,5 @@
-{{-- The control is full-width below `xl` (where it lives in the stacked filter drawer)
-     and inline-sized from `xl` on. `full` forces the full-width layout at every width. --}}
+{{-- A header filter inside the list's scrolling filter strip: never shrinks, never
+     wraps. `full` forces a full-width layout for hosts that lay filters out themselves. --}}
 @props(['filter', 'value' => '', 'full' => false])
 
 @php
@@ -12,9 +12,9 @@
      filter bar (an `overflow-x` ancestor clips absolutely positioned children vertically too). --}}
 <div x-data="{ open: false, showDatePicker: false, customDate: '{{ $isCustomDate ? $value : '' }}' }"
      @click.outside="open = false; showDatePicker = false"
-     class="relative {{ $full ? 'w-full' : 'max-xl:w-full xl:mr-4 xl:shrink-0' }}">
+     class="relative {{ $full ? 'w-full' : 'shrink-0' }}">
     <button x-ref="trigger_{{ $filter['column'] }}" @click="open = !open; showDatePicker = false" type="button"
-            class="{{ $active ? 'border-brand-primary! border-solid! border-2!' : 'border border-dashed border-zinc-300' }} {{ $full ? 'w-full' : 'max-xl:w-full' }} flex items-center gap-1 rounded-md px-3 h-8 py-1 text-sm leading-[1.375rem] focus:outline-none focus:ring-2 focus:ring-brand-border whitespace-nowrap">
+            class="{{ $active ? 'border-brand-primary! border-solid! border-2!' : 'border border-dashed border-zinc-300' }} {{ $full ? 'w-full' : '' }} flex items-center gap-1 rounded-md px-3 h-8 py-1 text-sm leading-[1.375rem] focus:outline-none focus:ring-2 focus:ring-brand-border whitespace-nowrap">
         <span>{{ $filter['label'] }}</span>
         @if($active)
             <span class="text-gray-400 mx-0.5">|</span>

--- a/resources/views/components/filters/picklist.blade.php
+++ b/resources/views/components/filters/picklist.blade.php
@@ -1,10 +1,10 @@
-{{-- The control is full-width below `xl` (where it lives in the stacked filter drawer)
-     and inline-sized from `xl` on. `full` forces the full-width layout at every width. --}}
+{{-- A header filter inside the list's scrolling filter strip: never shrinks, never
+     wraps. `full` forces a full-width layout for hosts that lay filters out themselves. --}}
 @props(['filter', 'value' => '', 'full' => false])
 
 <select wire:change="storeActiveListFilters"
         wire:model.live="listFilters.{{ $filter['column'] }}"
-        class="@if($value !== '') border-brand-primary! border-solid! border-2! @endif {{ $full ? 'w-full' : 'max-xl:w-full xl:mr-4 xl:min-w-36 xl:max-w-48 xl:shrink-0' }} truncate rounded-md border border-dashed border-zinc-300 px-3 h-8 py-1 pr-8 text-sm leading-[1.375rem] focus:outline-none focus:ring-2 focus:ring-brand-border">
+        class="@if($value !== '') border-brand-primary! border-solid! border-2! @endif {{ $full ? 'w-full' : 'min-w-36 max-w-48 shrink-0' }} truncate rounded-md border border-dashed border-zinc-300 px-3 h-8 py-1 pr-8 text-sm leading-[1.375rem] focus:outline-none focus:ring-2 focus:ring-brand-border">
     <option value="">{{ $filter['label'] }}</option>
     @foreach($filter['options'] ?? [] as $key => $option)
         <option value="{{ $key }}">{{ $option }}</option>

--- a/resources/views/components/modal-title.blade.php
+++ b/resources/views/components/modal-title.blade.php
@@ -7,8 +7,8 @@
     'listRelations' => [],
     /**
      * Keep the header on ONE non-wrapping row at every breakpoint instead of stacking
-     * below `lg`. Set by the generic list header, which collapses its overflowing
-     * controls into the filter drawer rather than onto a second line.
+     * below `lg`. Set by the generic list header, whose title row carries only the
+     * title and the buttons; search and filters sit on the filter row below it.
      */
     'row' => false,
 ])

--- a/resources/views/components/table/list-controls-primary.blade.php
+++ b/resources/views/components/table/list-controls-primary.blade.php
@@ -1,32 +1,12 @@
 {{--
-    The list header controls that always stay on the header row, next to the title:
-    the registry list actions and every YAML action that is not `style: secondary`.
-    These never move into the filter drawer — the primary call to action of a list
-    has to remain reachable at every viewport width.
+    The primary list buttons: every YAML action that is not `style: secondary`,
+    rendered on the TITLE row, right-aligned, at every viewport width — the primary
+    call to action of a list is never moved anywhere else. The registry list
+    actions live in list-controls-registry.
 
     Expects: $host (the NoerdList Livewire component), $controls (see
     NoerdList::headerControls()), $listRelations.
 --}}
-@if ($controls['registry'] !== [])
-    {{-- Collapses when every action hid itself: the children are server-rendered
-         before Alpine initializes, so probing for a button is reliable. Without
-         this an empty wrapper would still carry the parent's gap. --}}
-    <div
-        x-data="{ hasActions: false }"
-        x-init="hasActions = $el.querySelector('button') !== null"
-        x-show="hasActions"
-        x-cloak
-        class="flex shrink-0 items-center gap-2"
-    >
-        @foreach ($controls['registry'] as $listHeaderAction)
-            @livewire($listHeaderAction, [
-                'model' => $host->listModel ?? null,
-                'component' => $host->getComponentName(),
-            ], key('list-header-action-' . $listHeaderAction))
-        @endforeach
-    </div>
-@endif
-
 @if ($controls['primary'] !== [])
     <div class="flex shrink-0 gap-2">
         @foreach ($controls['primary'] as $actionIndex => $actionItem)
@@ -63,8 +43,7 @@
                     {{ __($actionItem['label']) }}
                     @if ($shortcut !== null)
                         {{-- Hidden on touch widths: the badge only advertises a keyboard
-                             shortcut and would widen the button on a phone, where the
-                             header has to stay on a single row. --}}
+                             shortcut and would widen the button on a phone. --}}
                         <kbd class="ml-2 hidden rounded border border-white/30 bg-white/20 px-1 py-0.5 text-xs text-brand-primary-text lg:inline-block">{{ $shortcut['badge'] }}</kbd>
                     @endif
                 </x-noerd::button>

--- a/resources/views/components/table/list-controls-registry.blade.php
+++ b/resources/views/components/table/list-controls-registry.blade.php
@@ -1,0 +1,28 @@
+{{--
+    The registry list actions (HeaderActionsRegistry::listActions(), e.g. a
+    module's layout or object manager buttons). The generic list header
+    renders them in the right group of its filter row; a list host with its own
+    custom header gets them from list-controls, after the search and the buttons.
+
+    Expects: $host (the NoerdList Livewire component), $controls (see
+    NoerdList::headerControls()).
+--}}
+@if ($controls['registry'] !== [])
+    {{-- Collapses when every action hid itself: the children are server-rendered
+         before Alpine initializes, so probing for a button is reliable. Without
+         this an empty wrapper would still carry the parent's gap. --}}
+    <div
+        x-data="{ hasActions: false }"
+        x-init="hasActions = $el.querySelector('button') !== null"
+        x-show="hasActions"
+        x-cloak
+        class="flex shrink-0 items-center gap-2"
+    >
+        @foreach ($controls['registry'] as $listHeaderAction)
+            @livewire($listHeaderAction, [
+                'model' => $host->listModel ?? null,
+                'component' => $host->getComponentName(),
+            ], key('list-header-action-' . $listHeaderAction))
+        @endforeach
+    </div>
+@endif

--- a/resources/views/components/table/list-controls-secondary.blade.php
+++ b/resources/views/components/table/list-controls-secondary.blade.php
@@ -1,9 +1,8 @@
 {{--
-    The list header's secondary buttons: CSV export and every YAML action marked
-    `style: secondary`. Rendered ONCE — below `xl` they stack full-width in the
-    filter drawer, from `xl` on they sit on the header row. The layout switch is
-    pure CSS (`max-xl:` / `xl:`), so there is no second copy and therefore no key
-    prefix, no `stacked` flag and no shortcut that could fire twice.
+    The list's secondary buttons: CSV export and every YAML action marked
+    `style: secondary`. They sit on the TITLE row next to the primary buttons —
+    the title row holds every button, the filter row below holds search, filters
+    and pagination.
 
     Expects: $host (the NoerdList Livewire component), $controls (see
     NoerdList::headerControls()), $listRelations.
@@ -13,10 +12,7 @@
         wire:key="list-csv-export"
         variant="secondary"
         icon="arrow-down-tray"
-        {{-- x-noerd::button centres itself with `my-auto` for the header ROW; in the
-             drawer's flex COLUMN that margin would absorb the free vertical space
-             and scatter the buttons down the panel. --}}
-        class="max-xl:!my-0 max-xl:w-full xl:h-8 xl:shrink-0"
+        class="h-8 shrink-0"
         title="{{ __('Export CSV') }}"
         wire:click="exportCsv"
     >
@@ -44,7 +40,7 @@
     @endphp
     <div
         wire:key="list-secondary-action-{{ $actionIndex }}"
-        class="max-xl:w-full xl:shrink-0"
+        class="shrink-0"
         @if ($shortcut !== null)
             x-data
             @keydown.window="let e = $event; if ({{ $shortcut['js'] }}) { e.preventDefault(); $refs.actionBtn{{ $actionIndex }}.click(); }"
@@ -54,12 +50,12 @@
             variant="secondary"
             :icon="$actionItem['heroicon'] ?? null"
             x-ref="actionBtn{{ $actionIndex }}"
-            class="relative max-xl:!my-0 max-xl:w-full xl:h-8"
+            class="relative h-8 whitespace-nowrap"
             @click.prevent="{{ $clickExpression }}"
         >
             {{ __($actionItem['label']) }}
             @if ($shortcut !== null)
-                <kbd class="ml-2 hidden rounded border border-gray-300 bg-gray-100 px-1 py-0.5 text-xs text-gray-500 xl:inline-block">{{ $shortcut['badge'] }}</kbd>
+                <kbd class="ml-2 hidden rounded border border-gray-300 bg-gray-100 px-1 py-0.5 text-xs text-gray-500 lg:inline-block">{{ $shortcut['badge'] }}</kbd>
             @endif
         </x-noerd::button>
     </div>

--- a/resources/views/components/table/list-controls.blade.php
+++ b/resources/views/components/table/list-controls.blade.php
@@ -1,9 +1,10 @@
 {{--
-    Generic list header controls for a header that does NOT collapse: CSV export,
-    search, registry list actions and the YAML `actions` buttons, in one row.
-    Included by x-noerd::modal-title for a NoerdList host that brings its own custom
-    header slot. The generic list-header renders the same partials itself instead,
-    so the collapsing half can double as the filter drawer — see list-header.
+    Generic list header controls for a list host that brings its OWN custom header
+    slot (e.g. a list nested in tab panels): search, CSV export, the `style:
+    secondary` actions, the registry list actions and the primary YAML buttons, in
+    one row. Included by x-noerd::modal-title. The generic list-header renders the
+    same partials itself, spread over its title row and its filter row — see
+    list-header.
 
     Expects: $host (the NoerdList Livewire component), $listRelations. Positioning
     (ml-auto, modal controls offset) is owned by the modal-title wrapper — never add
@@ -22,5 +23,7 @@
         @include('noerd::components.table.list-controls-secondary', $controlArguments)
     </div>
 @endif
+
+@include('noerd::components.table.list-controls-registry', $controlArguments)
 
 @include('noerd::components.table.list-controls-primary', $controlArguments)

--- a/resources/views/components/table/list-filters.blade.php
+++ b/resources/views/components/table/list-filters.blade.php
@@ -1,9 +1,8 @@
 {{--
-    The list header's filter controls: the YAML picklist/date filters, one chip per
-    active Excel-style column filter and the clear-all button. Rendered ONCE — below
-    `xl` they stack full-width in the filter drawer, from `xl` on they sit inline on
-    the header row. The layout switch is pure CSS, so there is no second copy and
-    hence no key prefix to keep the two apart.
+    The list's filter controls: the YAML picklist/date filters, one chip per
+    active Excel-style column filter and the clear-all button. Rendered ONCE,
+    inside the horizontally scrolling strip of the filter row — every control is
+    `shrink-0`, so the strip grows and scrolls instead of squeezing or wrapping.
 --}}
 @foreach ($tableFilters as $tableFilter)
     @if (in_array($tableFilter['type'] ?? 'Picklist', ['ShowFrom', 'ShowUntil']))
@@ -20,15 +19,15 @@
 @foreach ($chips as $filterChip)
     <span
         wire:key="column-filter-chip-{{ $filterChip['field'] }}"
-        class="flex items-center gap-1 rounded-full bg-gray-100 py-0.5 pr-1 pl-2.5 text-xs font-normal whitespace-nowrap text-gray-700 max-xl:w-full max-xl:justify-start xl:shrink-0"
+        class="flex shrink-0 items-center gap-1 rounded-full bg-gray-100 py-0.5 pr-1 pl-2.5 text-xs font-normal whitespace-nowrap text-gray-700"
     >
         <span class="font-medium">{{ $filterChip['label'] }}:</span>
-        <span class="truncate">{{ $filterChip['value'] }}</span>
+        <span class="max-w-48 truncate">{{ $filterChip['value'] }}</span>
         <button
             type="button"
             wire:click="clearColumnFilter('{{ $filterChip['field'] }}')"
             title="{{ __('Clear filter') }}"
-            class="ml-auto rounded-full p-0.5 text-gray-500 hover:bg-gray-200 hover:text-gray-700"
+            class="rounded-full p-0.5 text-gray-500 hover:bg-gray-200 hover:text-gray-700"
         >
             <x-dynamic-component component="heroicons::mini.solid.x-mark" class="size-3" />
         </button>
@@ -36,18 +35,14 @@
 @endforeach
 
 @if ($hasClearAll)
-    {{-- One button in both layouts: a labelled full-width row in the drawer, a bare
-         icon button on the header row. `!my-0` cancels the button's row-centring
-         auto margin, which the drawer's flex COLUMN would otherwise stretch. --}}
     <x-noerd::button
         variant="secondary"
         size="sm"
         icon="x-mark"
         type="button"
-        class="max-xl:!my-0 max-xl:w-full xl:shrink-0 xl:px-1.5"
+        class="shrink-0 px-1.5"
         wire:click="clearAllListFilters"
         :title="__('Clear all filters')"
-    >
-        <span class="xl:hidden">{{ __('Clear all filters') }}</span>
-    </x-noerd::button>
+        :aria-label="__('Clear all filters')"
+    />
 @endif

--- a/resources/views/components/table/list-header.blade.php
+++ b/resources/views/components/table/list-header.blade.php
@@ -1,193 +1,142 @@
 <x-slot:header>
-    {{-- The generic list header is ONE non-wrapping row at every viewport width
-         (`row` on modal-title). From `xl` on, the filters, the search field, CSV
-         export and the `style: secondary` actions sit inline on that row; below it
-         they move into a drawer behind the funnel button instead of wrapping onto
-         further lines, which is what makes the header usable on a phone. Only the
-         title and the primary actions are on the row at every width.
+    {{-- The generic list header is TWO rows at every viewport width:
 
-         Everything is rendered ONCE — the controls container below IS the drawer
-         panel below `xl` and the inline row from `xl` on, switched by `max-xl:` /
-         `xl:` classes. Nothing is duplicated, so there is no key prefix, no
-         `stacked` flag and no shortcut that could fire twice.
+         • The TITLE row (modal-title, `row` = one non-wrapping flex line): the
+           list title with its record count (and the view switcher when the list
+           ships several YAML views) on the left, every button on the right — the
+           `style: secondary` actions, CSV export and the primary "New …" actions.
+           modal-title draws the grey separator below it.
+         • The FILTER row, rendered only when something belongs in it (a search
+           field, header filters/chips, or registry list actions): the search field
+           on the left, the filters in a horizontally SCROLLING strip next to it,
+           and on the right the registry list actions (e.g. a module's layout
+           and object managers) followed by the pagination summary with its
+           previous/next buttons.
+
+         Neither row ever wraps and nothing collapses into a drawer: the three
+         zones of the filter row are `shrink-0` | `flex-1 min-w-0` | `shrink-0`,
+         so any overflow goes into the middle strip, which scrolls exactly like
+         the quick-menu. No JavaScript measures or positions anything —
+         `noerdScrollShadow` only toggles the idle scrollbar class.
+
+         Both rows live in the page's header slot, i.e. above the scrolling body,
+         so they stay put while the table scrolls.
 
          The controls are included here rather than injected by modal-title
-         (:listControls="false") because they have to sit inside this row. --}}
+         (:listControls="false") because they are spread over the two rows. --}}
+    @php
+        $controls = $this->headerControls();
+        $filterChips = $this->activeColumnFilterChips;
+        $hasFilters = (bool) $this->tableFilters || $filterChips !== [];
+        $paginator = isset($rows) && ! is_array($rows) ? $rows : null;
+
+        // The filter row exists only when something belongs in it. Pagination
+        // alone never opens it — the footer already carries the same navigation.
+        $hasFilterRow = $controls['search'] || $hasFilters || $controls['registry'] !== [];
+
+        $controlArguments = [
+            'host' => $this,
+            'controls' => $controls,
+            'listRelations' => $relations ?? [],
+            'tableFilters' => $this->tableFilters,
+            'listFilters' => $this->listFilters,
+            'chips' => $filterChips,
+            'hasClearAll' => collect($this->listFilters)->filter()->isNotEmpty() || count($filterChips) > 1,
+        ];
+    @endphp
+
     <x-noerd::modal-title :listRelations="$relations ?? []" :listControls="false" row>
-        @php
-            $controls = $this->headerControls();
-            $filterChips = $this->activeColumnFilterChips;
-            $hasFilters = (bool) $this->tableFilters || $filterChips !== [];
-            $hasDrawer = $hasFilters || $this->hasCollapsibleControls();
+        <div class="flex w-full min-w-0 items-center">
+            {{-- The title must never clip its own overflow: the view switcher's
+                 dropdown is an absolutely positioned child of it, and an
+                 `overflow: hidden` here would swallow the whole panel. Only the
+                 title TEXT truncates, one level further in. --}}
+            <div class="min-w-0">
+                @if (count($listViews ?? []) > 1)
+                    {{-- List-view switcher: pick one of several YAML views for this list --}}
+                    <x-noerd::action-menu align="left" width="w-56" wrapperClass="relative min-w-0">
+                        <x-slot:trigger>
+                            <button
+                                type="button"
+                                x-on:click="open = ! open"
+                                class="flex min-w-0 max-w-full cursor-pointer items-center gap-1 rounded focus:outline-hidden"
+                                :aria-expanded="open"
+                                aria-haspopup="true"
+                                title="{{ __('Switch list view') }}"
+                            >
+                                <span class="truncate">{{ $title }}</span>
+                                @if ($paginator !== null)
+                                    <span class="shrink-0 font-light">({{ $paginator->total() }})</span>
+                                @endif
+                                <x-noerd::icons.chevron-down class="my-auto shrink-0 text-gray-500" />
+                            </button>
+                        </x-slot:trigger>
 
-            // The badge counts everything the drawer hides from view, so an active
-            // search is still visible while the search field itself is in there.
-            $activeFilterCount = collect($this->listFilters)->filter()->count()
-                + count($filterChips)
-                + ($this->search !== '' ? 1 : 0);
-
-            $controlArguments = [
-                'host' => $this,
-                'controls' => $controls,
-                'listRelations' => $relations ?? [],
-                'tableFilters' => $this->tableFilters,
-                'listFilters' => $this->listFilters,
-                'chips' => $filterChips,
-                'hasClearAll' => collect($this->listFilters)->filter()->isNotEmpty() || count($filterChips) > 1,
-            ];
-        @endphp
-
-        <div
-            class="flex w-full min-w-0 items-center"
-            @if ($hasDrawer)
-                x-data="{ drawer: false }"
-                @keydown.escape.window="drawer = false"
-            @endif
-        >
-            <div class="flex min-w-0 shrink-0 items-center gap-2">
-                {{-- The title must never clip its own overflow: the view switcher's
-                     dropdown is an absolutely positioned child of it, and an
-                     `overflow: hidden` here would swallow the whole panel. Only the
-                     title TEXT truncates, one level further in. --}}
-                <div class="min-w-0">
-                    @if (count($listViews ?? []) > 1)
-                        {{-- List-view switcher: pick one of several YAML views for this list --}}
-                        <x-noerd::action-menu align="left" width="w-56" wrapperClass="relative min-w-0">
-                            <x-slot:trigger>
-                                <button
-                                    type="button"
-                                    x-on:click="open = ! open"
-                                    class="flex min-w-0 max-w-full cursor-pointer items-center gap-1 rounded focus:outline-hidden"
-                                    :aria-expanded="open"
-                                    aria-haspopup="true"
-                                    title="{{ __('Switch list view') }}"
-                                >
-                                    <span class="truncate">{{ $title }}</span>
-                                    @if (isset($rows) && ! is_array($rows))
-                                        <span class="shrink-0 font-light">({{ $rows->total() }})</span>
-                                    @endif
-                                    <x-noerd::icons.chevron-down class="my-auto shrink-0 text-gray-500" />
-                                </button>
-                            </x-slot:trigger>
-
-                            @foreach ($listViews as $viewKey => $view)
-                                <x-noerd::action-menu-item
-                                    wire:click="switchListView('{{ $viewKey }}')"
-                                    :active="$viewKey === $activeListView"
-                                >
-                                    {{ __($view['title']) }}
-                                    <span class="opacity-50">({{ $view['appLabel'] }})</span>
-                                </x-noerd::action-menu-item>
-                            @endforeach
-                        </x-noerd::action-menu>
-                    @else
-                        <div class="truncate">
-                            {{ $title }}
-                            @if (isset($rows) && ! is_array($rows))
-                                <span class="font-light"> ({{ $rows->total() }}) </span>
-                            @endif
-                        </div>
-                    @endif
-                </div>
-
-                @if ($hasDrawer)
-                    {{-- Opens the drawer. Only exists where the controls are in it. --}}
-                    <button
-                        type="button"
-                        x-on:click="drawer = true"
-                        class="relative inline-flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-sm border border-gray-300 text-gray-700 transition hover:bg-gray-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden xl:hidden"
-                        :aria-expanded="drawer"
-                        title="{{ __('Filters') }}"
-                    >
-                        <span class="sr-only">{{ __('Filters') }}</span>
-                        <x-dynamic-component component="heroicons::outline.funnel" class="size-4" />
-                        @if ($activeFilterCount > 0)
-                            <span class="absolute -top-1.5 -right-1.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-brand-primary px-1 text-[10px] leading-none font-semibold text-brand-primary-text">
-                                {{ $activeFilterCount }}
-                            </span>
+                        @foreach ($listViews as $viewKey => $view)
+                            <x-noerd::action-menu-item
+                                wire:click="switchListView('{{ $viewKey }}')"
+                                :active="$viewKey === $activeListView"
+                            >
+                                {{ __($view['title']) }}
+                                <span class="opacity-50">({{ $view['appLabel'] }})</span>
+                            </x-noerd::action-menu-item>
+                        @endforeach
+                    </x-noerd::action-menu>
+                @else
+                    <div class="truncate">
+                        {{ $title }}
+                        @if ($paginator !== null)
+                            <span class="font-light"> ({{ $paginator->total() }}) </span>
                         @endif
-                    </button>
+                    </div>
                 @endif
             </div>
 
-            @if ($hasDrawer)
-                {{-- Backdrop, drawer widths only. Sits above the modal stack (z-50/z-[60])
-                     so a list opened as a modal keeps its drawer usable. --}}
-                <div
-                    x-show="drawer"
-                    x-cloak
-                    x-transition:enter="transition ease-out duration-200"
-                    x-transition:enter-start="opacity-0"
-                    x-transition:enter-end="opacity-100"
-                    x-transition:leave="transition ease-in duration-150"
-                    x-transition:leave-start="opacity-100"
-                    x-transition:leave-end="opacity-0"
-                    x-on:click="drawer = false"
-                    class="fixed inset-0 z-[70] bg-gray-800/50 xl:hidden"
-                ></div>
-
-                {{-- THE controls. One element, two layouts:
-                     • from `xl`: a flex ROW inside the header, filters left, search and
-                       buttons pushed right (`xl:ml-auto` on the search group).
-                     • below `xl`: a full-height panel fixed to the right edge, stacked
-                       as a flex COLUMN — search first, then the filters, then the
-                       buttons, ordered with `order-*` rather than by rendering the
-                       groups a second time.
-                     Visibility below `xl` is driven by opacity/visibility (not
-                     `display`), so the panel can transition without a translate that
-                     would push the page into horizontal overflow. --}}
-                {{-- `xl:overflow-x-auto` makes the row scroll instead of wrap, but a
-                     scroll container clips BOTH axes (CSS forces `overflow-y` to
-                     `auto` as soon as one axis is not `visible`), and the row's box
-                     is exactly as tall as its 32px controls. Without room the focus
-                     ring of the search field (`ring-2` + `ring-offset-2`) is cut down
-                     to a bare sliver on its left. `xl:p-1.5` opens 6px on every side
-                     for it; the negative margins (and the reduced `xl:ml-2.5`) cancel
-                     that padding again, so the row sits exactly where it did. --}}
-                <div
-                    class="xl:-my-1.5 xl:-mr-1.5 xl:ml-2.5 xl:flex xl:min-w-0 xl:flex-1 xl:flex-row xl:items-center xl:gap-1 xl:overflow-x-auto xl:p-1.5
-                           max-xl:fixed max-xl:inset-y-0 max-xl:right-0 max-xl:z-[70] max-xl:flex max-xl:w-80 max-xl:max-w-[85vw] max-xl:flex-col max-xl:items-stretch max-xl:gap-3 max-xl:overflow-y-auto max-xl:bg-white max-xl:p-6 max-xl:text-sm max-xl:font-normal max-xl:shadow-xl max-xl:transition max-xl:duration-200"
-                    x-bind:class="drawer
-                        ? 'max-xl:visible max-xl:translate-x-0 max-xl:opacity-100'
-                        : 'max-xl:invisible max-xl:translate-x-2 max-xl:opacity-0'"
-                >
-                    {{-- Drawer chrome — no place on the inline row. --}}
-                    <div class="flex items-center border-b border-gray-300 pb-4 max-xl:order-first xl:hidden">
-                        <span class="font-semibold text-zinc-900">{{ __('Filters') }}</span>
-                        <button
-                            type="button"
-                            x-on:click="drawer = false"
-                            class="ml-auto inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-sm border border-gray-300 text-gray-700 transition hover:bg-gray-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden"
-                            title="{{ __('Close') }}"
-                        >
-                            <span class="sr-only">{{ __('Close') }}</span>
-                            <x-dynamic-component component="heroicons::mini.solid.x-mark" class="size-4" />
-                        </button>
-                    </div>
-
-                    @if ($controls['search'])
-                        <div class="max-xl:order-1 max-xl:w-full xl:order-2 xl:ml-auto xl:shrink-0 xl:pl-2">
-                            @include('noerd::components.table.list-search', $controlArguments)
-                        </div>
-                    @endif
-
-                    @if ($hasFilters)
-                        <div class="flex max-xl:order-2 max-xl:flex-col max-xl:gap-3 xl:order-1 xl:min-w-0 xl:items-center xl:gap-1">
-                            @include('noerd::components.table.list-filters', $controlArguments)
-                        </div>
-                    @endif
-
-                    @if ($controls['csv'] || $controls['secondary'] !== [])
-                        <div class="flex max-xl:order-3 max-xl:flex-col max-xl:gap-3 xl:order-3 xl:shrink-0 xl:items-center xl:gap-2 xl:pl-2">
-                            @include('noerd::components.table.list-controls-secondary', $controlArguments)
-                        </div>
-                    @endif
-                </div>
-            @endif
-
-            <div class="ml-auto flex shrink-0 items-center gap-4 pl-4" :class="isModal ? modalControlsClass : ''">
+            <div class="ml-auto flex shrink-0 items-center gap-2 pl-4" :class="isModal ? modalControlsClass : ''">
+                @include('noerd::components.table.list-controls-secondary', $controlArguments)
                 @include('noerd::components.table.list-controls-primary', $controlArguments)
             </div>
         </div>
     </x-noerd::modal-title>
+
+    @if ($hasFilterRow)
+        <div
+            wire:key="list-filter-row"
+            class="flex w-full min-w-0 items-center gap-x-2 border-b border-gray-300 px-6 py-2 text-sm font-normal"
+        >
+            @if ($controls['search'])
+                <div class="shrink-0">
+                    @include('noerd::components.table.list-search', $controlArguments)
+                </div>
+            @endif
+
+            @if ($hasFilters)
+                {{-- The scrolling strip, built like the quick-menu: overflow-x-scroll
+                     (not auto) keeps the 6px scrollbar track permanently reserved and
+                     -mb-[6px] cancels it out of the layout, so the controls never
+                     shift when the scrollbar appears — it draws in the row's bottom
+                     padding instead. noerd-scrollbar-idle hides the thumb while
+                     nothing overflows (a custom WebKit scrollbar would otherwise draw
+                     it at full length); noerdScrollShadow keeps the class in sync.
+
+                     A scroll container clips BOTH axes, so `p-1` opens 4px on every
+                     side for the controls' focus rings. Popovers are safe: the
+                     picklist is a native <select>, the date dropdown anchors with
+                     `x-anchor.fixed`, and chips have none. --}}
+                <div
+                    class="noerd-scrollbar noerd-scrollbar-idle -mb-[6px] flex min-w-0 flex-1 items-center gap-x-2 overflow-x-scroll p-1"
+                    x-data="noerdScrollShadow()"
+                >
+                    @include('noerd::components.table.list-filters', $controlArguments)
+                </div>
+            @endif
+
+            <div class="ml-auto flex shrink-0 items-center gap-2 pl-2">
+                @include('noerd::components.table.list-controls-registry', $controlArguments)
+                @if ($paginator !== null && $paginator->total() > 0)
+                    @include('noerd::components.table.list-pagination-nav', ['paginator' => $paginator])
+                @endif
+            </div>
+        </div>
+    @endif
 </x-slot:header>

--- a/resources/views/components/table/list-pagination-nav.blade.php
+++ b/resources/views/components/table/list-pagination-nav.blade.php
@@ -1,0 +1,46 @@
+{{--
+    Pagination summary ("1-50 of 150") plus icon-only previous/next buttons. ONE
+    partial for both places it appears — the right group of the list's filter row
+    and the pagination footer — so the two can never drift apart. It is rendered
+    twice per page with byte-identical markup: no wire:key, no placement suffix.
+
+    Expects: $paginator (a LengthAwarePaginator). Never reads $this — the footer
+    copy is rendered through $rows->links(), where the component is not in scope.
+
+    The buttons are labelled with aria-label, never with an sr-only span: sr-only
+    is position:absolute, and inside a button without its own positioning the
+    span escapes the body's scroll container and stretches the document.
+--}}
+@php
+    $pageName = $paginator->getPageName();
+@endphp
+
+<div class="flex shrink-0 items-center gap-2">
+    <span class="hidden whitespace-nowrap text-sm font-normal text-gray-700 tabular-nums sm:inline">
+        {{ __(':from-:to of :total', [
+            'from' => $paginator->firstItem() ?? 0,
+            'to' => $paginator->lastItem() ?? 0,
+            'total' => $paginator->total(),
+        ]) }}
+    </span>
+    <x-noerd::button
+        variant="control"
+        type="button"
+        icon="heroicons::mini.solid.chevron-left"
+        wire:click="previousPage('{{ $pageName }}')"
+        wire:loading.attr="disabled"
+        :disabled="$paginator->onFirstPage()"
+        :title="__('Previous')"
+        :aria-label="__('Previous')"
+    />
+    <x-noerd::button
+        variant="control"
+        type="button"
+        icon="heroicons::mini.solid.chevron-right"
+        wire:click="nextPage('{{ $pageName }}')"
+        wire:loading.attr="disabled"
+        :disabled="! $paginator->hasMorePages()"
+        :title="__('Next')"
+        :aria-label="__('Next')"
+    />
+</div>

--- a/resources/views/components/table/list-search.blade.php
+++ b/resources/views/components/table/list-search.blade.php
@@ -1,8 +1,8 @@
 {{--
-    The list header's search field. Rendered ONCE: below `xl` it sits in the filter
-    drawer, from `xl` on the header row — the same element, re-laid-out by CSS, so
-    there is no second copy whose wire:key, Alpine state and keyboard shortcut would
-    have to be kept apart from this one.
+    The list's search field: the first element of the filter row, OUTSIDE the
+    horizontally scrolling filter strip, so it never scrolls out of view and its
+    focus ring (`ring-2` + `ring-offset-2`) is never clipped by a scroll container.
+    A fixed width keeps the strip's free space predictable.
 
     Expects: $host (the NoerdList Livewire component).
 --}}
@@ -12,7 +12,7 @@
 
 <div
     wire:key="list-search"
-    class="relative max-xl:w-full xl:shrink-0"
+    class="relative w-40 shrink-0 sm:w-56"
     x-data="{ searchFocused: false }"
     @keydown.window="let e = $event; if ({{ $searchShortcut['js'] }}) { e.preventDefault(); $refs.searchInput.focus(); }"
 >
@@ -24,10 +24,10 @@
         placeholder="{{ __('Search') }}"
         wire:model.live.debounce.300ms="search"
         type="text"
-        class="mt-0! h-8 w-full xl:min-w-[200px] xl:pr-8"
+        class="mt-0! h-8 w-full pr-8"
     />
     {{-- The shortcut badge only advertises a keyboard affordance, so it stays on
-         keyboard widths — in the drawer it would just crowd the field. --}}
+         keyboard widths — on a phone it would just crowd the field. --}}
     <kbd
         x-show="! searchFocused"
         x-transition:enter="transition ease-out duration-100"
@@ -36,6 +36,6 @@
         x-transition:leave="transition ease-in duration-75"
         x-transition:leave-start="opacity-100"
         x-transition:leave-end="opacity-0"
-        class="pointer-events-none absolute top-1/2 right-1.5 hidden -translate-y-1/2 rounded border border-gray-300 bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500 xl:block"
+        class="pointer-events-none absolute top-1/2 right-1.5 hidden -translate-y-1/2 rounded border border-gray-300 bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500 lg:block"
     >{{ $searchShortcut['badge'] }}</kbd>
 </div>

--- a/resources/views/components/title.blade.php
+++ b/resources/views/components/title.blade.php
@@ -1,8 +1,8 @@
 @props([
     /**
      * Keep the header on ONE non-wrapping row at every breakpoint. Used by the generic
-     * list header, whose overflowing controls collapse into the filter drawer instead of
-     * wrapping onto further lines. Detail headers stay stacked below `lg`.
+     * list header, whose title row holds only the title and the buttons — search and
+     * filters live on their own row below it. Detail headers stay stacked below `lg`.
      */
     'row' => false,
 ])

--- a/resources/views/pagination.blade.php
+++ b/resources/views/pagination.blade.php
@@ -1,77 +1,28 @@
+{{-- The list's pagination footer: the rows-per-page select (footer only) and the
+     same summary + previous/next buttons the filter row shows at the top. --}}
 <div>
     <nav
         role="navigation"
-        aria-label="Pagination Navigation"
-        class="my-auto flex h-[44px]! items-center justify-between py-3"
+        aria-label="{{ __('Pagination Navigation') }}"
+        class="flex items-center justify-between py-3"
     >
-        {{-- Info text + per-page dropdown left --}}
-        <div class="hidden sm:flex sm:items-center sm:gap-4">
-            <p class="text-sm text-gray-700">
-                <span>{{ __('Showing') }}</span>
-                <span class="font-medium">{{ $paginator->firstItem() }}</span>
-                <span>{{ __('to') }}</span>
-                <span class="font-medium">{{ $paginator->lastItem() }}</span>
-                <span>{{ __('of') }}</span>
-                <span class="font-medium">{{ $paginator->total() }}</span>
-                <span>{{ __('results') }}</span>
-            </p>
+        {{-- The options never exceed NoerdList::MAX_PER_PAGE: clampPerPage()
+             would silently reject anything above it, leaving the select without
+             a matching option. --}}
+        <label class="flex items-center gap-2 text-sm text-gray-700">
+            <span class="whitespace-nowrap">{{ __('Rows per page') }}</span>
             <select
                 wire:model.live="perPage"
-                class="focus:border-brand-primary focus:ring-brand-primary cursor-pointer rounded-md border-gray-300 py-1 pr-7 pl-2 text-sm text-gray-700"
+                class="focus:border-brand-primary focus:ring-brand-primary h-8 cursor-pointer rounded-md border-gray-300 py-1 pr-7 pl-2 text-sm text-gray-700"
             >
-                @foreach ([10, 50, 100, 250, 500, 1000] as $size)
+                @foreach ([10, 25, 50, 100, 200] as $size)
                     <option value="{{ $size }}">{{ $size }}</option>
                 @endforeach
             </select>
+        </label>
+
+        <div class="ml-auto">
+            @include('noerd::components.table.list-pagination-nav', ['paginator' => $paginator])
         </div>
-
-        {{-- Previous + Next right --}}
-        @if ($paginator->hasPages())
-            <div class="flex items-center gap-6">
-                @if ($paginator->onFirstPage())
-                    <span class="inline-flex cursor-default items-center border-t-2 border-transparent text-sm font-medium text-gray-300">
-                        <svg class="mr-3 size-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                            <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
-                        </svg>
-                        {{ __('Previous') }}
-                    </span>
-                @else
-                    <button
-                        type="button"
-                        wire:click="previousPage('{{ $paginator->getPageName() }}')"
-                        wire:loading.attr="disabled"
-                        dusk="previousPage{{ $paginator->getPageName() == 'page' ? '' : '.' . $paginator->getPageName() }}"
-                        class="inline-flex cursor-pointer items-center border-t-2 border-transparent text-sm font-medium text-gray-500 transition hover:text-gray-700"
-                    >
-                        <svg class="mr-3 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                            <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
-                        </svg>
-                        {{ __('Previous') }}
-                    </button>
-                @endif
-
-                @if ($paginator->hasMorePages())
-                    <button
-                        type="button"
-                        wire:click="nextPage('{{ $paginator->getPageName() }}')"
-                        wire:loading.attr="disabled"
-                        dusk="nextPage{{ $paginator->getPageName() == 'page' ? '' : '.' . $paginator->getPageName() }}"
-                        class="inline-flex cursor-pointer items-center border-t-2 border-transparent text-sm font-medium text-gray-500 transition hover:text-gray-700"
-                    >
-                        {{ __('Next') }}
-                        <svg class="ml-3 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                            <path fill-rule="evenodd" d="M3 10a.75.75 0 0 1 .75-.75h10.638l-4.158-3.96a.75.75 0 0 1 1.04-1.08l5.5 5.25a.75.75 0 0 1 0 1.08l-5.5 5.25a.75.75 0 0 1-1.04-1.08l4.158-3.96H3.75A.75.75 0 0 1 3 10Z" clip-rule="evenodd" />
-                        </svg>
-                    </button>
-                @else
-                    <span class="inline-flex cursor-default items-center border-t-2 border-transparent text-sm font-medium text-gray-300">
-                        {{ __('Next') }}
-                        <svg class="ml-3 size-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                            <path fill-rule="evenodd" d="M3 10a.75.75 0 0 1 .75-.75h10.638l-4.158-3.96a.75.75 0 0 1 1.04-1.08l5.5 5.25a.75.75 0 0 1 0 1.08l-5.5 5.25a.75.75 0 0 1-1.04-1.08l4.158-3.96H3.75A.75.75 0 0 1 3 10Z" clip-rule="evenodd" />
-                        </svg>
-                    </span>
-                @endif
-            </div>
-        @endif
     </nav>
 </div>

--- a/src/Traits/NoerdList.php
+++ b/src/Traits/NoerdList.php
@@ -446,7 +446,7 @@ trait NoerdList
 
     /**
      * The generic header controls this list actually renders, resolved ONCE so the
-     * header row, the filter drawer and modal-title cannot disagree about what
+     * title row, the filter row and modal-title cannot disagree about what
      * exists. Every consumer reads this — never re-derive "does the list have a
      * search field / secondary action" from $listSettings at the call site.
      *
@@ -481,8 +481,9 @@ trait NoerdList
     }
 
     /**
-     * Whether anything renders in the half of the header that collapses into the
-     * filter drawer below `lg` (search, CSV export, `style: secondary` actions).
+     * Whether the list has a search field, a CSV export or `style: secondary`
+     * actions — the controls a custom header slot gets injected next to the
+     * primary buttons and the registry actions.
      */
     public function hasCollapsibleControls(): bool
     {
@@ -806,7 +807,9 @@ trait NoerdList
             return;
         }
 
-        $this->perPage = session("listPerPage.{$this->componentName()}", 50);
+        // Clamped: a session value stored by an earlier per-page option set (or by
+        // hand) must never exceed MAX_PER_PAGE, or the footer select has no match.
+        $this->perPage = $this->clampPerPage((int) session("listPerPage.{$this->componentName()}", 50));
         $this->loadListFilters();
 
         // Column filters: a ?cf[...] URL param (shared link) wins over the session

--- a/tests/Components/ListHeaderTest.php
+++ b/tests/Components/ListHeaderTest.php
@@ -14,8 +14,9 @@ uses(TestCase::class, RefreshDatabase::class);
 
 /*
  | The generic list header: which controls it computes (headerControls()), how a
- | list host with its OWN header slot gets them injected, and how they collapse
- | into the drawer instead of wrapping onto a second row.
+ | list host with its OWN header slot gets them injected, and how the two rows
+ | are laid out — buttons on the title row, search + filters + pagination on the
+ | filter row, whose filter strip scrolls instead of wrapping or collapsing.
  */
 
 beforeEach(function (): void {
@@ -72,18 +73,25 @@ describe('control injection', function (): void {
             ->toContain('wire:model.live.debounce.300ms="search"');
     });
 
-    it('keeps room for the focus ring inside the scrolling controls row', function (): void {
-        // `xl:overflow-x-auto` makes the header row scroll rather than wrap, and a scroll
-        // container clips BOTH axes. Without padding the row is exactly as tall as its
-        // 32px controls, so the search field's focus ring is cut down to a black sliver.
+    it('keeps room for focus rings inside the scrolling filter strip', function (): void {
+        // The strip is a scroll container, which clips BOTH axes; without padding
+        // the focus ring of a filter control is cut off. It is built exactly like
+        // the quick-menu: a reserved 6px track pulled out of the layout, and the
+        // idle class that hides the thumb while nothing overflows.
         $html = Livewire::test(CollapsingHeaderListComponent::class)->assertOk()->html();
 
-        preg_match_all('/class="([^"]*xl:overflow-x-auto[^"]*)"/', $html, $matches);
+        preg_match_all('/class="([^"]*overflow-x-scroll[^"]*)"/', $html, $matches);
 
-        expect($matches[1])->not->toBeEmpty();
+        expect($matches[1])->not->toBeEmpty()
+            ->and($html)->toContain('x-data="noerdScrollShadow()"');
 
         foreach ($matches[1] as $classAttribute) {
-            expect($classAttribute)->toContain('xl:p-1.5');
+            expect($classAttribute)->toContain('noerd-scrollbar')
+                ->toContain('noerd-scrollbar-idle')
+                ->toContain('-mb-[6px]')
+                ->toContain('p-1')
+                ->toContain('min-w-0')
+                ->toContain('flex-1');
         }
     });
 });
@@ -131,12 +139,12 @@ describe('headerControls', function (): void {
             ->and($controls['registry'])->toBe([]);
     });
 
-    it('answers whether anything collapses into the drawer', function (): void {
+    it('answers whether the list has a search field, a CSV export or secondary actions', function (): void {
         expect(Livewire::test(CollapsingHeaderListComponent::class)->instance()->hasCollapsibleControls())->toBeTrue()
             ->and(Livewire::test(BareHeaderListComponent::class)->instance()->hasCollapsibleControls())->toBeFalse();
     });
 
-    it('counts the primary actions towards the header controls but not towards the drawer', function (): void {
+    it('counts the primary actions towards the header controls but not towards the injected group', function (): void {
         $host = Livewire::test(PrimaryOnlyHeaderListComponent::class)->instance();
 
         expect($host->hasCollapsibleControls())->toBeFalse()
@@ -155,38 +163,70 @@ describe('header rendering', function (): void {
             ->and(mb_substr_count($html, '$refs.searchInput.focus()'))->toBe(1);
     });
 
-    it('keeps the header on a single row instead of stacking below lg', function (): void {
+    it('keeps the title row on a single line instead of stacking below lg', function (): void {
         $html = Livewire::test(CollapsingHeaderListComponent::class)->assertOk()->html();
 
         // x-noerd::title stacks below `lg` for detail headers; the list header opts
-        // out via `row`, so its title element is flex at EVERY width and the controls
-        // collapse into the drawer instead of wrapping.
+        // out via `row`, so its title element is flex at EVERY width — the buttons
+        // stay on the title line and nothing wraps.
         assertElementHasClasses($html, ['font-semibold', 'text-slate-900', 'flex', 'h-[30px]']);
         assertNoElementHasClasses($html, ['font-semibold', 'text-slate-900', 'lg:flex', 'lg:h-[30px]']);
     });
 
-    it('opens the drawer from a funnel button that only exists below lg', function (): void {
+    it('renders the filters on a second row that scrolls instead of wrapping or collapsing', function (): void {
         $html = Livewire::test(CollapsingHeaderListComponent::class)->assertOk()->html();
 
-        // Below `lg` the controls become a drawer opened by the funnel button; the
-        // header row itself never wraps onto a second line.
-        expect($html)->toContain('x-data="{ drawer: false }"')
-            ->and($html)->toContain('drawer = true')
-            ->and($html)->not->toContain('flex-wrap');
+        expect($html)->toContain('wire:key="list-filter-row"')
+            ->and($html)->not->toContain('drawer')
+            ->and($html)->not->toContain('flex-wrap')
+            ->and($html)->not->toContain('max-xl:')
+            ->and($html)->not->toContain('xl:overflow-x-auto');
     });
 
-    it('offers no drawer when there is nothing to collapse', function (): void {
+    it('keeps the search field outside the scrolling strip and the filters inside it', function (): void {
+        app(HeaderActionsRegistry::class)->registerListAction('header-actions-test::probe');
+
+        $html = Livewire::test(CollapsingHeaderListComponent::class)->assertOk()->html();
+
+        // Filter row order: search | scrolling strip with the filters | registry
+        // actions — all of it above the table. (The pagination nav needs a real
+        // paginator and is covered by ListPaginationTest.)
+        $positions = array_map(
+            static fn(string $needle): int|false => mb_strpos($html, $needle),
+            ['wire:key="list-search"', 'overflow-x-scroll', 'listFilters.color', 'HA-PROBE:', '<table'],
+        );
+
+        expect($positions)->each->not->toBeFalse();
+        expect($positions)->toBe(collect($positions)->sort()->values()->all());
+    });
+
+    it('puts CSV and the secondary actions on the title row next to the primary buttons', function (): void {
+        $html = Livewire::test(CollapsingHeaderListComponent::class)->assertOk()->html();
+
+        $filterRow = mb_strpos($html, 'wire:key="list-filter-row"');
+
+        expect(mb_strpos($html, 'wire:key="list-csv-export"'))->toBeLessThan($filterRow)
+            ->and(mb_strpos($html, '$wire.exportSecondary(null, [])'))->toBeLessThan($filterRow)
+            ->and(mb_strpos($html, '$wire.listAction(null, [])'))->toBeLessThan($filterRow);
+    });
+
+    it('renders no filter row when there is nothing to put in it', function (): void {
         $html = Livewire::test(BareHeaderListComponent::class)->assertOk()->html();
 
-        expect($html)->not->toContain('x-data="{ drawer: false }"')
-            ->and($html)->not->toContain('drawer = true');
+        expect($html)->not->toContain('wire:key="list-filter-row"')
+            ->and($html)->not->toContain('overflow-x-scroll');
     });
 
-    it('counts an active search in the funnel badge, which is all the drawer leaves visible', function (): void {
-        $html = Livewire::test(CollapsingHeaderListComponent::class)->set('search', 'rot')->html();
+    it('opens the filter row for registry actions alone', function (): void {
+        app(HeaderActionsRegistry::class)->registerListAction('header-actions-test::probe');
 
-        assertElementHasClasses($html, ['bg-brand-primary', 'px-1', 'text-[10px]']);
+        $html = Livewire::test(BareHeaderListComponent::class)->assertOk()->html();
+
+        expect($html)->toContain('wire:key="list-filter-row"')
+            ->and($html)->toContain('HA-PROBE:')
+            ->and($html)->not->toContain('overflow-x-scroll');
     });
+
 });
 
 /**
@@ -237,10 +277,18 @@ class CustomHeaderListComponent extends Component
     }
 }
 
-/** List with a search field, CSV export and both a secondary and a primary action. */
+/** List with a search field, a header filter, CSV export and both a secondary and a primary action. */
 class CollapsingHeaderListComponent extends Component
 {
     use NoerdList;
+
+    /**
+     * @return array{column: string, label: string, options: array<string, string>}
+     */
+    public function getColorListFilter(): array
+    {
+        return ['column' => 'color', 'label' => 'Color', 'options' => ['red' => 'Red']];
+    }
 
     /**
      * @return array<string, mixed>

--- a/tests/Components/ListPaginationTest.php
+++ b/tests/Components/ListPaginationTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Component;
+use Livewire\Livewire;
+use Noerd\Models\NoerdUser;
+use Noerd\Tests\TestCase;
+use Noerd\Traits\NoerdList;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+/*
+ | The list's pagination navigation: one partial ("1-50 of 150" + icon-only
+ | previous/next buttons) rendered in the header's filter row AND in the footer,
+ | plus the footer-only rows-per-page select capped at MAX_PER_PAGE.
+ */
+
+beforeEach(function (): void {
+    $this->actingAs(NoerdUser::factory()->adminUser()->withSelectedApp('setup')->create());
+    NoerdUser::factory()->count(2)->create();
+    $this->total = NoerdUser::count();
+});
+
+it('renders the same summary and page buttons in the filter row and in the footer', function (): void {
+    $html = Livewire::test(PaginatedListComponent::class)->set('perPage', 1)->html();
+
+    expect(mb_substr_count($html, "1-1 of {$this->total}"))->toBe(2)
+        ->and(mb_substr_count($html, "previousPage('page')"))->toBe(2)
+        ->and(mb_substr_count($html, "nextPage('page')"))->toBe(2)
+        ->and($html)->not->toContain('Showing')
+        ->and($html)->not->toContain('results')
+        // Icon-only buttons: labelled through aria-label, never an sr-only span
+        // (position:absolute would stretch the document past the scroll container).
+        ->and(mb_substr_count($html, 'aria-label="Previous"'))->toBe(2)
+        ->and(mb_substr_count($html, 'aria-label="Next"'))->toBe(2)
+        ->and($html)->not->toContain('sr-only');
+
+    // Byte-identical markup: the two copies come from one partial.
+    preg_match_all('/<div class="flex shrink-0 items-center gap-2">\s*<span class="hidden[^§]*?<\/button>\s*<\/div>/u', $html, $navs);
+
+    expect($navs[0])->toHaveCount(2)
+        ->and($navs[0][0])->toBe($navs[0][1]);
+});
+
+it('shows the nav in the filter row above the table and only in the footer below it', function (): void {
+    $html = Livewire::test(PaginatedListComponent::class)->set('perPage', 1)->html();
+
+    $filterRow = mb_strpos($html, 'wire:key="list-filter-row"');
+    $table = mb_strpos($html, '<table');
+    $firstNav = mb_strpos($html, "previousPage('page')");
+    $secondNav = mb_strpos($html, "previousPage('page')", $firstNav + 1);
+
+    expect($filterRow)->toBeLessThan($firstNav)
+        ->and($firstNav)->toBeLessThan($table)
+        ->and($table)->toBeLessThan($secondNav);
+});
+
+it('hides the nav while the list is empty but keeps the filter row', function (): void {
+    // Pagination alone never opens the filter row, and an empty result has
+    // nothing to page through — only the search field stays.
+    $html = Livewire::test(PaginatedListComponent::class)->set('search', 'zz-no-such-user')->html();
+
+    expect($html)->toContain('wire:key="list-filter-row"')
+        ->and($html)->toContain('wire:key="list-search"')
+        ->and($html)->not->toContain("previousPage('page')");
+});
+
+it('disables the previous button on the first page and the next button on the last', function (): void {
+    $component = Livewire::test(PaginatedListComponent::class)->set('perPage', 1);
+
+    $navButtons = static function (string $html): array {
+        preg_match_all('/<button[^>]*wire:click="(previousPage|nextPage)\(\'page\'\)"[^>]*>/', $html, $buttons, PREG_SET_ORDER);
+
+        return array_map(static fn(array $button): array => [$button[1], str_contains($button[0], 'disabled="disabled"')], $buttons);
+    };
+
+    expect($navButtons($component->html()))->toBe([
+        ['previousPage', true], ['nextPage', false],
+        ['previousPage', true], ['nextPage', false],
+    ]);
+
+    $component->call('nextPage', 'page');
+
+    expect($component->html())->toContain("2-2 of {$this->total}")
+        ->and($navButtons($component->html()))->toBe([
+            ['previousPage', false], ['nextPage', false],
+            ['previousPage', false], ['nextPage', false],
+        ]);
+
+    $component->call('gotoPage', $this->total, 'page');
+
+    expect($navButtons($component->html()))->toBe([
+        ['previousPage', false], ['nextPage', true],
+        ['previousPage', false], ['nextPage', true],
+    ]);
+});
+
+it('offers a labelled rows-per-page select in the footer only, with no option above MAX_PER_PAGE', function (): void {
+    $html = Livewire::test(PaginatedListComponent::class)->html();
+
+    expect(mb_substr_count($html, 'wire:model.live="perPage"'))->toBe(1)
+        ->and($html)->toContain('Rows per page');
+
+    preg_match_all('/<option value="(\d+)">/', $html, $options);
+    $sizes = array_map('intval', $options[1]);
+
+    expect($sizes)->toBe([10, 25, 50, 100, 200])
+        ->and(max($sizes))->toBe(200);
+});
+
+it('clamps a stored page size above MAX_PER_PAGE when mounting', function (): void {
+    session(['listPerPage.paginated-list' => 500]);
+
+    expect(Livewire::test(PaginatedListComponent::class)->get('perPage'))->toBe(200);
+});
+
+/** A model-backed list over noerd_users with the generic header and footer. */
+class PaginatedListComponent extends Component
+{
+    use NoerdList;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function with(): array
+    {
+        return [
+            'listConfig' => $this->buildList(
+                $this->listQuery(NoerdUser::class)->orderBy('id')->paginate($this->perPage),
+                'paginated-list',
+            ),
+        ];
+    }
+
+    public function render(): string
+    {
+        return '<x-noerd::page><x-noerd::list /></x-noerd::page>';
+    }
+
+    protected function componentName(): string
+    {
+        return 'paginated-list';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getListConfig(?string $customName = null): array
+    {
+        return [
+            'title' => 'Users',
+            'columns' => [
+                ['field' => 'name', 'label' => 'Name'],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

The generic list header was one row: title, a scroll container holding filters, chips, search and the secondary buttons, then the primary buttons. From `xl` the middle scrolled, below it the same DOM became a fixed drawer. Filters and the search field overlapped (e.g. the bank transactions list with two picklist filters).

The header is now two rows at every viewport width, and nothing collapses or wraps:

- **Title row**: the title with its record count (and the view switcher) on the left, every button on the right (`style: secondary` actions, CSV export, primary actions). `modal-title` draws the grey separator below it.
- **Filter row** (rendered only when a search field, header filters/chips or registry list actions exist): the search field at a fixed width on the left, the filters in a horizontally scrolling strip built like the quick-menu (`overflow-x-scroll`, reserved 6px track, `noerd-scrollbar-idle` toggled by `noerdScrollShadow`), and on the right the registry list actions followed by the pagination summary `1-50 of 150` with icon-only previous/next buttons.
- The below-`xl` drawer, the funnel button and its badge are gone. No JavaScript measures or positions anything.

Pagination:

- New partial `table/list-pagination-nav` renders the summary and the page buttons; it is included in the filter row and in the footer, so both are byte-identical.
- The footer keeps only the labelled rows-per-page select. Its options are `10, 25, 50, 100, 200` (the former 250/500/1000 were silently rejected by `clampPerPage()`); a stored session value is clamped on mount.
- The icon buttons are labelled with `aria-label` instead of an `sr-only` span: the absolutely positioned span escaped the body's scroll container and stretched the document.

Also: the registry list actions moved into their own partial `table/list-controls-registry`; the custom-header injection (`list-controls`) keeps rendering them.

## Tests

- `ListHeaderTest` rewritten for the two rows (search outside the strip, filters inside, buttons on the title row, no drawer, no `flex-wrap`, filter row only when needed).
- New `ListPaginationTest` (nav rendered twice and identical, disabled states per page, footer options, session clamp, labelled select).
- Docs (`list-filters.md`, `list-view.md`, `header-actions.md`), the Boost guideline and the list skill describe the new layout.

Full package suite: 1424 passed.