### PR TITLE
Bump version to v0.16.14

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
             "name": "Johannes Brock"
         }
     ],
-    "version": "v0.16.13",
+    "version": "v0.16.14",
     "license": "MIT",
     "require": {
         "php": "^8.3",


### PR DESCRIPTION
Release v0.16.14: keyboard shortcuts fire only on the topmost layer (#145).