### PR TITLE
Skip the Boost agent documentation in the module dependency guard

### DIFF
--- a/tests/Unit/ModuleHelperTest.php
+++ b/tests/Unit/ModuleHelperTest.php
@@ -142,6 +142,17 @@ describe('assertModuleDependenciesDeclared()', function (): void {
         'tests/ZzLeakTest.php',
         'app-configs/zz-module/lists/leak.yml',
     ]);
+
+    it('ignores the Boost guideline, which names foreign modules in prose', function (): void {
+        zzWriteModuleSkeleton();
+        File::ensureDirectoryExists(zzModuleDir() . '/resources/boost/guidelines');
+        File::put(
+            zzModuleDir() . '/resources/boost/guidelines/core.blade.php',
+            "The zz-module must never reference Zz\\Other\\Gadget.\n",
+        );
+
+        assertModuleDependenciesDeclared(zzModuleDir());
+    });
 });
 
 describe('assertModuleUpdateCommandPublishesConfigs()', function (): void {

--- a/tests/helpers.php
+++ b/tests/helpers.php
@@ -173,6 +173,10 @@ if (! function_exists('assertModuleDependenciesDeclared')) {
      * derived from the sibling app-modules' composer.json files, so the guard
      * needs no hand-maintained mapping and also catches test-only leaks.
      *
+     * The agent documentation under resources/boost (the Boost guideline and
+     * the skills) is skipped: it is prose that names foreign classes on
+     * purpose — describing a boundary is not crossing it.
+     *
      * @param  string  $moduleDir  absolute path of the module under test
      * @param  array<int, string>  $allowedPackages  extra packages to tolerate
      */
@@ -212,6 +216,10 @@ if (! function_exists('assertModuleDependenciesDeclared')) {
                 }
                 // The boundary tests themselves name foreign namespaces as needles.
                 if (str_contains($file->getFilename(), 'ModuleBoundaryTest')) {
+                    continue;
+                }
+                // Agent documentation (Boost guideline, skills) is prose, not code.
+                if (str_contains(str_replace('\\', '/', $file->getPathname()), '/resources/boost/')) {
                     continue;
                 }
                 $content = (string) file_get_contents($file->getPathname());


### PR DESCRIPTION
## Problem

Since every module ships a Boost guideline at `resources/boost/guidelines/core.blade.php`,
`assertModuleDependenciesDeclared()` reports false violations in four modules
(booking-members, crm, customer, party).

The guideline is agent documentation — prose rendered into the host's `CLAUDE.md` by
`boost:update`. It only carries the `.blade.php` extension because Boost renders it as a
view, so the guard scans it like source (`resources/` is scanned, extension `php`) and its
plain `str_contains()` matches any namespace named in a sentence.

The failure is structural: those guidelines document the module boundary *by naming the
forbidden namespace*, e.g.

> no `Noerd\Party\` / `Noerd\Accounting\` reference in `src`, `resources`, `routes`, `database`

Describing a boundary is not crossing it.

## Change

`assertModuleDependenciesDeclared()` now skips every file under `resources/boost/` —
directory-level, so it also covers `resources/boost/skills/` and any future guideline
partial. Nothing else changes: `src`, `routes`, `database`, `config`, `app-configs` and
`tests` are scanned exactly as before.

`tests/Unit/ModuleHelperTest.php` pins the behaviour next to the existing self-tests: a
guideline naming `Zz\Other\Gadget` passes, while the existing case that writes the same
needle into `src/` still fails.

## Verification

`vendor/bin/pest --filter=ModuleHelperTest` — 12 passed. Removing the new skip makes the
added case fail, so it really covers the change.