### PR TITLE
Skip the agent guidelines when checking a module's declared dependencies

### DIFF
--- a/tests/Unit/ModuleHelperTest.php
+++ b/tests/Unit/ModuleHelperTest.php
@@ -142,6 +142,17 @@ describe('assertModuleDependenciesDeclared()', function (): void {
         'tests/ZzLeakTest.php',
         'app-configs/zz-module/lists/leak.yml',
     ]);
+
+    it('ignores a foreign namespace named in the agent documentation', function (): void {
+        zzWriteModuleSkeleton();
+        File::ensureDirectoryExists(zzModuleDir() . '/resources/boost/guidelines');
+        File::put(
+            zzModuleDir() . '/resources/boost/guidelines/core.blade.php',
+            "## Boundaries\n\n- never reference `Zz\\Other\\` from this module\n",
+        );
+
+        assertModuleDependenciesDeclared(zzModuleDir());
+    });
 });
 
 describe('assertModuleUpdateCommandPublishesConfigs()', function (): void {

--- a/tests/helpers.php
+++ b/tests/helpers.php
@@ -169,7 +169,9 @@ if (! function_exists('assertModuleDependenciesDeclared')) {
      * Module-independence guard: every OTHER app module whose PSR-4 namespace
      * appears anywhere in this module (src, resources, routes, database,
      * config, app-configs and tests) must be declared in the module's
-     * composer.json require or require-dev. The known module namespaces are
+     * composer.json require or require-dev. Agent documentation under
+     * resources/boost/ is skipped: a guideline states the boundary rule in
+     * prose and names the namespaces it forbids. The known module namespaces are
      * derived from the sibling app-modules' composer.json files, so the guard
      * needs no hand-maintained mapping and also catches test-only leaks.
      *
@@ -212,6 +214,12 @@ if (! function_exists('assertModuleDependenciesDeclared')) {
                 }
                 // The boundary tests themselves name foreign namespaces as needles.
                 if (str_contains($file->getFilename(), 'ModuleBoundaryTest')) {
+                    continue;
+                }
+                // Agent documentation (the Boost guideline, skills) is prose, not
+                // code: a module's guideline states its boundary rule and has to
+                // name the namespaces it must NOT use.
+                if (str_contains(str_replace('\\', '/', $file->getPathname()), '/resources/boost/')) {
                     continue;
                 }
                 $content = (string) file_get_contents($file->getPathname());


### PR DESCRIPTION
`assertModuleDependenciesDeclared()` scans every file of a module for foreign
module namespaces and fails when the owning package is not declared in
`composer.json`. That scan also covered `resources/boost/guidelines/`, where a
module's Boost guideline states its boundary rule in prose — and has to name the
namespaces it must NOT use ("never reference `Noerd\Party\` from this module").
A correctly documented boundary therefore failed the guard.

The scan now skips `resources/boost/`: agent documentation is prose, not code.
`ModuleBoundaryTest` files were already excluded for the same reason.

Adds a regression test that writes a guideline naming a foreign namespace and
asserts the guard stays green.