### PR TITLE
Fill highlighted fields instead of ringing them

### DIFF
--- a/docs/detail-view.md
+++ b/docs/detail-view.md
@@ -172,7 +172,7 @@ expression for reactive visibility on top of the tab switch:
 | `tab` | Tab number (defaults to 1) |
 | `theme` | Per-field theme override (see [Themes](themes.md)) |
 | `number` | Explicit row number in the `numbered` theme (defaults to auto-increment) |
-| `highlight` | Render the field with a highlight ring (see [Highlighted Fields](#highlighted-fields)); normally stamped at runtime, not written in YAML |
+| `highlight` | Render the field's control with a highlight fill (see [Highlighted Fields](#highlighted-fields)); normally stamped at runtime, not written in YAML |
 | `previousValue` | Render `was: …` under the field (see [Highlighted Fields](#highlighted-fields)) |
 
 ## Highlighted Fields
@@ -182,7 +182,7 @@ proposal from an AI agent, a value copied from another record. Two optional fiel
 
 | Key | Effect |
 |-----|--------|
-| `highlight` | Renders the field with a ring and a tooltip on the label ("This value was proposed for you") |
+| `highlight` | Fills the field's control with a light amber tint and adds a tooltip on the label ("This value was proposed for you") |
 | `previousValue` | Renders `was: …` under the field — what it held before the proposal replaced it |
 
 Both are normally **stamped onto the layout at runtime** rather than written into the YAML: a
@@ -204,9 +204,10 @@ $this->pageLayout['fields'] = LayoutFields::map(
 );
 ```
 
-The ring is drawn on the field wrapper in `noerd::components.detail.block`, so it works for every
-field type in every theme without an element template of its own; the label marker reads the flag
-out of `FieldContext`, exactly like `helpText`.
+The fill is applied from the field wrapper in `noerd::components.detail.block` (a `data-highlight`
+wrapper whose descendant variants tint every `input`, `select`, `textarea` and rich-text editor —
+checkboxes excepted), so it works for every field type in every theme without an element template
+of its own; the label marker reads the flag out of `FieldContext`, exactly like `helpText`.
 
 **Rendering another component's form.** A component may render a FOREIGN detail YAML — that is what
 makes a generic review screen possible: load it with

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -1129,10 +1129,10 @@ $this->pageLayout = StaticConfigHelper::getComponentFields('accounting::expense-
 
 ### Mark Values the Reader Did Not Enter
 
-A field holding a proposed value gets the layout key `highlight: true` (ring + label tooltip) and
-optionally `previousValue` (renders `was: …` underneath). Both are stamped onto `$pageLayout` at
-runtime with `Noerd\Support\LayoutFields::map()` — never written into the shipped YAML, and never
-rebuilt per module: the ring lives once in `noerd::components.detail.block`.
+A field holding a proposed value gets the layout key `highlight: true` (amber-filled control + label
+tooltip) and optionally `previousValue` (renders `was: …` underneath). Both are stamped onto
+`$pageLayout` at runtime with `Noerd\Support\LayoutFields::map()` — never written into the shipped
+YAML, and never rebuilt per module: the fill lives once in `noerd::components.detail.block`.
 
 - Reference: `docs/detail-view.md` ("Highlighted Fields")
 

--- a/resources/views/components/detail/block.blade.php
+++ b/resources/views/components/detail/block.blade.php
@@ -94,19 +94,21 @@
                     }
 
                     // The `highlight` field key marks a value the reader did not enter
-                    // themselves (a prefilled proposal). The ring sits on the field
-                    // wrapper, so it works for every field type in every theme —
-                    // element templates build their own control classes and share no
-                    // partial to hook into.
-                    $highlightClasses = ($field['highlight'] ?? false)
-                        ? ' rounded-lg p-2 -m-2 ring-2 ring-amber-400/70'
+                    // themselves (a prefilled proposal). The control is tinted from
+                    // the field wrapper through descendant variants, so it works for
+                    // every field type in every theme — element templates build their
+                    // own control classes (bg-white) and share no partial to hook into.
+                    // Checkboxes stay untinted: a filled box reads as "checked".
+                    $isHighlighted = (bool) ($field['highlight'] ?? false);
+                    $highlightClasses = $isHighlighted
+                        ? ' [&_input:not([type=checkbox])]:bg-amber-50 [&_select]:bg-amber-50 [&_textarea]:bg-amber-50 [&_[contenteditable]]:bg-amber-50'
                         : '';
 
                     // Set unconditionally so optional keys (helpText) never leak into
                     // the next field; cleared again after the loop.
                     \Noerd\Support\FieldContext::set($field);
                 @endphp
-                <div class="{{ $fieldThemeDefinition->fullWidthRows ? 'col-span-full' : 'col-span-1 sm:col-span-' . ($field['colspan'] ?? '3') }}{{ $highlightClasses }}" {!! $getShowIfDirective($field) !!}>
+                <div class="{{ $fieldThemeDefinition->fullWidthRows ? 'col-span-full' : 'col-span-1 sm:col-span-' . ($field['colspan'] ?? '3') }}{{ $highlightClasses }}" @if ($isHighlighted) data-highlight @endif {!! $getShowIfDirective($field) !!}>
                     @php
                         $fieldTypeDefinition = $fieldTypeRegistry->resolve($field['type'] ?? '');
                         $resolvedRendererProps = $fieldTypeDefinition?->resolveProps(

--- a/tests/Feature/DetailHighlightTest.php
+++ b/tests/Feature/DetailHighlightTest.php
@@ -13,11 +13,14 @@ beforeEach(function (): void {
     $this->actingAs(NoerdUser::factory()->adminUser()->withSelectedApp('setup')->create());
 });
 
-it('rings the fields marked highlight and leaves the others plain', function (): void {
+it('fills the controls of the fields marked highlight and leaves the others plain', function (): void {
     $html = Livewire::test('noerd-test::highlight-test')->assertSuccessful()->html();
 
     // Two of the three fields are marked — the nested block is walked too.
-    expect(mb_substr_count($html, 'ring-amber-400/70'))->toBe(2);
+    expect(mb_substr_count($html, 'data-highlight'))->toBe(2)
+        // Blade escapes the `&` of the arbitrary variant; match past it.
+        ->and(mb_substr_count($html, '_input:not([type=checkbox])]:bg-amber-50'))->toBe(2)
+        ->and($html)->not->toContain('ring-amber');
 });
 
 it('marks the label of a highlighted field', function (): void {
@@ -33,10 +36,10 @@ it('shows what the field held before, only where a previous value was recorded',
         ->assertSee(__('was: :value', ['value' => 'the old value']));
 });
 
-it('rings the field in every theme, not just the default one', function (): void {
+it('fills the field in every theme, not just the default one', function (): void {
     foreach (['default', 'compact', 'numbered'] as $theme) {
         $html = Livewire::test('noerd-test::highlight-test', ['theme' => $theme])->html();
 
-        expect(mb_substr_count($html, 'ring-amber-400/70'))->toBe(2, "theme {$theme}");
+        expect(mb_substr_count($html, 'data-highlight'))->toBe(2, "theme {$theme}");
     }
 });


### PR DESCRIPTION
## Summary

- A field stamped with `highlight: true` (AI proposals in the confirmation review, copied values) was drawn with a `ring-2 ring-amber-400/70` on its grid-cell wrapper. In a dense compact form that produced overlapping yellow frames around every row.
- The wrapper now carries `data-highlight` plus descendant variants that fill every `input`, `select`, `textarea` and rich-text editor of the field with `bg-amber-50`. Checkboxes stay untinted because a filled box reads as "checked". No theme element template had to change.
- The sparkle tooltip on the label and the `was: …` line are unchanged.

## Tests

- `tests/Feature/DetailHighlightTest.php` counts the `data-highlight` wrappers per theme and asserts the ring is gone.
- Docs (`docs/detail-view.md`) and the Boost guideline updated.