### PR TITLE
Bump version to v0.16.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
             "name": "Johannes Brock"
         }
     ],
-    "version": "v0.16.12",
+    "version": "v0.16.13",
     "license": "MIT",
     "require": {
         "php": "^8.3",


### PR DESCRIPTION
Release v0.16.13: highlighted fields fill their control instead of ringing the wrapper (#142).