### PR TITLE
Keep the current app selected when an app-access route belongs to a hidden tenant app

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -60,7 +60,12 @@ Every noerd-based module protects its routes with `['noerd', 'app-access:{module
 `NoerdServiceProvider`, backed by `Noerd\Middleware\AppAccessMiddleware`) that takes the app key as
 its parameter: `app-access:inventory` only lets requests through when the selected tenant has the
 `inventory` app assigned and the per-app authorization gate allows it; it also selects that app in
-the session, so a deep link always lands in the right app. Without it, any authenticated user of
+the session, so a deep link always lands in the right app. A HIDDEN app (`tenant_app.is_hidden`,
+an app that only backs the screens of another app) is never selected: the user keeps the app they
+came from, with its navigation and its `app-configs/{app}/` YAML, as long as that app is assigned
+and accessible. For a route shared by several apps (`app-access:booking,booking-members`) the
+selected app is kept when it is one of them; otherwise the first visible one in route order is
+selected. Without it, any authenticated user of
 any tenant app can open the module's screens. The `noerd:make-module` scaffolder and the
 `noerd:make-*` generators emit routes wrapped in `['noerd', 'app-access:{app}']` (see
 [Creating Modules](creating-modules.md)).
@@ -69,7 +74,7 @@ any tenant app can open the module's screens. The `noerd:make-module` scaffolder
 
 | Alias | Middleware | Purpose |
 |-------|------------|---------|
-| `app-access:{app}` | `AppAccessMiddleware` | The tenant must have the app assigned and the app gate must allow it; also selects the app in the session |
+| `app-access:{app}` | `AppAccessMiddleware` | The tenant must have the app assigned and the app gate must allow it; also selects the app in the session (a hidden app never — the current app is kept) |
 | `setup` | `SetupMiddleware` | The `/setup` area — tenant admins only (`NoerdUser::isAdmin()`) |
 | `action-permission:{key}` | `ActionPermissionMiddleware` | A registered named action must be allowed for the user (see [Permissions](permissions.md#named-action-checks)) |
 | `setup.collections.ui` | `EnsureSetupCollectionDefinitionsEnabled` | The collection-definition screens, only reachable while `noerd.collections.mode` is `database` (see [Setup Collections](setup-collections.md)) |

--- a/src/Middleware/AppAccessMiddleware.php
+++ b/src/Middleware/AppAccessMiddleware.php
@@ -6,11 +6,14 @@ namespace Noerd\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
 use Noerd\Enums\NoerdExceptionType;
 use Noerd\Exceptions\NoerdException;
 use Noerd\Helpers\AccessHelper;
 use Noerd\Helpers\NoerdAuth;
 use Noerd\Helpers\TenantHelper;
+use Noerd\Models\Tenant;
+use Noerd\Models\TenantApp;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -18,6 +21,11 @@ use Symfony\Component\HttpFoundation\Response;
  * for routes shared by several apps): the tenant must run one of the apps and
  * the user must be allowed to access it. The matching app becomes the selected
  * app, so the navigation always shows the app the route belongs to.
+ *
+ * A HIDDEN app (tenant_app.is_hidden) never becomes the selected app: it backs
+ * the screens of another app (liefertool pulls PRODUCT in, booking-members
+ * keeps BOOKING) and is refused by the app switcher, so the user stays in the
+ * app they came from and keeps its navigation and its app-configs.
  */
 class AppAccessMiddleware
 {
@@ -47,18 +55,20 @@ class AppAccessMiddleware
 
         // In single-tenant mode every app is assigned — only the per-app
         // authorization gate (see AccessHelper) applies.
-        $assigned = config('noerd.features.multi_tenant')
-            ? $tenant->tenantApps()->namedAny($appNames)->pluck('name')->map(fn(string $name): string => mb_strtolower($name))->all()
+        $assignedRows = config('noerd.features.multi_tenant')
+            ? $tenant->tenantApps()->namedAny($appNames)->get()
+            : null;
+
+        $assignedNames = $assignedRows
+            ? $assignedRows->pluck('name')->map(fn(string $name): string => mb_strtolower($name))->all()
             : $appNames;
 
-        // The first candidate in route order wins.
-        $matchingApp = null;
-        foreach ($appNames as $candidate) {
-            if (in_array($candidate, $assigned, true)) {
-                $matchingApp = $candidate;
-                break;
-            }
-        }
+        // The route's apps the tenant runs, in ROUTE order — the first one wins.
+        $assigned = array_values(array_filter(
+            $appNames,
+            fn(string $candidate): bool => in_array($candidate, $assignedNames, true),
+        ));
+        $matchingApp = $assigned[0] ?? null;
 
         if (! $matchingApp) {
             throw new NoerdException(
@@ -74,10 +84,66 @@ class AppAccessMiddleware
             );
         }
 
-        if (TenantHelper::getSelectedApp() !== mb_strtoupper($matchingApp)) {
-            TenantHelper::setSelectedApp(mb_strtoupper($matchingApp));
-        }
+        $this->selectApp($tenant, $matchingApp, $assigned, $assignedRows);
 
         return $next($request);
+    }
+
+    /**
+     * Decide which app the navigation shows for this request.
+     *
+     * The selected app is kept when it is one of the route's own apps, or when
+     * the route belongs to a hidden app and the selected app is one the tenant
+     * runs and the user may access. Otherwise the first VISIBLE assigned
+     * candidate is selected — a hidden one only as the very last resort (no
+     * selection yet, or one that is no longer valid for this tenant).
+     *
+     * @param  list<string>  $assigned  lowercase names of the route's apps the tenant runs, in route order
+     * @param  Collection<int, TenantApp>|null  $assignedRows  their rows with the pivot, null in single-tenant mode
+     */
+    private function selectApp(Tenant $tenant, string $matchingApp, array $assigned, ?Collection $assignedRows): void
+    {
+        $selected = TenantHelper::getSelectedApp();
+        $selectedLower = $selected ? mb_strtolower($selected) : null;
+
+        if ($selectedLower !== null && in_array($selectedLower, $assigned, true)) {
+            return;
+        }
+
+        $hidden = $assignedRows
+            ? $assignedRows
+                ->filter(fn(TenantApp $app): bool => (bool) $app->pivot->is_hidden)
+                ->map(fn(TenantApp $app): string => mb_strtolower($app->name))
+                ->values()
+                ->all()
+            : [];
+
+        $visibleCandidates = array_values(array_diff($assigned, $hidden));
+
+        if ($visibleCandidates === []
+            && $selectedLower !== null
+            && $this->tenantRunsApp($tenant, $selectedLower)
+            && AccessHelper::canAccessApp($selectedLower)) {
+            return;
+        }
+
+        $target = $matchingApp;
+        foreach ($visibleCandidates as $candidate) {
+            if (AccessHelper::canAccessApp($candidate)) {
+                $target = $candidate;
+                break;
+            }
+        }
+
+        TenantHelper::setSelectedApp(mb_strtoupper($target));
+    }
+
+    private function tenantRunsApp(Tenant $tenant, string $appName): bool
+    {
+        if (! config('noerd.features.multi_tenant')) {
+            return true;
+        }
+
+        return $tenant->tenantApps()->namedAny([$appName])->exists();
     }
 }

--- a/tests/Middleware/AppAccessMiddlewareTest.php
+++ b/tests/Middleware/AppAccessMiddlewareTest.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
 use Noerd\Exceptions\NoerdException;
+use Noerd\Helpers\AccessHelper;
 use Noerd\Helpers\TenantHelper;
 use Noerd\Middleware\AppAccessMiddleware;
 use Noerd\Models\NoerdUser;
 use Noerd\Models\TenantApp;
 use Noerd\Tests\TestCase;
+use Symfony\Component\HttpFoundation\Response;
 
 uses(TestCase::class, RefreshDatabase::class);
 
@@ -94,5 +97,99 @@ describe('AppAccessMiddleware', function (): void {
         $this->middleware->handle($request, fn() => response('OK'), 'media');
 
         expect(TenantHelper::getSelectedApp())->toBe('MEDIA');
+    });
+});
+
+describe('hidden apps', function (): void {
+    function zzAttachApp(string $name, bool $hidden): TenantApp
+    {
+        $app = TenantApp::factory()->create(['name' => $name, 'route' => mb_strtolower($name)]);
+        TenantHelper::getSelectedTenant()->tenantApps()->attach($app->id, ['is_hidden' => $hidden]);
+        TenantHelper::clearCache();
+
+        return $app;
+    }
+
+    function zzHandle(AppAccessMiddleware $middleware, NoerdUser $user, string ...$apps): Response
+    {
+        $request = Request::create('/zz', 'GET');
+        $request->setUserResolver(fn() => $user);
+
+        return $middleware->handle($request, fn() => response('OK'), ...$apps);
+    }
+
+    beforeEach(function (): void {
+        $this->user = NoerdUser::factory()->withExampleTenant()->create();
+        $this->actingAs($this->user);
+    });
+
+    it('keeps the selected app when the route belongs to a hidden app', function (): void {
+        zzAttachApp('ZZSHOP', hidden: false);
+        zzAttachApp('ZZCATALOG', hidden: true);
+        TenantHelper::setSelectedApp('ZZSHOP');
+
+        $response = zzHandle($this->middleware, $this->user, 'zzcatalog');
+
+        expect($response->getContent())->toBe('OK')
+            ->and(TenantHelper::getSelectedApp())->toBe('ZZSHOP');
+    });
+
+    it('selects the hidden app when nothing is selected yet', function (): void {
+        zzAttachApp('ZZCATALOG', hidden: true);
+        TenantHelper::setSelectedApp(null);
+
+        zzHandle($this->middleware, $this->user, 'zzcatalog');
+
+        expect(TenantHelper::getSelectedApp())->toBe('ZZCATALOG');
+    });
+
+    it('selects the hidden app when the selected app is not assigned to the tenant', function (): void {
+        zzAttachApp('ZZCATALOG', hidden: true);
+        TenantHelper::setSelectedApp('ZZSTALE');
+
+        zzHandle($this->middleware, $this->user, 'zzcatalog');
+
+        expect(TenantHelper::getSelectedApp())->toBe('ZZCATALOG');
+    });
+
+    it('selects the hidden app when the selected app is denied by the app gate', function (): void {
+        zzAttachApp('ZZSHOP', hidden: false);
+        zzAttachApp('ZZCATALOG', hidden: true);
+        TenantHelper::setSelectedApp('ZZSHOP');
+        Gate::define(AccessHelper::APP_GATE, fn($user, string $app): bool => mb_strtolower($app) !== 'zzshop');
+
+        zzHandle($this->middleware, $this->user, 'zzcatalog');
+
+        expect(TenantHelper::getSelectedApp())->toBe('ZZCATALOG');
+    });
+
+    it('keeps the selected app when it is one of the route apps, even behind a hidden first candidate', function (): void {
+        zzAttachApp('ZZBASE', hidden: true);
+        zzAttachApp('ZZPLUS', hidden: false);
+        TenantHelper::setSelectedApp('ZZPLUS');
+
+        zzHandle($this->middleware, $this->user, 'zzbase', 'zzplus');
+
+        expect(TenantHelper::getSelectedApp())->toBe('ZZPLUS');
+    });
+
+    it('prefers a visible route app over a hidden one when switching apps', function (): void {
+        zzAttachApp('ZZBASE', hidden: true);
+        zzAttachApp('ZZPLUS', hidden: false);
+        TenantHelper::setSelectedApp(null);
+
+        zzHandle($this->middleware, $this->user, 'zzbase', 'zzplus');
+
+        expect(TenantHelper::getSelectedApp())->toBe('ZZPLUS');
+    });
+
+    it('still switches to a visible app the route belongs to', function (): void {
+        zzAttachApp('ZZSHOP', hidden: false);
+        zzAttachApp('ZZOTHER', hidden: false);
+        TenantHelper::setSelectedApp('ZZOTHER');
+
+        zzHandle($this->middleware, $this->user, 'zzshop');
+
+        expect(TenantHelper::getSelectedApp())->toBe('ZZSHOP');
     });
 });


### PR DESCRIPTION
## Summary

- `AppAccessMiddleware` no longer selects a HIDDEN tenant app (`tenant_app.is_hidden`): such an app only backs the screens of another app (liefertool pulls PRODUCT in, booking-members keeps BOOKING) and is refused by the app switcher. The user keeps the app they came from, with its navigation and its `app-configs/{app}/` YAML, as long as that app is assigned and accessible.
- For routes shared by several apps (`app-access:booking,booking-members`) the selected app is kept when it is one of them; otherwise the first visible candidate in route order is selected. A hidden app is selected only as the last resort (no selection yet, a stale selection, or one denied by the app gate).
- Documented in `docs/auth.md`.

Before this change, clicking "Products" in the delivery app switched the session to PRODUCT, so the delivery navigation and the per-app `products-list.yml` / `product-detail.yml` copies were never used.

## Tests

- Seven new cases in `tests/Middleware/AppAccessMiddlewareTest.php` with zz fixture apps on the hidden pivot.
- Standalone suite: 1440 passed.