### PR TITLE
Bump version to v0.16.16

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
             "name": "Johannes Brock"
         }
     ],
-    "version": "v0.16.15",
+    "version": "v0.16.16",
     "license": "MIT",
     "require": {
         "php": "^8.3",


### PR DESCRIPTION
Release v0.16.16: `RelationFieldRegistry::typeForColumn()` (#149).