### PR TITLE
Add RelationFieldRegistry::typeForColumn() for the foreign-key naming convention

### DIFF
--- a/docs/relation-field-types.md
+++ b/docs/relation-field-types.md
@@ -129,6 +129,12 @@ Polymorphic fields render through the shared Livewire component
 
 ## Runtime Behaviour
 
+- A foreign-key column maps to its relation type by naming convention — `customer_id` →
+  `customerRelation`, `product_group_id` → `productGroupRelation` (camelCase + `Relation`).
+  `RelationFieldRegistry::typeForColumn($column)` is the single home of that convention and
+  returns `null` when no such type is registered: the list cell `relationBadge` resolves its
+  title through it, and tools that derive fields from the database schema (the Plus layout
+  editor) use it to offer a foreign key as the matching relation field on a detail
 - All registered relation types render through the shared Livewire component `noerd-relation-field`
   (polymorphic types through `noerd-polymorphic-relation-field`), unless the definition names a
   custom `fieldComponent`

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -391,6 +391,9 @@ listComponent: ..., detailRoute: ..., modelClass: ..., titleResolver: ...))`; th
 that type and nothing else. The generic `type: relation` does not exist and throws during rendering.
 The field component keeps the value and the display title in sync with the detail itself
 (`detailData.{field}` + `relationTitles.{field}`), so the detail needs no code for the common case.
+A foreign-key column maps to its type by naming convention (`customer_id` → `customerRelation`);
+`RelationFieldRegistry::typeForColumn($column)` is the single home of that rule (null when no
+such type is registered) — never re-derive it in a module.
 
 When the detail must REACT to a selection (derive further fields, load defaults):
 

--- a/src/Services/RelationFieldRegistry.php
+++ b/src/Services/RelationFieldRegistry.php
@@ -103,6 +103,26 @@ final class RelationFieldRegistry
     }
 
     /**
+     * The registered relation type behind a foreign-key column, by naming
+     * convention: `customer_id` → `customerRelation`, `product_group_id` →
+     * `productGroupRelation`. This is the single home of that convention — the
+     * `relationBadge` list cell resolves its title through it, and tools that
+     * derive fields from the database schema (the Plus layout editor) use it to
+     * offer a foreign key as the matching relation field. Null when the column
+     * is no `*_id` column or no such type is registered.
+     */
+    public function typeForColumn(string $column): ?string
+    {
+        if (! str_ends_with($column, '_id')) {
+            return null;
+        }
+
+        $type = Str::camel(Str::beforeLast($column, '_id')) . 'Relation';
+
+        return $this->has($type) ? $type : null;
+    }
+
+    /**
      * @return array<string, RelationFieldDefinition>
      */
     public function all(): array

--- a/src/Services/RelationTitleResolver.php
+++ b/src/Services/RelationTitleResolver.php
@@ -75,7 +75,8 @@ final class RelationTitleResolver
         $base = Str::beforeLast($fkColumn, '_id');
         $resolved = [];
 
-        $definition = $this->registry->resolve(Str::camel($base) . 'Relation');
+        $type = $this->registry->typeForColumn($fkColumn);
+        $definition = $type !== null ? $this->registry->resolve($type) : null;
         if ($definition?->modelClass !== null && class_exists($definition->modelClass)) {
             foreach ($definition->modelClass::query()->findMany(array_values($pending)) as $model) {
                 $title = $definition->resolveTitle($model);
@@ -121,7 +122,8 @@ final class RelationTitleResolver
     {
         $base = Str::beforeLast($fkColumn, '_id');
 
-        $definition = $this->registry->resolve(Str::camel($base) . 'Relation');
+        $type = $this->registry->typeForColumn($fkColumn);
+        $definition = $type !== null ? $this->registry->resolve($type) : null;
         if ($definition !== null) {
             $title = $definition->resolveTitleForValue($id);
             if ($title !== '') {

--- a/tests/Unit/RelationFieldRegistryTest.php
+++ b/tests/Unit/RelationFieldRegistryTest.php
@@ -128,3 +128,20 @@ it('normalizes translated relation titles and derives default select event names
     // follows the session language / app locale.
     expect($definition->resolveTitle((object) []))->toBe('Page');
 });
+
+it('derives the relation type of a foreign-key column from the registered types', function (): void {
+    $registry = new RelationFieldRegistry(new FieldTypeRegistry());
+
+    $registry->register('fixtureWidgetRelation', RelationFieldDefinition::model(
+        listComponent: 'fixture-widgets-list',
+        modelClass: null,
+    ));
+
+    expect($registry->typeForColumn('fixture_widget_id'))->toBe('fixtureWidgetRelation')
+        // A `*_id` column whose type nobody registered is no relation.
+        ->and($registry->typeForColumn('gadget_id'))->toBeNull()
+        ->and($registry->typeForColumn('external_id'))->toBeNull()
+        // Not a foreign-key column at all.
+        ->and($registry->typeForColumn('fixture_widget'))->toBeNull()
+        ->and($registry->typeForColumn('name'))->toBeNull();
+});


### PR DESCRIPTION
## Summary

- `RelationFieldRegistry::typeForColumn(string $column): ?string` derives the registered relation type of a foreign-key column by naming convention (`customer_id` → `customerRelation`, `product_group_id` → `productGroupRelation`) and returns `null` when the column is no `*_id` column or no such type is registered.
- `RelationTitleResolver::resolve()` / `prime()` use the helper instead of computing the convention inline twice — behaviour unchanged.
- The helper gives schema-driven tooling (the Plus layout editor's field picker) one place to ask whether a foreign key can be offered as a relation field on a detail.

## Docs

- `docs/relation-field-types.md` (Runtime Behaviour) and the Boost guideline name the convention and the helper.

## Tests

- `tests/Unit/RelationFieldRegistryTest.php`: new case for `typeForColumn()`.
- Full standalone suite: 1441 passed.