### PR TITLE
Bump version to v0.16.15

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
             "name": "Johannes Brock"
         }
     ],
-    "version": "v0.16.14",
+    "version": "v0.16.15",
     "license": "MIT",
     "require": {
         "php": "^8.3",


### PR DESCRIPTION
Release v0.16.15: the app-access middleware keeps the current app selected when a route belongs to a hidden tenant app (#147).