### PR TITLE
Drop the extra open-in-new-tab link from modal tabs and make the toggle click handler optional

### DIFF
--- a/resources/views/components/tab.blade.php
+++ b/resources/views/components/tab.blade.php
@@ -45,7 +45,9 @@
 @if ($opensAsModal)
     @php
         // A modalRoute tab points at the record's real page, so it also supplies
-        // the href for cmd-click / "open in new tab".
+        // the href for cmd/ctrl-click. No extra "open in new tab" link: the
+        // external-link icon is reserved for `external` targets, the modal tab
+        // is marked by the stack icon alone.
         $componentRouteUrl = $tabModalRoute
             ? route($tabModalRoute, $routeParameters ?? [])
             : ($route ? route($route, $routeParameters) : null);
@@ -68,16 +70,5 @@
                 <x-icon name="square-2-stack" data-modal-tab-icon="true" class="ml-1 h-4 w-4 shrink-0 text-gray-400" />
             </span>
         </a>
-        @if ($componentRouteUrl)
-            <a
-                href="{{ $componentRouteUrl }}"
-                target="_blank"
-                rel="noopener"
-                class="border-b-2 border-transparent py-3 pl-2 text-gray-500 hover:text-black focus:outline-none focus-visible:outline-none"
-                aria-label="{{ __('Open in new tab') }}"
-            >
-                <x-noerd::icons.external />
-            </a>
-        @endif
     </div>
 @endif

--- a/resources/views/components/toggle.blade.php
+++ b/resources/views/components/toggle.blade.php
@@ -18,7 +18,7 @@
 
     <button
         x-ref="toggle"
-        wire:click="{{ $click }}"
+        @if ($click) wire:click="{{ $click }}" @endif
         @click="value = ! value"
         type="button"
         role="switch"

--- a/tests/Components/ToggleComponentTest.php
+++ b/tests/Components/ToggleComponentTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Blade;
+use Noerd\Tests\TestCase;
+
+uses(TestCase::class);
+
+it('only wires a click handler when one is given', function (): void {
+    expect(Blade::render('<x-noerd::toggle model="closed" click="store" />'))
+        ->toContain('wire:click="store"');
+
+    expect(Blade::render('<x-noerd::toggle model="closed" />'))
+        ->not->toContain('wire:click');
+});

--- a/tests/Feature/TabModalRouteTest.php
+++ b/tests/Feature/TabModalRouteTest.php
@@ -133,6 +133,18 @@ it('marks tabs that open their own modal with an icon', function (): void {
     expect($inlineTabs)->not->toContain('data-modal-tab-icon');
 });
 
+it('marks a modal tab with the stack icon only and no external-link affordance', function (): void {
+    $html = renderLayoutTabs([
+        ['label' => 'Related Record', 'modalRoute' => 'zz.tab.record', 'arguments' => ['modelId' => '$modelId']],
+    ], 42);
+
+    // The external-link icon is reserved for `external` tabs; cmd/ctrl-click on the
+    // modal tab's own href still opens the full page in a new browser tab.
+    expect($html)->toContain('zz-tab-record/42')
+        ->not->toContain('target="_blank"')
+        ->not->toContain(__('Open in new tab'));
+});
+
 it('hides a requiresId tab until the record is saved', function (): void {
     $tab = [
         'label' => 'Related Records',


### PR DESCRIPTION
A tab that opens its record as a modal rendered two affordances: the tab itself plus a separate external-link icon. The external-link icon is reserved for `external` targets, so the modal tab now carries the stack icon alone — cmd/ctrl-click on the tab's own href still opens the full page in a new browser tab.

`x-noerd::toggle` emitted `wire:click=""` when no `click` action was given, which made Livewire round-trip on every switch. The attribute is now only rendered when an action is passed.

Covered by `ToggleComponentTest` and a new case in `TabModalRouteTest`; full package suite green (1432 tests).