### PR TITLE
Bump version to v0.16.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
             "name": "Johannes Brock"
         }
     ],
-    "version": "v0.16.10",
+    "version": "v0.16.11",
     "license": "MIT",
     "require": {
         "php": "^8.3",


### PR DESCRIPTION
Release v0.16.11: the two-row list header with shared pagination (#138) and the nullable currency field with number step option (#137).